### PR TITLE
SES bug fix

### DIFF
--- a/boto/ses/connection.py
+++ b/boto/ses/connection.py
@@ -178,7 +178,7 @@ class SESConnection(AWSAuthConnection):
         if(format not in ("text","html")):
             raise ValueError("'format' argument must be 'text' or 'html'")
 
-        if(not (html_body and text_body)):
+        if(not (html_body or text_body)):
             raise ValueError("No text or html body found for mail")
 
         self._build_list_params(params, to_addresses,


### PR DESCRIPTION
my first ever pull request so please review.

i believe the "and" needs to be an "or" to enable an email to get sent (as is consistent with the error message).

BUG
        if(not (html_body and text_body)):
            raise ValueError("No text or html body found for mail")

FIX
        if(not (html_body or text_body)):
            raise ValueError("No text or html body found for mail")
