### PR TITLE
Keyword params for sqs connect_to_region 

### DIFF
--- a/boto/sqs/__init__.py
+++ b/boto/sqs/__init__.py
@@ -41,8 +41,8 @@ def regions():
                           endpoint='ap-southeast-1.queue.amazonaws.com')
             ]
 
-def connect_to_region(region_name):
+def connect_to_region(region_name, **kw_params):
     for region in regions():
         if region.name == region_name:
-            return region.connect()
+            return region.connect(**kw_params)
     return None


### PR DESCRIPTION
Have modified sqs connect_to_region to allow keyword params to be passed through to underlying region connect() function
