### PR TITLE
rds.DBSecurityGroup.revoke parameters don't match rds.connection.revoke

### DIFF
--- a/boto/rds/__init__.py
+++ b/boto/rds/__init__.py
@@ -33,7 +33,7 @@ from boto.rds.regioninfo import RDSRegionInfo
 def regions():
     """
     Get all available regions for the RDS service.
-        
+
     :rtype: list
     :return: A list of :class:`boto.rds.regioninfo.RDSRegionInfo`
     """
@@ -135,9 +135,9 @@ class RDSConnection(AWSQueryConnection):
 
         :type instance_class: str
         :param instance_class: The compute and memory capacity of the DBInstance.
-                               
+
                                Valid values are:
-                               
+
                                * db.m1.small
                                * db.m1.large
                                * db.m1.xlarge
@@ -207,7 +207,7 @@ class RDSConnection(AWSQueryConnection):
                                            automatically to the Read Replica
                                            during the maintenance window.
                                            Default is True.
-                                           
+
         :rtype: :class:`boto.rds.dbinstance.DBInstance`
         :return: The new db instance.
         """
@@ -270,9 +270,9 @@ class RDSConnection(AWSQueryConnection):
         :param instance_class: The compute and memory capacity of the
                                DBInstance.  Default is to inherit from
                                the source DB Instance.
-                               
+
                                Valid values are:
-                               
+
                                * db.m1.small
                                * db.m1.large
                                * db.m1.xlarge
@@ -296,7 +296,7 @@ class RDSConnection(AWSQueryConnection):
                                            during the maintenance window.
                                            Default is to inherit this value
                                            from the source DB Instance.
-                                           
+
         :rtype: :class:`boto.rds.dbinstance.DBInstance`
         :return: The new db instance.
         """
@@ -356,7 +356,7 @@ class RDSConnection(AWSQueryConnection):
                                apply_immediately is True.
 
                                Valid values are:
-                               
+
                                * db.m1.small
                                * db.m1.large
                                * db.m1.xlarge
@@ -716,15 +716,15 @@ class RDSConnection(AWSQueryConnection):
                            the rule from.
 
         :type ec2_security_group_name: string
-        :param ec2_security_group_name: The name of the EC2 security group you are
-                                        granting access to.
+        :param ec2_security_group_name: The name of the EC2 security group from which
+                                        you are removing access.
 
         :type ec2_security_group_owner_id: string
         :param ec2_security_group_owner_id: The ID of the owner of the EC2 security
-                                            group you are granting access to.
+                                            from which you are removing access.
 
         :type cidr_ip: string
-        :param cidr_ip: The CIDR block you are providing access to.
+        :param cidr_ip: The CIDR block from which you are removing access.
                         See http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
 
         :rtype: bool
@@ -742,7 +742,7 @@ class RDSConnection(AWSQueryConnection):
     # For backwards compatibility.  This method was improperly named
     # in previous versions.  I have renamed it to match the others.
     revoke_security_group = revoke_dbsecurity_group
-    
+
     # DBSnapshot methods
 
     def get_all_dbsnapshots(self, snapshot_id=None, instance_id=None,

--- a/boto/rds/dbsecuritygroup.py
+++ b/boto/rds/dbsecuritygroup.py
@@ -14,7 +14,7 @@
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
 # ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
@@ -25,7 +25,7 @@ Represents an DBSecurityGroup
 from boto.ec2.securitygroup import SecurityGroup
 
 class DBSecurityGroup(object):
-    
+
     def __init__(self, connection=None, owner_id=None,
                  name=None, description=None):
         self.connection = connection
@@ -70,12 +70,12 @@ class DBSecurityGroup(object):
         Add a new rule to this DBSecurity group.
         You need to pass in either a CIDR block to authorize or
         and EC2 SecurityGroup.
-        
+
         @type cidr_ip: string
         @param cidr_ip: A valid CIDR IP range to authorize
 
         @type ec2_group: :class:`boto.ec2.securitygroup.SecurityGroup>`
-                         
+
         @rtype: bool
         @return: True if successful.
         """
@@ -92,28 +92,29 @@ class DBSecurityGroup(object):
 
     def revoke(self, cidr_ip=None, ec2_group=None):
         """
-        Revoke access to a CIDR range or EC2 SecurityGroup
-        You need to pass in either a CIDR block to authorize or
-        and EC2 SecurityGroup.
-        
+        Revoke access to a CIDR range or EC2 SecurityGroup.
+        You need to pass in either a CIDR block or
+        an EC2 SecurityGroup from which to revoke access.
+
         @type cidr_ip: string
-        @param cidr_ip: A valid CIDR IP range to authorize
+        @param cidr_ip: A valid CIDR IP range to revoke
 
         @type ec2_group: :class:`boto.ec2.securitygroup.SecurityGroup>`
-                         
+
         @rtype: bool
         @return: True if successful.
         """
         if isinstance(ec2_group, SecurityGroup):
             group_name = ec2_group.name
             group_owner_id = ec2_group.owner_id
-        else:
-            group_name = None
-            group_owner_id = None
-        return self.connection.revoke_dbsecurity_group(self.name,
-                                                       cidr_ip,
-                                                       group_name,
-                                                       group_owner_id)
+            return self.connection.revoke_dbsecurity_group(
+                self.name,
+                ec2_security_group_name=group_name,
+                ec2_security_group_owner_id=group_owner_id)
+
+        # Revoking by CIDR IP range
+        return self.connection.revoke_dbsecurity_group(
+            self.name, cidr_ip=cidr_ip)
 
 class IPRange(object):
 


### PR DESCRIPTION
Related to #36

The argument order in the call from DBSecurityGroup.revoke doesn't match the order in RDSConnection.revoke_dbsecurity_group. Also refactored that method a bit to make it clear that you can either revoke by CIDR OR by group, but not both. Cleaned up some docstrings as well.
