### PR TITLE
Fix create_scheduled_group_action to support setting to 0. 

### DIFF
--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -485,11 +485,11 @@ class AutoScaleConnection(AWSQueryConnection):
                     'ScheduledActionName'       :   name,
                     'Time'                      :   time.isoformat(),
                  }
-        if desired_capacity:
+        if desired_capacity is not None:
             params['DesiredCapacity'] = desired_capacity
-        if min_size:
+        if min_size is not None:
             params['MinSize'] = min_size
-        if max_size:
+        if max_size is not None:
             params['MaxSize'] = max_size
         return self.get_status('PutScheduledUpdateGroupAction', params)
 


### PR DESCRIPTION
I was unable to shut down an auto-scaling group because the code wouldn't pass 0 to AWS when setting the max_size.
