### PR TITLE
base64 decode user data

### DIFF
--- a/boto/ec2/autoscale/launchconfig.py
+++ b/boto/ec2/autoscale/launchconfig.py
@@ -21,6 +21,7 @@
 
 
 from datetime import datetime
+import base64
 from boto.resultset import ResultSet
 from boto.ec2.elb.listelement import ListElement
 
@@ -169,7 +170,7 @@ class LaunchConfiguration(object):
         elif name == 'RamdiskId':
             self.ramdisk_id = value
         elif name == 'UserData':
-            self.user_data = value
+            self.user_data = base64.b64decode(value)
         elif name == 'LaunchConfigurationARN':
             self.launch_configuration_arn = value
         elif name == 'InstanceMonitoring':


### PR DESCRIPTION
User data should be decoded when fetching a launch configuration. (Currently, getting a launch configuration, changing the name, and saving it produces one with doubly-encoded user data.)
