### PR TITLE
Please pull the following one-liner bugfix which fixes copying of metadata on copy key for google storage.

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -551,7 +551,7 @@ class Bucket(object):
             headers[provider.storage_class_header] = storage_class
         if metadata:
             headers[provider.metadata_directive_header] = 'REPLACE'
-            headers = boto.utils.merge_meta(headers, metadata)
+            headers = boto.utils.merge_meta(headers, metadata, provider)
         else:
             headers[provider.metadata_directive_header] = 'COPY'
         response = self.connection.make_request('PUT', self.name, new_key_name,


### PR DESCRIPTION
[bugfix]: fix bug in S3 Bucket.copy_key affecting copying of key metadata on google storage (e.g. by use of Key.copy).
- Was failing to supply provider for copying metadata resulting in amazon meta header prefix rather than google meta header.
- Discovered while working on https://bitbucket.org/okfn/ofs
