### PR TITLE
Some minor style fixes + support for `python setup.py test`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2006-2010 Mitch Garnaat http://garnaat.org/
 # Copyright (c) 2010, Eucalyptus Systems, Inc.
@@ -25,8 +25,10 @@
 
 try:
     from setuptools import setup
+    extra = {"test_suite": "tests.test.suite"}
 except ImportError:
     from distutils.core import setup
+    extra = {}
 
 import sys
 
@@ -41,7 +43,7 @@ if (maj, min) == (2, 4):
 setup(name = "boto",
       version = Version,
       description = "Amazon Web Services Library",
-      long_description="Python interface to Amazon's Web Services.",
+      long_description = "Python interface to Amazon's Web Services.",
       author = "Mitch Garnaat",
       author_email = "mitch@garnaat.com",
       scripts = ["bin/sdbadmin", "bin/elbadmin", "bin/cfadmin",
@@ -49,24 +51,24 @@ setup(name = "boto",
                  "bin/list_instances", "bin/taskadmin", "bin/kill_instance",
                  "bin/bundle_image", "bin/pyami_sendmail", "bin/lss3",
                  "bin/cq", "bin/route53"],
-      install_requires=install_requires,
+      install_requires = install_requires,
       url = "http://code.google.com/p/boto/",
-      packages = [ 'boto', 'boto.sqs', 'boto.s3', 'boto.gs', 'boto.file',
-                   'boto.ec2', 'boto.ec2.cloudwatch', 'boto.ec2.autoscale',
-                   'boto.ec2.elb', 'boto.sdb', 'boto.cacerts',
-                   'boto.sdb.db', 'boto.sdb.db.manager', 'boto.mturk',
-                   'boto.pyami', 'boto.mashups', 'boto.contrib', 'boto.manage',
-                   'boto.services', 'boto.cloudfront', 'boto.roboto',
-                   'boto.rds', 'boto.vpc', 'boto.fps', 'boto.emr', 'boto.sns',
-                   'boto.ecs', 'boto.iam', 'boto.route53', 'boto.ses',
-                   'tests', 'tests.devpay', 'tests.ec2', 'tests.sdb',
-                   'tests.sqs', 'tests.s3'],
-      license = 'MIT',
-      platforms = 'Posix; MacOS X; Windows',
-      classifiers = [ 'Development Status :: 5 - Production/Stable',
-                      'Intended Audience :: Developers',
-                      'License :: OSI Approved :: MIT License',
-                      'Operating System :: OS Independent',
-                      'Topic :: Internet',
-                      ],
+      packages = ["boto", "boto.sqs", "boto.s3", "boto.gs", "boto.file",
+                  "boto.ec2", "boto.ec2.cloudwatch", "boto.ec2.autoscale",
+                  "boto.ec2.elb", "boto.sdb", "boto.cacerts",
+                  "boto.sdb.db", "boto.sdb.db.manager", "boto.mturk",
+                  "boto.pyami", "boto.mashups", "boto.contrib", "boto.manage",
+                  "boto.services", "boto.cloudfront", "boto.roboto",
+                  "boto.rds", "boto.vpc", "boto.fps", "boto.emr", "boto.sns",
+                  "boto.ecs", "boto.iam", "boto.route53", "boto.ses",
+                  "tests", "tests.devpay", "tests.ec2", "tests.sdb",
+                  "tests.sqs", "tests.s3"],
+      license = "MIT",
+      platforms = "Posix; MacOS X; Windows",
+      classifiers = ["Development Status :: 5 - Production/Stable",
+                     "Intended Audience :: Developers",
+                     "License :: OSI Approved :: MIT License",
+                     "Operating System :: OS Independent",
+                     "Topic :: Internet"],
+      **extra
       )

--- a/tests/test.py
+++ b/tests/test.py
@@ -39,62 +39,69 @@ from autoscale.test_connection import AutoscaleConnectionTest
 from sdb.test_connection import SDBConnectionTest
 
 def usage():
-    print 'test.py  [-t testsuite] [-v verbosity]'
-    print '    -t   run specific testsuite (s3|ssl|s3ver|s3nover|gs|sqs|ec2|sdb|all)'
-    print '    -v   verbosity (0|1|2)'
+    print "test.py  [-t testsuite] [-v verbosity]"
+    print "    -t   run specific testsuite (s3|ssl|s3ver|s3nover|gs|sqs|ec2|sdb|all)"
+    print "    -v   verbosity (0|1|2)"
 
 def main():
     try:
-        opts, args = getopt.getopt(sys.argv[1:], 'ht:v:',
-                                   ['help', 'testsuite', 'verbosity'])
+        opts, args = getopt.getopt(sys.argv[1:], "ht:v:",
+                                   ["help", "testsuite", "verbosity"])
     except:
         usage()
         sys.exit(2)
-    testsuite = 'all'
+    testsuite = "all"
     verbosity = 1
     for o, a in opts:
-        if o in ('-h', '--help'):
+        if o in ("-h", "--help"):
             usage()
             sys.exit()
-        if o in ('-t', '--testsuite'):
+        if o in ("-t", "--testsuite"):
             testsuite = a
-        if o in ('-v', '--verbosity'):
+        if o in ("-v", "--verbosity"):
             verbosity = int(a)
     if len(args) != 0:
         usage()
         sys.exit()
-    suite = unittest.TestSuite()
-    if testsuite == 'all':
-        suite.addTest(unittest.makeSuite(SQSConnectionTest))
-        suite.addTest(unittest.makeSuite(S3ConnectionTest))
-        suite.addTest(unittest.makeSuite(EC2ConnectionTest))
-        suite.addTest(unittest.makeSuite(SDBConnectionTest))
-        suite.addTest(unittest.makeSuite(AutoscaleConnectionTest))
-    elif testsuite == 's3':
-        suite.addTest(unittest.makeSuite(S3ConnectionTest))
-        suite.addTest(unittest.makeSuite(S3VersionTest))
-    elif testsuite == 'ssl':
-        suite.addTest(unittest.makeSuite(CertValidationTest))
-    elif testsuite == 's3ver':
-        suite.addTest(unittest.makeSuite(S3VersionTest))
-    elif testsuite == 's3nover':
-        suite.addTest(unittest.makeSuite(S3ConnectionTest))
-    elif testsuite == 'gs':
-        suite.addTest(unittest.makeSuite(GSConnectionTest))
-    elif testsuite == 'sqs':
-        suite.addTest(unittest.makeSuite(SQSConnectionTest))
-    elif testsuite == 'ec2':
-        suite.addTest(unittest.makeSuite(EC2ConnectionTest))
-    elif testsuite == 'autoscale':
-        suite.addTest(unittest.makeSuite(AutoscaleConnectionTest))
-    elif testsuite == 'sdb':
-        suite.addTest(unittest.makeSuite(SDBConnectionTest))
-    else:
+    try:
+        tests = suite(collection)
+    except ValueError:
         usage()
         sys.exit()
     if verbosity > 1:
         logging.basicConfig(level=logging.DEBUG)
-    unittest.TextTestRunner(verbosity=verbosity).run(suite)
+    unittest.TextTestRunner(verbosity=verbosity).run(tests)
+
+def suite(testsuite="all"):
+    tests = unittest.TestSuite()
+    if testsuite == "all":
+        tests.addTest(unittest.makeSuite(SQSConnectionTest))
+        tests.addTest(unittest.makeSuite(S3ConnectionTest))
+        tests.addTest(unittest.makeSuite(EC2ConnectionTest))
+        tests.addTest(unittest.makeSuite(SDBConnectionTest))
+        tests.addTest(unittest.makeSuite(AutoscaleConnectionTest))
+    elif testsuite == "s3":
+        tests.addTest(unittest.makeSuite(S3ConnectionTest))
+        tests.addTest(unittest.makeSuite(S3VersionTest))
+    elif testsuite == "ssl":
+        tests.addTest(unittest.makeSuite(CertValidationTest))
+    elif testsuite == "s3ver":
+        tests.addTest(unittest.makeSuite(S3VersionTest))
+    elif testsuite == "s3nover":
+        tests.addTest(unittest.makeSuite(S3ConnectionTest))
+    elif testsuite == "gs":
+        tests.addTest(unittest.makeSuite(GSConnectionTest))
+    elif testsuite == "sqs":
+        tests.addTest(unittest.makeSuite(SQSConnectionTest))
+    elif testsuite == "ec2":
+        tests.addTest(unittest.makeSuite(EC2ConnectionTest))
+    elif testsuite == "autoscale":
+        tests.addTest(unittest.makeSuite(AutoscaleConnectionTest))
+    elif testsuite == "sdb":
+        tests.addTest(unittest.makeSuite(SDBConnectionTest))
+    else:
+        raise ValueError("Invalid choice.")
+    return tests
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- `setup.py` syntax is now more consistent.
- `setup.py` supports the `test` command if setuptools/distribute is being used.
- Refactored `tests/test.py` to allow `setup.py` to hook in more easily.
