### PR TITLE
Fix for https://github.com/boto/boto/issues#issue/86

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -511,9 +511,6 @@ class Bucket(object):
             else:
                 src_bucket = self.connection.get_bucket(src_bucket_name)
             acl = src_bucket.get_xml_acl(src_key_name)
-        elif preserve_acl:
-            src_bucket = self.connection.get_bucket(src_bucket_name)
-            acl = src_bucket.get_xml_acl(src_key_name)
         src = '%s/%s' % (src_bucket_name, urllib.quote(src_key_name))
         if src_version_id:
             src += '?version_id=%s' % src_version_id


### PR DESCRIPTION
Copying keys while preserving ACLs failed if source and destination bucket were not identical. I fixed it and it works for me.

Best, 
Fabian
