### PR TITLE
Fixed string conversion in SDBConverter

### DIFF
--- a/boto/sdb/db/manager/sdbmanager.py
+++ b/boto/sdb/db/manager/sdbmanager.py
@@ -346,16 +346,17 @@ class SDBConverter(object):
             return None
 
     def encode_string(self, value):
-        """Encode string to make sure it's unicode/utf-8 compatible.
-        Thanks to Robert Mela for this code"""
+        """Convert ASCII, Latin-1 or UTF-8 to pure Unicode"""
         if not isinstance(value, str): return value
         try:
-            return unicode(value)
-        except: pass
-        arr = []
-        for ch in value:
-            arr.append(unichr(ord(ch)))
-        return u"".join(arr)
+            return unicode(value, 'utf-8')
+        except: # really, this should throw an exception.
+                # in the interest of not breaking current
+		# systems, however:
+            arr = []
+            for ch in value:
+                arr.append(unichr(ord(ch)))
+            return u"".join(arr)
 
     def decode_string(self, value):
         """Decoding a string is really nothing, just


### PR DESCRIPTION
SDBConverter's encode_string(val) method was mangling any string that wasn't already unicode codepoint or pure ascii. I've changed to it be compatible with latin-1 and utf-8, though I've preserved the code that tries to convert byte-by-byte if the decoding fails. This isn't ideal behavior because byte-by-byte decoding like that will never come out right unless it's being performed on ASCII, but leaving it doesn't break existing code.
