### PR TITLE
Prefer simplejson over json module (performance reasons)

### DIFF
--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -137,9 +137,9 @@ about that particular data point.
 My server obviously isn't very busy right now!
 """
 try:
-    import json
-except ImportError:
     import simplejson as json
+except ImportError:
+    import json
 
 from boto.connection import AWSQueryConnection
 from boto.ec2.cloudwatch.metric import Metric

--- a/boto/ec2/cloudwatch/alarm.py
+++ b/boto/ec2/cloudwatch/alarm.py
@@ -23,12 +23,10 @@
 from datetime import datetime
 from boto.resultset import ResultSet
 from boto.ec2.cloudwatch.listelement import ListElement
-
 try:
-    import json
-except ImportError:
     import simplejson as json
-
+except ImportError:
+    import json
 
 class MetricAlarm(object):
 

--- a/boto/pyami/config.py
+++ b/boto/pyami/config.py
@@ -197,9 +197,9 @@ class Config(ConfigParser.SafeConfigParser):
     
     def dump_to_sdb(self, domain_name, item_name):
         try:
-            import json
-        except ImportError:
             import simplejson as json
+        except ImportError:
+            import json
 
         sdb = boto.connect_sdb()
         domain = sdb.lookup(domain_name)

--- a/boto/sns/connection.py
+++ b/boto/sns/connection.py
@@ -24,9 +24,9 @@ from boto.sdb.regioninfo import SDBRegionInfo
 import boto
 import uuid
 try:
-    import json
-except ImportError:
     import simplejson as json
+except ImportError:
+    import json
 
 #boto.set_stream_logger('sns')
 

--- a/boto/sqs/jsonmessage.py
+++ b/boto/sqs/jsonmessage.py
@@ -23,9 +23,9 @@ from boto.sqs.message import MHMessage
 from boto.exception import SQSDecodeError
 import base64
 try:
-    import json
-except ImportError:
     import simplejson as json
+except ImportError:
+    import json
 
 class JSONMessage(MHMessage):
     """


### PR DESCRIPTION
simplejson has had a lot of performance improvements since it was originally incorporated into the standard library.  We should prefer it to json.
