### PR TITLE
ItemSet cannot cope with responses that do not contain TotalItems and TotalPages

### DIFF
--- a/boto/ecs/item.py
+++ b/boto/ecs/item.py
@@ -104,6 +104,8 @@ class ItemSet(ResponseGroup):
         self.action = action
         self.params = params
         self.curItem = None
+        self.total_results = 0
+        self.total_pages = 0
 
     def startElement(self, name, attrs, connection):
         if name == "Item":


### PR DESCRIPTION
Responses to some queries, such as ItemLookup are going to contain only a single item and therefore the response XML will not contain TotalItems and TotalPages.

This breaks ItemSet, because the iterator expect these two to be set. This patch sets them to default value of 0 and so ItemSet can cope with requests with and without TotalItems and TotalPages.
