### PR TITLE
Fix documentation for instance_initiated_shutdown_behavior

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -507,12 +507,9 @@ class EC2Connection(AWSQueryConnection):
 
         :type instance_initiated_shutdown_behavior: string
         :param instance_initiated_shutdown_behavior: Specifies whether the
-                                                     instance's EBS volumes are
-                                                     stopped (i.e. detached) or
-                                                     terminated (i.e. deleted)
-                                                     when the instance is
-                                                     shutdown by the
-                                                     owner.  Valid values are:
+                                                     instance stops or terminates on
+                                                     instance-initiated shutdown.
+                                                     Valid values are:
                                                      
                                                      * stop
                                                      * terminate

--- a/boto/ec2/image.py
+++ b/boto/ec2/image.py
@@ -220,11 +220,9 @@ class Image(TaggedEC2Object):
                                         via the API.
 
         :type instance_initiated_shutdown_behavior: string
-        :param instance_initiated_shutdown_behavior: Specifies whether the instance's
-                                                     EBS volumes are stopped (i.e. detached)
-                                                     or terminated (i.e. deleted) when
-                                                     the instance is shutdown by the
-                                                     owner.  Valid values are:
+        :param instance_initiated_shutdown_behavior: Specifies whether the instance
+                                                     stops or terminates on instance-initiated
+                                                     shutdown. Valid values are:
                                                      stop | terminate
 
         :type placement_group: string


### PR DESCRIPTION
instance_initiated_shutdown_behavior was described as affecting what happens to EBS volumes, not what happens to the instance on instance-initiated shutdown.
