### PR TITLE
Response headers in URL

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -443,11 +443,12 @@ class Bucket(object):
         """
         return self.key_class(self, key_name)
 
-    def generate_url(self, expires_in, method='GET',
-                     headers=None, force_http=False):
+    def generate_url(self, expires_in, method='GET', headers=None,
+                     force_http=False, response_headers=None):
         return self.connection.generate_url(expires_in, method, self.name,
                                             headers=headers,
-                                            force_http=force_http)
+                                            force_http=force_http,
+                                            response_headers=response_headers)
 
     def delete_key(self, key_name, headers=None,
                    version_id=None, mfa_token=None):

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -398,7 +398,7 @@ class Key(object):
         return self.bucket.set_canned_acl('public-read', self.name, headers)
 
     def generate_url(self, expires_in, method='GET', headers=None,
-                     query_auth=True, force_http=False):
+                     query_auth=True, force_http=False, response_headers=None):
         """
         Generate a URL to access this key.
         
@@ -421,7 +421,8 @@ class Key(object):
         return self.bucket.connection.generate_url(expires_in, method,
                                                    self.bucket.name, self.name,
                                                    headers, query_auth,
-                                                   force_http)
+                                                   force_http,
+                                                   response_headers)
 
     def send_file(self, fp, headers=None, cb=None, num_cb=10, query_args=None):
         """


### PR DESCRIPTION
Response header overriding now possible in generated URLs. Closes boto/boto#163.

I did run the unit tests (I'm not sure if they cover the URL generation) and everything passed with the exception of services to which I am not subscribed (like SQS). Additionally, I generated just a few URLs, with and without the `response-content-header` argument, to make sure I could still generate things without the additional parameters.

Feel free to adjust the code to better fit boto coding standards or squash any bugs if they exist.
