### PR TITLE
Made boolean argument in make_marketplace_registration_url consistant

### DIFF
--- a/boto/fps/connection.py
+++ b/boto/fps/connection.py
@@ -113,7 +113,7 @@ class FPSConnection(AWSQueryConnection):
         else:
             raise FPSResponseError(response.status, response.reason, body)
 
-    def make_marketplace_registration_url(self, returnURL, pipelineName, maxFixedFee=0.0, maxVariableFee=0.0, recipientPaysFee='True', **params):  
+    def make_marketplace_registration_url(self, returnURL, pipelineName, maxFixedFee=0.0, maxVariableFee=0.0, recipientPaysFee=True, **params):  
         """
         Generate the URL with the signature required for signing up a recipient
         """


### PR DESCRIPTION
I realized I had made a mistake and set the boolean argument recipientPaysFee as a string instead of a boolean. I changed it to a boolean to be consistant with the other functions.
