### PR TITLE
lss3 fix for mixed-case buckets

### DIFF
--- a/bin/lss3
+++ b/bin/lss3
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import boto
+from boto.s3.connection import OrdinaryCallingFormat
 
 def sizeof_fmt(num):
     for x in ['b ','KB','MB','GB','TB', 'XB']:
@@ -45,12 +46,24 @@ def list_buckets(s3):
 
 if __name__ == "__main__":
     import sys
-    s3 = boto.connect_s3()
+
+    pairs = []
+    mixedCase = False
+    for name in sys.argv[1:]:
+            if "/" in name:
+                pairs.append(name.split("/",1))
+            else:
+                pairs.append([name, None])
+            if pairs[-1][0].lower() != pairs[-1][0]:
+                mixedCase = True
+    
+    if mixedCase:
+        s3 = boto.connect_s3(calling_format=OrdinaryCallingFormat())
+    else:
+        s3 = boto.connect_s3()
+
     if len(sys.argv) < 2:
         list_buckets(s3)
     else:
-        for name in sys.argv[1:]:
-            prefix = None
-            if "/" in name:
-                (name, prefix) = name.split("/",1)
+        for name, prefix in pairs:
             list_bucket(s3.get_bucket(name), prefix)


### PR DESCRIPTION
Use OrdinaryCallingFormat when mixed-case bucket names are passed to lss3
