### PR TITLE
The delete_domain() method is used to delete domains.

### DIFF
--- a/boto/sdb/domain.py
+++ b/boto/sdb/domain.py
@@ -276,7 +276,7 @@ class Domain:
         """
         Delete this domain, and all items under it
         """
-        return self.connection.delete(self)
+        return self.connection.delete_domain(self)
 
 
 class DomainMetaData:


### PR DESCRIPTION
Hi - just a small fix, the Domain class was trying to call a non-existent method on the connection.
