### PR TITLE
updates to boto.emr from mrjob

### DIFF
--- a/boto/emr/bootstrap_action.py
+++ b/boto/emr/bootstrap_action.py
@@ -36,3 +36,8 @@ class BootstrapAction(object):
             args.extend(self.bootstrap_action_args)
 
         return args
+
+    def __repr__(self):
+        return '%s.%s(name=%r, path=%r, bootstrap_action_args=%r)' % (
+            self.__class__.__module__, self.__class__.__name__,
+            self.name, self.path, self.bootstrap_action_args)

--- a/boto/emr/emrobject.py
+++ b/boto/emr/emrobject.py
@@ -53,6 +53,12 @@ class Arg(EmrObject):
         self.value = value
 
 
+class BootstrapAction(EmrObject):
+    Fields = set(['Name',
+                  'Args',
+                  'Path'])
+
+
 class Step(EmrObject):
     Fields = set(['Name',
                   'ActionOnFailure',
@@ -85,7 +91,9 @@ class InstanceGroup(EmrObject):
                   'Market',
                   'LastStateChangeReason',
                   'InstanceRole',
-                  'InstanceGroupId'])
+                  'InstanceGroupId',
+                  'LaunchGroup',
+                  'SpotPrice'])
 
 
 class JobFlow(EmrObject):
@@ -96,7 +104,6 @@ class JobFlow(EmrObject):
                   'Id',
                   'InstanceCount',
                   'JobFlowId',
-                  'KeepJobAliveWhenNoSteps',
                   'LogUri',
                   'MasterPublicDnsName',
                   'MasterInstanceId',
@@ -110,12 +117,14 @@ class JobFlow(EmrObject):
                   'MasterInstanceType',
                   'Ec2KeyName',
                   'InstanceCount',
-                  'KeepJobFlowAliveWhenNoSteps'])
+                  'KeepJobFlowAliveWhenNoSteps',
+                  'LastStateChangeReason'])
 
     def __init__(self, connection=None):
         self.connection = connection
         self.steps = None
         self.instancegroups = None
+        self.bootstrapactions = None
 
     def startElement(self, name, attrs, connection):
         if name == 'Steps':
@@ -124,6 +133,9 @@ class JobFlow(EmrObject):
         elif name == 'InstanceGroups':
             self.instancegroups = ResultSet([('member', InstanceGroup)])
             return self.instancegroups
+        elif name == 'BootstrapActions':
+            self.bootstrapactions = ResultSet([('member', BootstrapAction)])
+            return self.bootstrapactions
         else:
             return None
 

--- a/boto/emr/step.py
+++ b/boto/emr/step.py
@@ -94,7 +94,7 @@ class StreamingStep(Step):
     """
     Hadoop streaming step
     """
-    def __init__(self, name, mapper, reducer,
+    def __init__(self, name, mapper, reducer=None,
                  action_on_failure='TERMINATE_JOB_FLOW',
                  cache_files=None, cache_archives=None,
                  step_args=None, input=None, output=None):
@@ -141,8 +141,10 @@ class StreamingStep(Step):
         return None
 
     def args(self):
-        args = ['-mapper', self.mapper,
-                '-reducer', self.reducer]
+        args = ['-mapper', self.mapper]
+
+        if self.reducer:
+            args.extend(['-reducer', self.reducer])
 
         if self.input:
             if isinstance(self.input, list):
@@ -164,5 +166,14 @@ class StreamingStep(Step):
         if self.step_args:
             args.extend(self.step_args)
 
+        if not self.reducer:
+            args.extend(['-jobconf', 'mapred.reduce.tasks=0'])
+
         return args
 
+    def __repr__(self):
+        return '%s.%s(name=%r, mapper=%r, reducer=%r, action_on_failure=%r, cache_files=%r, cache_archives=%r, step_args=%r, input=%r, output=%r)' % (
+            self.__class__.__module__, self.__class__.__name__,
+            self.name, self.mapper, self.reducer, self.action_on_failure,
+            self.cache_files, self.cache_archives, self.step_args,
+            self.input, self.output)


### PR DESCRIPTION
Some updates, from the slightly hacked-up version of `boto.emr` that we use in `mrjob`. The important changes are:
- parse `BootstrapActions`
- `reducer` argument to `StreamingStep` is optional

(By the way, it would be a lot easier to edit the code for these objects if you alphabetized the Fields and possibly the classes. I'd already built a version of `InstanceGroup` that was identical except for the ordering of `Fields`. No stress. :)

I'm hoping to get Yelp using the latest version of `boto` (we're stuck on 1.6 due to some S3 issues), but until then, I'll do my best to keep `mrjob.botoemr` in sync with `boto.emr`

Also, `mrjob` is now officially released! Check out:
http://engineeringblog.yelp.com/2010/10/mrjob-distributed-computing-for-everybody.html
