### PR TITLE
Don't use mutable function arguments

### DIFF
--- a/boto/cloudfront/invalidation.py
+++ b/boto/cloudfront/invalidation.py
@@ -27,11 +27,11 @@ class InvalidationBatch(object):
         :see: http://docs.amazonwebservices.com/AmazonCloudFront/2010-08-01/APIReference/index.html?InvalidationBatchDatatype.html
     """
 
-    def __init__(self, paths=[], connection=None, distribution=None, caller_reference=''):
+    def __init__(self, paths=None, connection=None, distribution=None, caller_reference=''):
         """Create a new invalidation request:
             :paths: An array of paths to invalidate
         """
-        self.paths = paths
+        self.paths = paths or []
         self.distribution = distribution
         self.caller_reference = caller_reference
         if not self.caller_reference:

--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -107,7 +107,7 @@ class Key(S3Key):
         acl.add_group_grant(permission, group_id)
         self.set_acl(acl)
 
-    def set_contents_from_file(self, fp, headers={}, replace=True,
+    def set_contents_from_file(self, fp, headers=None, replace=True,
                                cb=None, num_cb=10, policy=None, md5=None,
                                res_upload_handler=None):
         """
@@ -163,8 +163,7 @@ class Key(S3Key):
         just overriding/sharing code the way it currently works).
         """
         provider = self.bucket.connection.provider
-        if headers is None:
-            headers = {}
+        headers = headers or {}
         if policy:
             headers[provider.acl_header] = policy
         if hasattr(fp, 'name'):

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -531,7 +531,8 @@ class Password(object):
         else:
             return 0
 
-def notify(subject, body=None, html_body=None, to_string=None, attachments=[], append_instance_id=True):
+def notify(subject, body=None, html_body=None, to_string=None, attachments=None, append_instance_id=True):
+    attachments = attachments or []
     if append_instance_id:
         subject = "[%s] %s" % (boto.config.get_value("Instance", "instance-id"), subject)
     if not to_string:


### PR DESCRIPTION
I was auditing some of our internal code and noticed boto uses mutable args in
a few places:

boto $ find . -name '_.py' | xargs egrep '^[ ]_def ' | grep '{}'
./gs/key.py:    def set_contents_from_file(self, fp, headers={}, replace=True,

boto $ find . -name '_.py' | xargs egrep '^[ ]_def ' | grep '[]'
./utils.py:def notify(subject, body=None, html_body=None, to_string=None, attachments=[], append_instance_id=True):
./cloudfront/invalidation.py:    def **init**(self, paths=[], connection=None, distribution=None, caller_reference=''):

Which is generally a bad idea since these are initialized when the function is
evaluated, not when it's invoked:

> > > def add_item(item, L=[]):
> > > ...   L.append(item)
> > > ...   return L
> > > ...
> > > add_item(1)
> > > [1]
> > > add_item(2)
> > > [1, 2]
> > > add_item(3)
> > > [1, 2, 3]
> > > add_item(4, [])
> > > [4]
> > > add_item(5, [])
> > > [5]
> > > add_item(6)
> > > [1, 2, 3, 6]

This leads to rather subtle bugs -- I usually set L to None in the args and
add:

L = L or []

at the top of the function to avoid this sort of thing...

Probably in these cases it's innocuous, but better safe than sorry I figure.

Matt
