### PR TITLE
Change cq to not care about the content of message

### DIFF
--- a/bin/cq
+++ b/bin/cq
@@ -24,6 +24,7 @@ import getopt, sys
 import boto.sqs
 from boto.sqs.connection import SQSConnection
 from boto.exception import SQSError
+from boto.sqs.message import RawMessage
 
 def usage():
     print 'cq [-c] [-q queue_name] [-o output_file] [-t timeout] [-r region]'
@@ -76,6 +77,7 @@ def main():
             print e.body
             sys.exit()
     for q in rs:
+        q.message_class = RawMessage
         if clear:
             n = q.clear()
             print 'clearing %d messages from %s' % (n, q.id)


### PR DESCRIPTION
Boto expects messages to be base64 encoded by default, but in this case, we don't care about the content.
Without this line cq ends up with error like "boto.exception.SQSDecodeError: SQSDecodeError: Unable to decode message" when we try to clear a queue which has non-boto-written messages in it.
