### PR TITLE
boto.ec2.elb:ELBConnection.describe_instance_health uses invalid list params

### DIFF
--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -54,11 +54,11 @@ def regions():
 
 def connect_to_region(region_name):
     """
-    Given a valid region name, return a 
+    Given a valid region name, return a
     :class:`boto.ec2.elb.ELBConnection`.
-    
+
     :param str region_name: The name of the region to connect to.
-    
+
     :rtype: :class:`boto.ec2.ELBConnection` or ``None``
     :return: A connection to the given region, or None if an invalid region
         name is given
@@ -313,7 +313,7 @@ class ELBConnection(AWSQueryConnection):
         """
         params = {'LoadBalancerName' : load_balancer_name}
         if instances:
-            self.build_list_params(params, instances, 'Instances.member.%d')
+            self.build_list_params(params, instances, 'Instances.member.%d.InstanceId')
         return self.get_list('DescribeInstanceHealth', params, [('member', InstanceState)])
 
     def configure_health_check(self, name, health_check):


### PR DESCRIPTION
This is the real fix for #9

DescribeInstanceHealth expects members like Instances.member.%d.InstanceId

Current master gives:

```
boto.exception.BotoServerError: BotoServerError: 400 Bad Request
<ErrorResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2010-07-01/">
  <Error>
    <Type>Sender</Type>
    <Code>MalformedInput</Code>
    <Message>Unexpected complex element termination</Message>
  </Error>
  <RequestId>1df3123d-39f3-11e0-8984-91f330e7c50d</RequestId>
</ErrorResponse>
```
