### PR TITLE
Support setting metadata on multipart uploads

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -990,7 +990,8 @@ class Bucket(object):
             raise self.connection.provider.storage_response_error(
                 response.status, response.reason, body)
 
-    def initiate_multipart_upload(self, key_name, headers=None, reduced_redundancy=False):
+    def initiate_multipart_upload(self, key_name, headers=None,
+            reduced_redundancy=False, metadata=None):
         """
         Start a multipart upload operation.
 
@@ -1011,6 +1012,10 @@ class Bucket(object):
                                    if you want the resulting key to use the
                                    reduced redundancy storage class set this
                                    flag when you initiate the upload.
+
+        :type metadata: dict
+        :param metadata: Any metadata that you would like to set on the key
+                         that results from the multipart upload.
         """
         query_args = 'uploads'
         if headers is None:
@@ -1021,6 +1026,11 @@ class Bucket(object):
                 headers[storage_class_header] = 'REDUCED_REDUNDANCY'
             # TODO: what if the provider doesn't support reduced redundancy?
             # (see boto.s3.key.Key.set_contents_from_file)
+        if metadata is None:
+            metadata = {}
+
+        headers = boto.utils.merge_meta(headers, metadata,
+                self.connection.provider)
         response = self.connection.make_request('POST', self.name, key_name,
                                                 query_args=query_args,
                                                 headers=headers)


### PR DESCRIPTION
Rather than providing meta data as headers (`x-amz-meta-KEY`), this patch allows metadata to be passed into the `initiate_multipart_upload` method as a dict. If the metadata is provided, it will be merged with the request headers appropriately resulting in the metadata being set on the key that results from the multipart upload.
