### PR TITLE
Add availability zone support to get_spot_price_history()

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -832,7 +832,8 @@ class EC2Connection(AWSQueryConnection):
                              [('item', SpotInstanceRequest)], verb='POST')
 
     def get_spot_price_history(self, start_time=None, end_time=None,
-                               instance_type=None, product_description=None):
+                               instance_type=None, product_description=None,
+                               availability_zone=None):
         """
         Retrieve the recent history of spot instances pricing.
         
@@ -864,6 +865,8 @@ class EC2Connection(AWSQueryConnection):
             params['InstanceType'] = instance_type
         if product_description:
             params['ProductDescription'] = product_description
+        if availability_zone:
+            params['AvailabilityZone'] = availability_zone
         return self.get_list('DescribeSpotPriceHistory', params,
                              [('item', SpotPriceHistory)], verb='POST')
 

--- a/boto/ec2/spotpricehistory.py
+++ b/boto/ec2/spotpricehistory.py
@@ -33,6 +33,7 @@ class SpotPriceHistory(EC2Object):
         self.instance_type = None
         self.product_description = None
         self.timestamp = None
+        self.availability_zone = None
 
     def __repr__(self):
         return 'SpotPriceHistory(%s):%2f' % (self.instance_type, self.price)
@@ -46,6 +47,8 @@ class SpotPriceHistory(EC2Object):
             self.product_description = value
         elif name == 'timestamp':
             self.timestamp = value
+        elif name == 'availabilityZone':
+            self.availability_zone = value
         else:
             setattr(self, name, value)
 


### PR DESCRIPTION
Filtering on or receiving info about availability zones requires setting your connection's api_version to 2011-05-15 or later. I'm not sure how to properly handle that (I did not want to touch the default API version.)

This might take care of #253.
