### PR TITLE
minor bug fix 

### DIFF
--- a/boto/cloudfront/invalidation.py
+++ b/boto/cloudfront/invalidation.py
@@ -89,7 +89,7 @@ class InvalidationBatch(object):
         elif name == "Status":
             self.status = value
         elif name == "Id":
-            self.id = id
+            self.id = value
         elif name == "CreateTime":
             self.create_time = value
         elif name == "CallerReference":


### PR DESCRIPTION
cloudfront invalidation request object id should be assigned the id returned from aws and not the built-in method id()
