### PR TITLE
python 2.4 does not include hashlib module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
 # ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
@@ -28,7 +28,15 @@ try:
 except ImportError:
     from distutils.core import setup
 
+import sys
+
 from boto import Version
+
+install_requires = []
+maj, min, micro, rel, serial = sys.version_info
+if (maj, min) == (2, 4):
+    # boto needs hashlib module which is not in py2.4
+    install_requires.append("hashlib")
 
 setup(name = "boto",
       version = Version,
@@ -36,10 +44,11 @@ setup(name = "boto",
       long_description="Python interface to Amazon's Web Services.",
       author = "Mitch Garnaat",
       author_email = "mitch@garnaat.com",
-      scripts = ["bin/sdbadmin", "bin/elbadmin", "bin/cfadmin", 
-                 "bin/s3put", "bin/fetch_file", "bin/launch_instance", 
-                 "bin/list_instances", "bin/taskadmin", "bin/kill_instance", 
+      scripts = ["bin/sdbadmin", "bin/elbadmin", "bin/cfadmin",
+                 "bin/s3put", "bin/fetch_file", "bin/launch_instance",
+                 "bin/list_instances", "bin/taskadmin", "bin/kill_instance",
                  "bin/bundle_image", "bin/pyami_sendmail", "bin/lss3", "bin/cq"],
+      install_requires=install_requires,
       url = "http://code.google.com/p/boto/",
       packages = [ 'boto', 'boto.sqs', 'boto.s3', 'boto.gs', 'boto.file',
                    'boto.ec2', 'boto.ec2.cloudwatch', 'boto.ec2.autoscale', 'boto.ec2.elb',


### PR DESCRIPTION
Modified setup.py to set install_requires = ['hashlib'] in the case of python 2.4
