### PR TITLE
Fix to allow public access cloudfront distributions to be created

### DIFF
--- a/boto/cloudfront/origin.py
+++ b/boto/cloudfront/origin.py
@@ -72,8 +72,9 @@ class S3Origin(object):
     def to_xml(self):
         s = '  <S3Origin>\n'
         s += '    <DNSName>%s</DNSName>\n' % self.dns_name
-        val = get_oai_value(self.origin_access_identity)
-        s += '    <OriginAccessIdentity>%s</OriginAccessIdentity>\n' % val
+        if self.origin_access_identity:
+            val = get_oai_value(self.origin_access_identity)
+            s += '    <OriginAccessIdentity>%s</OriginAccessIdentity>\n' % val
         s += '  </S3Origin>\n'
         return s
     


### PR DESCRIPTION
OriginAccessIdentity element needs to be ignored when it hasn't been set in order to allow public distributions to be created.
