### PR TITLE
Cache-Control response header failed to be extracted from HEAD request on a key

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -154,6 +154,7 @@ class Bucket(object):
             k.content_encoding = response.getheader('content-encoding')
             k.last_modified = response.getheader('last-modified')
             k.size = int(response.getheader('content-length'))
+            k.cache_control = response.getheader('cache-control')
             k.name = key_name
             k.handle_version_headers(response)
             return k


### PR DESCRIPTION
The Cache-Control header was not being extracted from the response headers in the get_key method.
