### PR TITLE
Property validator and typing fixes

### DIFF
--- a/boto/sdb/db/property.py
+++ b/boto/sdb/db/property.py
@@ -75,7 +75,7 @@ class Property(object):
         self.slot_name = '_' + self.name
 
     def default_validator(self, value):
-        if value == self.default_value():
+        if isinstance(value, basestring) or value == self.default_value():
             return
         if not isinstance(value, self.data_type):
             raise TypeError, 'Validation Error, expecting %s, got %s' % (self.data_type, type(value))


### PR DESCRIPTION
Basestring mods in base property to allow text properties to use unicode,
changed default_validator back, as basestring allowed improper values through for properties
copied validator and required over to a couple properties instead of calling super, which had problems
