### PR TITLE
Fixing Sphinx warnings and errors. Warnings/errors in one module can lead

### DIFF
--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -228,8 +228,9 @@ class MTurkConnection(AWSQueryConnection):
         Change the HIT type of an existing HIT. Note that the reward associated
         with the new HIT type must match the reward of the current HIT type in
         order for the operation to be valid.
-        \thit_id is a string
-        \thit_type is a string
+        
+        :type hit_id: str
+        :type hit_type: str
         """
         params = {'HITId' : hit_id,
                   'HITTypeId': hit_type}

--- a/boto/mturk/question.py
+++ b/boto/mturk/question.py
@@ -182,21 +182,23 @@ class QuestionForm(ValidatingXML, list):
     Overview element and a Question element followed by a second Overview element and Question
     element--all within the same QuestionForm.
     
-    <QuestionForm xmlns="[the QuestionForm schema URL]">
-        <Overview>
+    ::
+    
+        <QuestionForm xmlns="[the QuestionForm schema URL]">
+            <Overview>
+                [...]
+            </Overview>
+            <Question>
+                [...]
+            </Question>
+            <Overview>
+                [...]
+            </Overview>
+            <Question>
+                [...]
+            </Question>
             [...]
-        </Overview>
-        <Question>
-            [...]
-        </Question>
-        <Overview>
-            [...]
-        </Overview>
-        <Question>
-            [...]
-        </Question>
-        [...]
-    </QuestionForm>
+        </QuestionForm>
     
     QuestionForm is implemented as a list, so to construct a
     QuestionForm, simply append Questions and Overviews (with at least

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -807,8 +807,9 @@ class Bucket(object):
                              mfa_token=None, headers=None):
         """
         Configure versioning for this bucket.
-        Note: This feature is currently in beta release and is available
-              only in the Northern California region.
+        
+        ..note:: This feature is currently in beta release and is available
+                 only in the Northern California region.
 
         :type versioning: bool
         :param versioning: A boolean indicating whether version is
@@ -921,14 +922,17 @@ class Bucket(object):
 
         :rtype: dict
         :returns: A dictionary containing a Python representation
-                  of the XML response from S3.  The overall structure is:
+                  of the XML response from S3. The overall structure is:
 
-                   * WebsiteConfiguration
-                     * IndexDocument
-                       * Suffix : suffix that is appended to request that
-                         is for a "directory" on the website endpoint
-                     * ErrorDocument
-                       * Key : name of object to serve when an error occurs
+            * WebsiteConfiguration
+    
+              * IndexDocument
+    
+                * Suffix : suffix that is appended to request that
+                is for a "directory" on the website endpoint
+                * ErrorDocument
+    
+                  * Key : name of object to serve when an error occurs
         """
         response = self.connection.make_request('GET', self.name,
                 query_args='website', headers=headers)

--- a/docs/source/ref/ec2.rst
+++ b/docs/source/ref/ec2.rst
@@ -69,7 +69,7 @@ boto.ec2.autoscale.request
    :undoc-members:
 
 boto.ec2.autoscale.scheduled
---------------------------
+----------------------------
 
 .. automodule:: boto.ec2.autoscale.scheduled
    :members:   


### PR DESCRIPTION
Fixing Sphinx warnings and errors in mturk and S3. Adding documentation to s3.S3Connection.generate_url(), and some bucket methods. Would have done more, but #163 and http://groups.google.com/group/boto-dev/browse_thread/thread/e3e2534886f8bffe held me up a bit.
