### PR TITLE
Tag.n.Value should not be sent for DeleteTags when the user doesn't supply it

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -2386,9 +2386,8 @@ class EC2Connection(AWSQueryConnection):
         for key in keys:
             value = tags[key]
             params['Tag.%d.Key'%i] = key
-            if value is None:
-                value = ''
-            params['Tag.%d.Value'%i] = value
+            if value is not None:
+                params['Tag.%d.Value'%i] = value
             i += 1
         
     def get_all_tags(self, filters=None):


### PR DESCRIPTION
The current EC2 api, if given the Tag.n.Value parameter the empty string, will only delete it if the tag's value is the empty string. The intended behavior is to delete the tag regardless of the value. In this use case, no Value parameter should be sent to EC2.
