### PR TITLE
Add support for adding spot instances to EMR; Fix emr's add_instance_groups() & modify_instance_groups()

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -356,6 +356,8 @@ class EmrConnection(AWSQueryConnection):
             'Name' : instance_group.name,
             'Market' : instance_group.market
         }
+        if instance_group.market == 'SPOT':
+            params['BidPrice'] = instance_group.bidprice
         return params
 
     def _build_instance_group_list(self, instance_groups):

--- a/boto/emr/instance_group.py
+++ b/boto/emr/instance_group.py
@@ -20,14 +20,24 @@
 
 
 class InstanceGroup(object):
-    def __init__(self, num_instances, role, type, market, name):
+    def __init__(self, num_instances, role, type, market, name, bidprice=None):
         self.num_instances = num_instances
         self.role = role
         self.type = type
         self.market = market
         self.name = name
+        if market == 'SPOT':
+            if not isinstance(bidprice, basestring):
+                raise ValueError('bidprice must be specified if market == SPOT')
+            self.bidprice = bidprice
 
     def __repr__(self):
-        return '%s.%s(name=%r, num_instances=%r, role=%r, type=%r, market = %r)' % (
-            self.__class__.__module__, self.__class__.__name__,
-            self.name, self.num_instances, self.role, self.type, self.market)
+        if self.market == 'SPOT':
+            return '%s.%s(name=%r, num_instances=%r, role=%r, type=%r, market = %r, bidprice = %r)' % (
+                self.__class__.__module__, self.__class__.__name__,
+                self.name, self.num_instances, self.role, self.type, self.market,
+                self.bidprice)
+        else:
+            return '%s.%s(name=%r, num_instances=%r, role=%r, type=%r, market = %r)' % (
+                self.__class__.__module__, self.__class__.__name__,
+                self.name, self.num_instances, self.role, self.type, self.market)


### PR DESCRIPTION
These two commits allow users to add TASK spot instances to an existing jobflow, and fix bugs that prevent emr's add_instance_groups() and modify_instance_groups() from working (with or without spot instances).

I was uncertain how to provide proper tests for these methods, but am happy to write them if you can point me to a good example.
