### PR TITLE
Fix reduced redundancy support in multipart uploads

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -978,8 +978,16 @@ class Bucket(object):
             raise self.connection.provider.storage_response_error(
                 response.status, response.reason, body)
 
-    def initiate_multipart_upload(self, key_name, headers=None):
+    def initiate_multipart_upload(self, key_name, headers=None, reduced_redundancy=False):
         query_args = 'uploads'
+        if headers is None:
+            headers = {}
+        if reduced_redundancy:
+            storage_class_header = self.connection.provider.storage_class_header
+            if storage_class_header:
+                headers[storage_class_header] = 'REDUCED_REDUNDANCY'
+            # TODO: what if the provider doesn't support reduced redundancy?
+            # (see boto.s3.key.Key.set_contents_from_file)
         response = self.connection.make_request('POST', self.name, key_name,
                                                 query_args=query_args,
                                                 headers=headers)

--- a/boto/s3/multipart.py
+++ b/boto/s3/multipart.py
@@ -212,8 +212,7 @@ class MultiPartUpload(object):
             return self._parts
 
     def upload_part_from_file(self, fp, part_num, headers=None, replace=True,
-                               cb=None, num_cb=10, policy=None, md5=None,
-                               reduced_redundancy=False):
+                               cb=None, num_cb=10, policy=None, md5=None):
         """
         Upload another part of this MultiPart Upload.
         
@@ -231,7 +230,7 @@ class MultiPartUpload(object):
         query_args = 'uploadId=%s&partNumber=%d' % (self.id, part_num)
         key = self.bucket.new_key(self.key_name)
         key.set_contents_from_file(fp, headers, replace, cb, num_cb, policy,
-                                   md5, reduced_redundancy, query_args)
+                                   md5, reduced_redundancy=False, query_args=query_args)
 
     def complete_upload(self):
         """


### PR DESCRIPTION
In multipart uploads, the storage class is specified when initiating the upload, not when uploading individual parts.  See:

http://docs.amazonwebservices.com/AmazonS3/latest/API/index.html?mpUploadInitiate.html
http://docs.amazonwebservices.com/AmazonS3/latest/API/index.html?mpUploadUploadPart.html

So add a reduced_redundancy kwarg to Bucket.initiate_multipart_upload() and remove it from MultiPartUpload.upload_part_from_file, ensuring that method does _not_ specify reduced redundancy storage.

Signed-off-by: Steve Howard steve@thumbtack.com
