### PR TITLE
POST for ModifyInstanceAttribute

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -718,7 +718,7 @@ class EC2Connection(AWSQueryConnection):
         params = {'InstanceId' : instance_id,
                   'Attribute' : attribute,
                   'Value' : value}
-        return self.get_status('ModifyInstanceAttribute', params)
+        return self.get_status('ModifyInstanceAttribute', params, verb='POST')
 
     def reset_instance_attribute(self, instance_id, attribute):
         """


### PR DESCRIPTION
Most http servers are going to reject ModifyInstanceAttribute GET request if userData too long (> 8 KB)
