### PR TITLE
Minor fix to filtering on DescribeLoadBalancers

### DIFF
--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -56,20 +56,19 @@ class ELBConnection(AWSQueryConnection):
         for i in range(1, len(items)+1):
             params[label % i] = items[i-1]
 
-    def get_all_load_balancers(self, load_balancer_name=None):
+    def get_all_load_balancers(self, load_balancer_names=None):
         """
         Retrieve all load balancers associated with your account.
 
-        :type load_balancer_names: str
-        :param load_balancer_names: An optional filter string to get only one ELB
+        :type load_balancer_names: list
+        :param load_balancer_names: An optional list of load balancer names
 
         :rtype: list
         :return: A list of :class:`boto.ec2.elb.loadbalancer.LoadBalancer`
         """
         params = {}
-        if load_balancer_name:
-            #self.build_list_params(params, load_balancer_names, 'LoadBalancerName.%d')
-            params['LoadBalancerName'] = load_balancer_name
+        if load_balancer_names:
+            self.build_list_params(params, load_balancer_names, 'LoadBalancerNames.member.%d')
         return self.get_list('DescribeLoadBalancers', params, [('member', LoadBalancer)])
 
 


### PR DESCRIPTION
Filtering logic seemed broken.  When I added a LoadBalancerName parameter it would still result in the full list of LBs.

I checked the latest API reference at:
http://docs.amazonwebservices.com/ElasticLoadBalancing/latest/DeveloperGuide/index.html?API_DescribeLoadBalancers.html

...and noticed that it wants a list with members.  Made the attached commit.  Filtering by LBName now works for me.
