### PR TITLE
SES Support for UTF-8 Messages

### DIFF
--- a/boto/ses/connection.py
+++ b/boto/ses/connection.py
@@ -73,9 +73,14 @@ class SESConnection(AWSAuthConnection):
         :param params: Parameters that will be sent as POST data with the API
                        call.
         """
-        headers = {'Content-Type': 'application/x-www-form-urlencoded'}
+        headers = {'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
         params = params or {}
         params['Action'] = action
+
+        for k, v in params.items():
+            if isinstance(v, basestring):
+                params[k] = v.encode('utf-8')
+            
         response = super(SESConnection, self).make_request(
             'POST',
             '/',


### PR DESCRIPTION
urllib.urlencode does not support non-ascii characters. It will raise an exception that looks like:
UnicodeEncodeError: 'ascii' codec can't encode characters in position XXXX-XXXX: ordinal not in range(128)

This patch utf-8 encodes params before they are url encoded.
