### PR TITLE
Bug where destination address was required even though it isn't required by Amazon

### DIFF
--- a/boto/ses/connection.py
+++ b/boto/ses/connection.py
@@ -201,8 +201,9 @@ class SESConnection(AWSAuthConnection):
             'RawMessage.Data': base64.b64encode(raw_message),
         }
 
-        self._build_list_params(params, destinations,
-                               'Destinations.member')
+        if destinations:
+            self._build_list_params(params, destinations,
+                                   'Destinations.member')
 
         return self._make_request('SendRawEmail', params)
 


### PR DESCRIPTION
Fixed bug where send_raw_email required destinations addresses causing bcc header in raw message to be ignored
