### PR TITLE
Fix content-length problem when retrying a call.

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -184,6 +184,7 @@ class QuerySignatureHelper(HmacKeys):
         if http_request.method == 'POST':
             headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8'
             http_request.body = qs + '&Signature=' + urllib.quote(signature)
+            http_request.headers['Content-Length'] = str(len(http_request.body))
         else:
             http_request.body = ''
             # if this is a retried request, the qs from the previous try will

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -159,12 +159,11 @@ class HTTPRequest(object):
         connection._auth_handler.add_auth(self, **kwargs)
 
         self.headers['User-Agent'] = UserAgent
-
-        # Always set the content-length, even if there already was
-        # one.  Re-signing a request can result in the signature being
-        # a different length (because of URL encoding), and thus the
-        # whole body being a different length.
-        self.headers['Content-Length'] = str(len(self.body))
+        self.headers['User-Agent'] = UserAgent
+        # I'm not sure if this is still needed, now that add_auth is
+        # setting the content-length for POST requests.
+        if not self.headers.has_key('Content-Length'):
+            self.headers['Content-Length'] = str(len(self.body))
 
 class AWSAuthConnection(object):
     def __init__(self, host, aws_access_key_id=None, aws_secret_access_key=None,


### PR DESCRIPTION
When a POST call is retried, the timestamp is updated and the signature is recomputed.   Because the signature is URL encoded, the length of the body of the request can change.  This change re-sets the content-length header when the request is re-signed.
