### PR TITLE
current version doesn't work in python < 2.7

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -209,7 +209,7 @@ class AWSAuthConnection(object):
         # timeout, set http_socket_timeout in Boto config. Regardless,
         # timeouts will only be applied if Python is 2.6 or greater.
         self.http_connection_kwargs = {}
-        if (sys.version_info.major, sys.version_info.minor) >= (2, 6):
+        if (sys.version_info[0], sys.version_info[1]) >= (2, 6):
             if config.has_option('Boto', 'http_socket_timeout'):
                 timeout = config.getint('Boto', 'http_socket_timeout')
                 self.http_connection_kwargs['timeout'] = timeout


### PR DESCRIPTION
fixed by reverting to the old version_info structure (not using a named tuple)
