### PR TITLE
Closes #302: Support OtherSelectionText in Mechanical Turk Response

### DIFF
--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -908,7 +908,7 @@ class QuestionFormAnswer(BaseAutoResultElement):
     def endElement(self, name, value, connection):
         if name == 'QuestionIdentifier':
             self.qid = value
-        elif name in ['FreeText', 'SelectionIdentifier'] and self.qid:
+        elif name in ['FreeText', 'SelectionIdentifier', 'OtherSelectionText'] and self.qid:
             self.fields.append((self.qid,value))
         elif name == 'Answer':
             self.qid = None


### PR DESCRIPTION
Fix for "other" free text responses provided by SelectionAnswer questions. Closes #302.
