### PR TITLE
Combiner support for StreamingStep in EMR on Hadoop 0.20 and later

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -138,14 +138,8 @@ class EmrConnection(AWSQueryConnection):
         params = {}
         params['JobFlowId'] = jobflow_id
 
-        # only care about hadoop version if we have combiners
-        if any(step.combiner for step in steps):
-            hadoop_version = self.describe_jobflow(jobflow_id).hadoopversion
-        else:
-            hadoop_version = '0.18'
-
         # Step args
-        step_args = [self._build_step_args(step, hadoop_version) for step in steps]
+        step_args = [self._build_step_args(step) for step in steps]
         params.update(self._build_step_list(step_args))
 
         return self.get_object(
@@ -199,7 +193,7 @@ class EmrConnection(AWSQueryConnection):
                     slave_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
-                    hadoop_version='0.18',
+                    hadoop_version='0.20',
                     steps=[],
                     bootstrap_actions=[]):
         """
@@ -254,7 +248,7 @@ class EmrConnection(AWSQueryConnection):
 
         # Step args
         if steps:
-            step_args = [self._build_step_args(step, hadoop_version) for step in steps]
+            step_args = [self._build_step_args(step) for step in steps]
             params.update(self._build_step_list(step_args))
 
         if bootstrap_actions:
@@ -299,7 +293,7 @@ class EmrConnection(AWSQueryConnection):
 
         return bootstrap_action_params
 
-    def _build_step_args(self, step, hadoop_version='0.18'):
+    def _build_step_args(self, step):
         step_params = {}
         step_params['ActionOnFailure'] = step.action_on_failure
         step_params['HadoopJarStep.Jar'] = step.jar()
@@ -308,7 +302,7 @@ class EmrConnection(AWSQueryConnection):
         if main_class:
             step_params['HadoopJarStep.MainClass'] = main_class
 
-        args = step.args(hadoop_version=hadoop_version)
+        args = step.args()
         if args:
             self.build_list_params(step_params, args, 'HadoopJarStep.Args.member')
 

--- a/boto/emr/step.py
+++ b/boto/emr/step.py
@@ -109,6 +109,8 @@ class StreamingStep(Step):
         :param mapper: The mapper URI
         :type reducer: str
         :param reducer: The reducer URI
+        :type combiner: str
+        :param combiner: The combiner URI. Only works for Hadoop 0.20 and later!
         :type action_on_failure: str
         :param action_on_failure: An action, defined in the EMR docs to take on failure.
         :type cache_files: list(str)
@@ -146,7 +148,7 @@ class StreamingStep(Step):
     def main_class(self):
         return None
 
-    def args(self, hadoop_version='0.18'):
+    def args(self):
         args = []
 
         # put extra args BEFORE -mapper and -reducer so that e.g. -libjar
@@ -154,18 +156,10 @@ class StreamingStep(Step):
         if self.step_args:
             args.extend(self.step_args)
 
-        # Procedure for building combiners differs between Hadoop versions.
-        # In particular, Hadoop Streaming does not explicitly support
-        # combiners before version 0.20.
+        args.extend(['-mapper', self.mapper])
+
         if self.combiner:
-            if float(hadoop_version) >= 0.20:
-                args.extend(['-mapper', self.mapper])
-                args.extend(['-combiner', self.combiner])
-            else:
-                args.extend(['-mapper', '%s | sort | %s' % (self.mapper,
-                                                            self.combiner)])
-        else:
-            args.extend(['-mapper', self.mapper])
+            args.extend(['-combiner', self.combiner])
 
         if self.reducer:
             args.extend(['-reducer', self.reducer])


### PR DESCRIPTION
Hadoop 0.20 supports combiners in Hadoop Streaming. Now boto can too!

I also bumped the default Hadoop version number to 0.20 because that's EMR's default.
