### PR TITLE
Fix SimpleDB expected_value boolean test

### DIFF
--- a/boto/sdb/connection.py
+++ b/boto/sdb/connection.py
@@ -97,9 +97,9 @@ class SDBConnection(AWSQueryConnection):
 
     def build_expected_value(self, params, expected_value):
         params['Expected.1.Name'] = expected_value[0]
-        if expected_value[1] == True:
+        if expected_value[1] is True:
             params['Expected.1.Exists'] = 'true'
-        elif expected_value[1] == False:
+        elif expected_value[1] is False:
             params['Expected.1.Exists'] = 'false'
         else:
             params['Expected.1.Value'] = expected_value[1]


### PR DESCRIPTION
This fixes an edge case where expected_value[1] = 0, expected_value[1] == False return True, which is improper behavior. Example:

domain.put_attributes(name, {
  'value': 1
}, expected_values=('value', 0))

Would cause amazon to return this error, if the value in SimpleDB is already set to 0
<Response><Errors><Error><Code>ConditionalCheckFailed</Code><Message>Conditional check failed. Attribute (value) value exists</Message>
