### PR TITLE
Fixed failing streaming steps with Hadoop 0.20

### DIFF
--- a/boto/emr/step.py
+++ b/boto/emr/step.py
@@ -135,7 +135,7 @@ class StreamingStep(Step):
         self.step_args = step_args
 
     def jar(self):
-        return '/home/hadoop/contrib/streaming/hadoop-0.18-streaming.jar'
+        return '/home/hadoop/contrib/streaming/hadoop-streaming.jar'
 
     def main_class(self):
         return None


### PR DESCRIPTION
Streaming steps were using the 0.18 jar instead of the unversioned symlink.
