### PR TITLE
IAM documentation: remove inaccurate 'new'

### DIFF
--- a/boto/iam/connection.py
+++ b/boto/iam/connection.py
@@ -179,7 +179,7 @@ class IAMConnection(AWSQueryConnection):
         Add a user to a group
 
         :type group_name: string
-        :param group_name: The name of the new group
+        :param group_name: The name of the group
 
         :type user_name: string
         :param user_name: The to be added to the group.
@@ -194,7 +194,7 @@ class IAMConnection(AWSQueryConnection):
         Remove a user from a group.
 
         :type group_name: string
-        :param group_name: The name of the new group
+        :param group_name: The name of the group
 
         :type user_name: string
         :param user_name: The user to remove from the group.
@@ -494,7 +494,7 @@ class IAMConnection(AWSQueryConnection):
         Get all access keys associated with an account.
 
         :type user_name: string
-        :param user_name: The username of the new user
+        :param user_name: The username of the user
 
         :type marker: string
         :param marker: Use this only when paginating results and only in
@@ -525,7 +525,7 @@ class IAMConnection(AWSQueryConnection):
         implicitly based on the AWS Access Key ID used to sign the request.
 
         :type user_name: string
-        :param user_name: The username of the new user
+        :param user_name: The username of the user
 
         """
         params = {'UserName' : user_name}
@@ -567,7 +567,7 @@ class IAMConnection(AWSQueryConnection):
         :param access_key_id: The ID of the access key to be deleted.
 
         :type user_name: string
-        :param user_name: The username of the new user
+        :param user_name: The username of the user
 
         """
         params = {'AccessKeyId' : access_key_id}
@@ -648,7 +648,7 @@ class IAMConnection(AWSQueryConnection):
         :param cert_body: The body of the signing certificate.
 
         :type user_name: string
-        :param user_name: The username of the new user
+        :param user_name: The username of the user
 
         """
         params = {'CertificateBody' : cert_body}
@@ -665,7 +665,7 @@ class IAMConnection(AWSQueryConnection):
         on the AWS Access Key ID used to sign the request.
 
         :type user_name: string
-        :param user_name: The username of the new user
+        :param user_name: The username of the user
 
         :type cert_id: string
         :param cert_id: The ID of the certificate.
@@ -914,7 +914,7 @@ class IAMConnection(AWSQueryConnection):
         ability to access AWS services and the AWS Management Console.
 
         :type user_name: string
-        :param user_name: The name of the new user
+        :param user_name: The name of the user
 
         :type password: string
         :param password: The new password for the user


### PR DESCRIPTION
Another tiny documentation fix.
