### PR TITLE
Added 'number hits required' and 'adult' qualifications to mturk interface

### DIFF
--- a/boto/mturk/qualification.py
+++ b/boto/mturk/qualification.py
@@ -100,6 +100,14 @@ class PercentAssignmentsRejectedRequirement(Requirement):
     def __init__(self, comparator, integer_value, required_to_preview=False):
         Requirement.__init__(self, qualification_type_id="000000000000000000S0", comparator=comparator, integer_value=integer_value, required_to_preview=required_to_preview)
 
+class NumberHitsApprovedRequirement(Requirement):
+    """
+    Specifies the total number of HITs submitted by a Worker that have been approved. The value is an integer greater than or equal to 0.
+    """
+    
+    def __init__(self, comparator, integer_value, required_to_preview=False):
+        Requirement.__init__(self, qualification_type_id="00000000000000000040", comparator=comparator, integer_value=integer_value, required_to_preview=required_to_preview)
+
 class LocaleRequirement(Requirement):
     """
     A Qualification requirement based on the Worker's location. The Worker's location is specified by the Worker to Mechanical Turk when the Worker creates his account.
@@ -118,3 +126,11 @@ class LocaleRequirement(Requirement):
         if self.required_to_preview:
             params['RequiredToPreview'] = "true"
         return params
+
+class AdultRequirement(Requirement):
+    """
+    Requires workers to acknowledge that they are over 18 and that they agree to work on potentially offensive content. The value type is boolean, 1 (required), 0 (not required, the default).
+    """
+    
+    def __init__(self, comparator, integer_value, required_to_preview=False):
+        Requirement.__init__(self, qualification_type_id="00000000000000000060", comparator=comparator, integer_value=integer_value, required_to_preview=required_to_preview)


### PR DESCRIPTION
Reasonably self-explanatory; making sure that mturk/qualifications.py complies with 

http://docs.amazonwebservices.com/AWSMturkAPI/2008-08-02/index.html?ApiReference_QualificationRequirementDataStructureArticle.html

Testing: used the 'number hits required' for a project; haven't used the adult requirement.
- Alexey
