### PR TITLE
Support to create EC2 instances under VPC security groups

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -442,16 +442,17 @@ class EC2Connection(AWSQueryConnection):
                              [('item', Reservation)], verb='POST')
 
     def run_instances(self, image_id, min_count=1, max_count=1,
-                      key_name=None, security_group_ids=None,
-                      security_groups=None, user_data=None, 
-                      addressing_type=None, instance_type='m1.small', 
-                      placement=None, kernel_id=None, ramdisk_id=None,
+                      key_name=None, security_groups=None, 
+                      user_data=None, addressing_type=None, 
+                      instance_type='m1.small', placement=None, 
+                      kernel_id=None, ramdisk_id=None,
                       monitoring_enabled=False, subnet_id=None,
                       block_device_map=None,
                       disable_api_termination=False,
                       instance_initiated_shutdown_behavior=None,
                       private_ip_address=None,
-                      placement_group=None, client_token=None):
+                      placement_group=None, client_token=None,
+                      security_group_ids=None):
         """
         Runs an image on EC2.
 
@@ -467,9 +468,6 @@ class EC2Connection(AWSQueryConnection):
         :type key_name: string
         :param key_name: The name of the key pair with which to launch instances
 
-        :type security_group_ids: list of strings
-        :param security_groups_ids: The ID of the VPC security groups with which to
-                                associate instances
         :type security_groups: list of strings
         :param security_groups: The names of the security groups with which to
                                 associate instances
@@ -546,6 +544,10 @@ class EC2Connection(AWSQueryConnection):
         :rtype: Reservation
         :return: The :class:`boto.ec2.instance.Reservation` associated with
                  the request for machines
+
+        :type security_group_ids: list of strings
+        :param security_group_ids: The ID of the VPC security groups with which to
+                                associate instances
         """
         params = {'ImageId':image_id,
                   'MinCount':min_count,

--- a/boto/ec2/image.py
+++ b/boto/ec2/image.py
@@ -152,7 +152,7 @@ class Image(TaggedEC2Object):
         return self.state
 
     def run(self, min_count=1, max_count=1, key_name=None, 
-            security_group_ids=None, security_groups=None, user_data=None,
+            security_groups=None, user_data=None,
             addressing_type=None, instance_type='m1.small', placement=None,
             kernel_id=None, ramdisk_id=None,
             monitoring_enabled=False, subnet_id=None,
@@ -160,7 +160,7 @@ class Image(TaggedEC2Object):
             disable_api_termination=False,
             instance_initiated_shutdown_behavior=None,
             private_ip_address=None,
-            placement_group=None):
+            placement_group=None, security_group_ids=None):
         """
         Runs this instance.
         
@@ -173,9 +173,6 @@ class Image(TaggedEC2Object):
         :type key_name: string
         :param key_name: The name of the keypair to run this instance with.
         
-        :type security_group_ids: 
-        :param security_group_ids:
-
         :type security_groups: 
         :param security_groups:
         
@@ -234,17 +231,21 @@ class Image(TaggedEC2Object):
 
         :rtype: Reservation
         :return: The :class:`boto.ec2.instance.Reservation` associated with the request for machines
+
+        :type security_group_ids: 
+        :param security_group_ids:
         """
+
         return self.connection.run_instances(self.id, min_count, max_count,
-                                             key_name, security_group_ids, 
-                                             security_groups, user_data, 
-                                             addressing_type, instance_type, 
-                                             placement, kernel_id, ramdisk_id,
+                                             key_name, security_groups,
+                                             user_data, addressing_type,
+                                             instance_type, placement,
+                                             kernel_id, ramdisk_id,
                                              monitoring_enabled, subnet_id,
                                              block_device_map, disable_api_termination,
                                              instance_initiated_shutdown_behavior,
-                                             private_ip_address,
-                                             placement_group)
+                                             private_ip_address, placement_group, 
+                                             security_group_ids=security_group_ids)
 
     def deregister(self, delete_snapshot=False):
         return self.connection.deregister_image(self.id, delete_snapshot)


### PR DESCRIPTION
Add support to accept SecurityGroupId as a parameter for ec2 run instances.
This is required to create EC2 instances under VPC security groups

Reference: The latest EC2 run instance API  http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/index.html?ApiReference-query-RunInstances.html
