### PR TITLE
Fix EMR instance group methods to use spaces instead of tabs for indentat

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -145,48 +145,48 @@ class EmrConnection(AWSQueryConnection):
         return self.get_object(
             'AddJobFlowSteps', params, RunJobFlowResponse, verb='POST')
 
-	def add_instance_groups(self, jobflow_id, instance_groups):
-		"""
-		Adds instance groups to a running cluster.
-		
-		:type jobflow_id: str
-		:param jobflow_id: The id of the jobflow which will take the new instance groups
-		:type instance_groups: list(boto.emr.InstanceGroup)
-		:param instance_groups: A list of instance groups to add to the job
-		"""
-		if type(instance_groups) != types.ListType:
-			instance_groups = [instance_groups]
-		params = {}
-		params['JobFlowId'] = jobflow_id
-		
-		instance_group_args = [self._build_instance_group_args(ig) for ig in instance_groups]
-		params.update(self._build_instance_group_list(instance_group_args))
-		
-		return self.get_object('AddInstanceGroups', params, AddInstanceGroupsResponse, verb='POST')
-			
-	def modify_instance_groups(self, instance_group_ids, new_sizes):
-		"""
-		Modify the number of nodes and configuration settings in an instance group.
-				
-		:type instance_group_ids: list(str)
-		:param instance_group_ids: A list of the ID's of the instance groups to be modified
-		:type new_sizes: list(int)
-		:param new_sizes: A list of the new sizes for each instance group
-		"""
-		if type(instance_group_ids) != types.ListType:
-			instance_group_ids = [instance_group_ids]
-		if type(new_sizes) != types.ListType:
-			new_sizes = [new_sizes]
-			
-		instance_groups = zip(instance_group_ids, new_sizes)
-				
-		for k, ig in enumerate(instance_groups):
-			#could be wrong - the example amazon gives uses InstanceRequestCount, 
-			#while the api documentation says InstanceCount
-			params['InstanceGroups.member.%s.InstanceGroupId' % k+1 ] = ig[1][0] 
-			params['InstanceGroups.member.%s.InstanceCount' % k+1 ] = ig[1][1]
-			
-		return self.get_object('ModifyInstanceGroups', params, ModifyInstanceGroupsResponse, verb='POST')
+    def add_instance_groups(self, jobflow_id, instance_groups):
+        """
+        Adds instance groups to a running cluster.
+
+        :type jobflow_id: str
+        :param jobflow_id: The id of the jobflow which will take the new instance groups
+        :type instance_groups: list(boto.emr.InstanceGroup)
+        :param instance_groups: A list of instance groups to add to the job
+        """
+        if type(instance_groups) != types.ListType:
+            instance_groups = [instance_groups]
+        params = {}
+        params['JobFlowId'] = jobflow_id
+
+        instance_group_args = [self._build_instance_group_args(ig) for ig in instance_groups]
+        params.update(self._build_instance_group_list(instance_group_args))
+
+        return self.get_object('AddInstanceGroups', params, AddInstanceGroupsResponse, verb='POST')
+
+    def modify_instance_groups(self, instance_group_ids, new_sizes):
+        """
+        Modify the number of nodes and configuration settings in an instance group.
+
+        :type instance_group_ids: list(str)
+        :param instance_group_ids: A list of the ID's of the instance groups to be modified
+        :type new_sizes: list(int)
+        :param new_sizes: A list of the new sizes for each instance group
+        """
+        if type(instance_group_ids) != types.ListType:
+            instance_group_ids = [instance_group_ids]
+        if type(new_sizes) != types.ListType:
+            new_sizes = [new_sizes]
+
+        instance_groups = zip(instance_group_ids, new_sizes)
+
+        for k, ig in enumerate(instance_groups):
+            #could be wrong - the example amazon gives uses InstanceRequestCount,
+            #while the api documentation says InstanceCount
+            params['InstanceGroups.member.%s.InstanceGroupId' % k+1 ] = ig[1][0]
+            params['InstanceGroups.member.%s.InstanceCount' % k+1 ] = ig[1][1]
+
+        return self.get_object('ModifyInstanceGroups', params, ModifyInstanceGroupsResponse, verb='POST')
 
     def run_jobflow(self, name, log_uri, ec2_keyname=None, availability_zone=None,
                     master_instance_type='m1.small',
@@ -328,15 +328,15 @@ class EmrConnection(AWSQueryConnection):
         return params
 
     def _build_instance_group_args(self, instance_group):
-		params = {
-			'InstanceCount' : instance_group.num_instances,
-			'InstanceRole' : instance_group.role,
-			'InstanceType' : instance_group.type,
-			'Name' : instance_group.name,
-			'Market' : instance_group.market
-		}
-		return params
-		
+        params = {
+            'InstanceCount' : instance_group.num_instances,
+            'InstanceRole' : instance_group.role,
+            'InstanceType' : instance_group.type,
+            'Name' : instance_group.name,
+            'Market' : instance_group.market
+        }
+        return params
+
     def _build_instance_group_list(self, instance_groups):
         if type(instance_groups) != types.ListType:
             instance_groups = [instance_groups]

--- a/boto/emr/instance_group.py
+++ b/boto/emr/instance_group.py
@@ -20,14 +20,14 @@
 
 
 class InstanceGroup(object):
-	def __init__(self, num_instances, role, type, market, name):
-		self.num_instances = num_instances
-		self.role = role
-		self.type = type
-		self.market = market
-		self.name = name
-	
-	def __repr__(self):
-		return '%s.%s(name=%r, num_instances=%r, role=%r, type=%r, market = %r)' % (
+    def __init__(self, num_instances, role, type, market, name):
+        self.num_instances = num_instances
+        self.role = role
+        self.type = type
+        self.market = market
+        self.name = name
+
+    def __repr__(self):
+        return '%s.%s(name=%r, num_instances=%r, role=%r, type=%r, market = %r)' % (
             self.__class__.__module__, self.__class__.__name__,
             self.name, self.num_instances, self.role, self.type, self.market)


### PR DESCRIPTION
Replaced tabs with spaces... this makes the methods accessible again.
