### PR TITLE
If region is in fact specified, i think it should be a string (that seems

### DIFF
--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -89,7 +89,7 @@ class ELBConnection(AWSQueryConnection):
         if not region:
             region = RegionInfo(self, self.DefaultRegionName,
                                 self.DefaultRegionEndpoint)
-        else:
+        elif isinstance(region, basestring):
             self.region = RegionInfo(self, region,
                                 RegionData[region])
 


### PR DESCRIPTION
If region is in fact specified, i think it should be a string (that seems to be true for most other boto connections, and is much cleaner in any case) -- the lookup dict (to endpoint) exists, but currently the endpoint lookup doesnt work, so this should fix that so that str region specified works.

---

Original error:
  File "/xxxx/ec2/elb/**init**.py", line 96, in **init**
    self.region.endpoint, debug,
  AttributeError: 'str' object has no attribute 'endpoint'
