### PR TITLE
Made the -s option accept a comma-separated list and allowed #import in scripts

### DIFF
--- a/bin/launch_instance
+++ b/bin/launch_instance
@@ -102,7 +102,7 @@ def add_script(scr_url):
             #Read the other script and put it in that spot
             script_content += add_script("%s/%s" % (base_url, match.group(1)))
         else:
-            #As long as it's not the shebang line, add it and move on
+            #Otherwise, add the line and move on
             script_content += line
     return script_content
 


### PR DESCRIPTION
The -s option can now accept "-s x,y,z" notation as well as "-s x -s y -s z". 
Adding a line "#import filename" in a script will add all the lines from that script at that point in the first script.
