### PR TITLE
App Engine 1.5.0 is raising an ImportError when importing pyami.config.

### DIFF
--- a/boto/pyami/config.py
+++ b/boto/pyami/config.py
@@ -31,7 +31,7 @@ import boto
 try:
   os.path.expanduser('~')
   expanduser = os.path.expanduser
-except AttributeError:
+except (AttributeError, ImportError):
   # This is probably running on App Engine.
   expanduser = (lambda x: x)
 


### PR DESCRIPTION
App Engine is currently throwing an ImportError when attempting to use os.path.expanduser.  I think this is an App Engine bug, but might as well catch it.
