### PR TITLE
Issue with proxy settings

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -430,7 +430,7 @@ class AWSAuthConnection(object):
             # gracefully fail in case of pool overflow
             connection.close()
 
-    def proxy_ssl(self):
+    def proxy_ssl(self, goodProxy = True):
         host = '%s:%d' % (self.host, self.port)
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
@@ -443,7 +443,7 @@ class AWSAuthConnection(object):
         if self.proxy_user and self.proxy_pass:
             for k, v in self.get_proxy_auth_header().items():
                 sock.sendall("%s: %s\r\n" % (k, v))
-        #sock.sendall("\r\n")
+        sock.sendall("\r\n")
         resp = httplib.HTTPResponse(sock, strict=True, debuglevel=self.debug)
         resp.begin()
 
@@ -477,7 +477,11 @@ class AWSAuthConnection(object):
         else:
             # Fallback for old Python without ssl.wrap_socket
             if hasattr(httplib, 'ssl'):
-                sslSock = httplib.ssl.SSLSocket(sock)
+                try:
+                    sslSock = httplib.ssl.SSLSocket(sock)
+                except:
+                    h = self.proxy_ssl(False)
+                    return h
             else:
                 sslSock = socket.ssl(sock, None, None)
                 sslSock = httplib.FakeSocket(sock, sslSock)


### PR DESCRIPTION
 I get an "EOF violation of protocol" while trying to use boto behind a proxy, I fixed it commenting this line.

The issue might be comming from an old python version, this is the system I use :
- cloudera (ubuntu + hadoop)
- python2.6
- python-boto 1.9b-1 (ubuntu package)
