### PR TITLE
Fixes Amazon ECS Action=GET bug (#102)

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -565,7 +565,8 @@ class AWSQueryConnection(AWSAuthConnection):
         http_request = self.build_base_http_request(verb, path, None,
                                                     params, {}, '',
                                                     self.server_name())
-        http_request.params['Action'] = action
+        if action:
+            http_request.params['Action'] = action
         http_request.params['Version'] = self.APIVersion
         http_request = self.fill_in_auth(http_request)
         return self._send_http_request(http_request)

--- a/boto/ecs/__init__.py
+++ b/boto/ecs/__init__.py
@@ -30,7 +30,7 @@ from boto import handler
 class ECSConnection(AWSQueryConnection):
     """ECommerse Connection"""
 
-    APIVersion = '2010-09-01'
+    APIVersion = '2010-11-01'
 
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,
@@ -51,7 +51,7 @@ class ECSConnection(AWSQueryConnection):
         params['Operation'] = action
         if page:
             params['ItemPage'] = page
-        response = self.make_request("GET", params, "/onca/xml")
+        response = self.make_request(None, params, "/onca/xml")
         body = response.read()
         boto.log.debug(body)
 


### PR DESCRIPTION
Detailed description of the issue is in boto/boto issue #102.

This patch fixes the bug. I've also upped the ECS API version number to the more recent one.
