### PR TITLE
FPS settle request uses improper post parameters

### DIFF
--- a/boto/fps/connection.py
+++ b/boto/fps/connection.py
@@ -301,8 +301,9 @@ class FPSConnection(AWSQueryConnection):
         """
         params = {}
         params['ReserveTransactionId'] = reserveTransactionId
+        params['TransactionAmount.CurrencyCode'] = 'USD'
         if(transactionAmount != None):
-            params['TransactionAmount'] = transactionAmount
+            params['TransactionAmount.Amount'] = transactionAmount
         
         response = self.make_request("Settle", params)
         body = response.read()


### PR DESCRIPTION
The current version of settle makes a request that uses the post parameter "transactionAmount". This fails on every request for me. The Amazon documentation says that the transactionAmount is a "Amount" type which consists of two separate parameters, "CurrencyCode" and "Value". 

Currently I have a question open on the Amazon Forum (https://forums.aws.amazon.com/thread.jspa?messageID=261372&#261372) because the "Value" parameter will fail. Changing "Value" to "Amount" allows for the settle request to happen successfully. 

The changes I've made allow the settle request to succeed, but I'm still waiting on Amazon for their response to the situation.
