### PR TITLE
Generalized FPS make_url for easier use with MarketPlace registration

### DIFF
--- a/boto/fps/connection.py
+++ b/boto/fps/connection.py
@@ -129,10 +129,9 @@ class FPSConnection(AWSQueryConnection):
         params['pipelineName'] = str(pipelineName)
         params['maxFixedFee'] = str(maxFixedFee)
         params['maxVariableFee'] = str(maxVariableFee)
-        params['recipientPaysFee'] - str(recipientPaysFee)
+        params['recipientPaysFee'] = str(recipientPaysFee)
         params["signatureMethod"] = 'HmacSHA256'
         params["signatureVersion"] = '2'
-        params["transactionAmount"] = transactionAmount
 
         if(not params.has_key('callerReference')):
             params['callerReference'] = str(uuid.uuid4())


### PR DESCRIPTION
I removed a few parameters from the make_url function so that it could also be used in conjunction with registering a recipient for the market place. Was there already a way of doing this? Passing in the required parameters like maxFixedFee would thow an error since it would pass transactionAmount and paymentReason when they shouldn't have been included in the url.
