### PR TITLE
add a 'url' arg to get_instance_metadata and get_instance_userdata

### DIFF
--- a/boto/utils.py
+++ b/boto/utils.py
@@ -196,7 +196,7 @@ def _get_instance_metadata(url):
                 d[key] = val
     return d
 
-def get_instance_metadata(version='latest'):
+def get_instance_metadata(version='latest', url='http://169.254.169.254'):
     """
     Returns the instance metadata as a nested Python dictionary.
     Simple values (e.g. local_hostname, hostname, etc.) will be
@@ -204,12 +204,12 @@ def get_instance_metadata(version='latest'):
     be stored in the dict as a list of string values.  More complex
     fields such as public-keys and will be stored as nested dicts.
     """
-    url = 'http://169.254.169.254/%s/meta-data/' % version
-    return _get_instance_metadata(url)
+    return _get_instance_metadata('%s/%s/meta-data' % (url, version))
 
-def get_instance_userdata(version='latest', sep=None):
-    url = 'http://169.254.169.254/%s/user-data' % version
-    user_data = retry_url(url, retry_on_404=False)
+def get_instance_userdata(version='latest', sep=None,
+                          url='http://169.254.169.254'):
+    ud_url = '%s/%s/user-data' % (url,version)
+    user_data = retry_url(ud_url, retry_on_404=False)
     if user_data:
         if sep:
             l = user_data.split(sep)


### PR DESCRIPTION
This adds a 'url' arg to get_instance_metadata and get_instance_userdata

The reason for this argument is primarily to support using boto.utils in
a AWS like environment where there is a metadata service, but it is not
available in the standard location (under http://169.254.169.254/)

One such environment is Eucalyptus running in SYSTEM or STATIC modes.

Per http://open.eucalyptus.com/wiki/EucalyptusNetworkConfiguration_v2.0
| If your system is configured using SYSTEM or STATIC networking modes,
| then retrieving data requires the IP (or hostname) and port number of
| the Eucalyptus Cloud Controller (CLC):
|
| http://<IP or hostname of CLC>:8773/<specific request>

Cloud-init is addressing this under the bug at
http://bugs.launchpad.net/bugs/761847

Also thanks to Kieran Evans.
