### PR TITLE
Added correct sax reader for boto.emr.emrobject.BootstrapAction

### DIFF
--- a/boto/emr/emrobject.py
+++ b/boto/emr/emrobject.py
@@ -61,6 +61,11 @@ class BootstrapAction(EmrObject):
         'Path',
     ])
 
+    def startElement(self, name, attrs, connection):
+        if name == 'Args':
+            self.args = ResultSet([('member', Arg)])
+            return self.args
+
 
 class KeyValue(EmrObject):
     Fields = set([


### PR DESCRIPTION
Without this patch, you cannot read `boto.emr.emrobject.BootstrapAction.args` because it doesn't parse the XML properly.
