### PR TITLE
Corrected AZ config key name when creating a job

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -274,7 +274,7 @@ class EmrConnection(AWSQueryConnection):
         if ec2_keyname:
             params['Instances.Ec2KeyName'] = ec2_keyname
         if availability_zone:
-            params['Placement'] = availability_zone
+            params['Placement.AvailabilityZone'] = availability_zone
 
         return params
 


### PR DESCRIPTION
Corrected availability zone config key name when calling EmrConnection.run_jobflow() so the AZ is actually specified. May fix #74 among other issues.
