### PR TITLE
Fixing bug I introduced into compute_md5, fixed StringIO output handling

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -550,7 +550,9 @@ class Key(object):
         fp.seek(0)
         s = fp.read(self.BufferSize)
         while s:
-            m.update(s.encode('utf-8'))
+            if isinstance(s, unicode):
+                s = s.encode('utf-8')
+            m.update(s)
             s = fp.read(self.BufferSize)
         hex_md5 = m.hexdigest()
         base64md5 = base64.encodestring(m.digest())


### PR DESCRIPTION
Since compute_md5 could operate on output from StringIO, it may have to convert codepoint to something hashable by hashlib, which does not support unicode codepoint.  
