### PR TITLE
Documentation error: Versioned S3 buckets are available in all regions.

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -818,8 +818,7 @@ class Bucket(object):
         """
         Configure versioning for this bucket.
         
-        ..note:: This feature is currently in beta release and is available
-                 only in the Northern California region.
+        ..note:: This feature is currently in beta.
                  
         :type versioning: bool
         :param versioning: A boolean indicating whether version is


### PR DESCRIPTION
The documentation states that S3 bucket versioning is "available only in the Northern California region."

As of February 8, 2010, that's no longer the case: "We are pleased to announce the availability of the Versioning feature for beta use across all of our Amazon S3 Regions."

I'm not sure if it's still in beta as of July 2011, but it's most certainly no longer restricted to a single region.

Cite: http://aws.amazon.com/about-aws/whats-new/2010/02/08/versioning-feature-for-amazon-s3-now-available/
