### PR TITLE
"dh_host" argument got lost in sdb.db.manager

### DIFF
--- a/boto/sdb/db/manager/sdbmanager.py
+++ b/boto/sdb/db/manager/sdbmanager.py
@@ -397,9 +397,15 @@ class SDBManager(object):
         return self._domain
 
     def _connect(self):
-        self._sdb = boto.connect_sdb(aws_access_key_id=self.db_user,
-                                    aws_secret_access_key=self.db_passwd,
-                                    is_secure=self.enable_ssl)
+        args = dict(aws_access_key_id=self.db_user,
+                    aws_secret_access_key=self.db_passwd,
+                    is_secure=self.enable_ssl)
+        try:
+            region = [x for x in boto.sdb.regions() if x.endpoint == self.db_host][0]
+            args['region'] = region
+        except IndexError:
+            pass
+        self._sdb = boto.connect_sdb(**args)
         # This assumes that the domain has already been created
         # It's much more efficient to do it this way rather than
         # having this make a roundtrip each time to validate.


### PR DESCRIPTION
(Note: Re-created pull request, last one somehow wound up containing an unwanted commit)

sdb.db.manager.sdbmanager.SDBManager ignored the "db_host" argument, so despite different configurations in boto.cfg, sdb.amazonaws.com (us-east-1) was always used.

This is just a simple fix. As it looks up the region from boto.sdb.regions() some flexibility in choosing the endpoints is lost, which shouldn't matter as a) only Amazon currently operates SimpleDB and b) choosing endpoints didn't work at all until now which was even less flexible. :-)

The change should not change the behaviour (except possibly change the endpoint if configured), existing code should continue to work unaltered.
