### PR TITLE
VPC Internet gateway support

### DIFF
--- a/boto/vpc/__init__.py
+++ b/boto/vpc/__init__.py
@@ -26,6 +26,7 @@ Represents a connection to the EC2 service.
 from boto.ec2.connection import EC2Connection
 from boto.vpc.vpc import VPC
 from boto.vpc.customergateway import CustomerGateway
+from boto.vpc.internetgateway import InternetGateway
 from boto.vpc.vpngateway import VpnGateway, Attachment
 from boto.vpc.dhcpoptions import DhcpOptions
 from boto.vpc.subnet import Subnet
@@ -93,6 +94,91 @@ class VPCConnection(EC2Connection):
         """
         params = {'VpcId': vpc_id}
         return self.get_status('DeleteVpc', params)
+
+    # Internet Gateways
+
+    def get_all_internet_gateways(self, internet_gateway_ids=None, filters=None):
+        """
+        Get a list of internet gateways. You can filter results to return information
+        about only those gateways that you're interested in.
+
+        :type internet_gateway_ids: list
+        :param internet_gateway_ids: A list of strings with the desired gateway IDs.
+
+        :type filters: list of tuples
+        :param filters: A list of tuples containing filters.  Each tuple
+                        consists of a filter key and a filter value.
+        """
+        params = {}
+
+        if internet_gateway_ids:
+            self.build_list_params(params, internet_gateway_ids, 'InternetGatewayId')
+        if filters:
+            self.build_filter_params(params, dict(filters))
+
+        return self.get_list('DescribeInternetGateways', params, [('item', InternetGateway)])
+
+    def create_internet_gateway(self):
+        """
+        Creates an internet gateway for VPC.
+
+        :rtype: Newly created internet gateway.
+        :return: `boto.vpc.internetgateway.InternetGateway`
+        """
+        return self.get_object('CreateInternetGateway', {}, InternetGateway)
+
+    def delete_internet_gateway(self, internet_gateway_id):
+        """
+        Deletes an internet gateway from the VPC.
+
+        :type internet_gateway_id: str
+        :param internet_gateway_id: The ID of the internet gateway to delete.
+
+        :rtype: Bool
+        :return: True if successful
+        """
+        params = { 'InternetGatewayId': internet_gateway_id }
+        return self.get_status('DeleteInternetGateway', params)
+
+    def attach_internet_gateway(self, internet_gateway_id, vpc_id):
+        """
+        Attach an internet gateway to a specific VPC.
+
+        :type internet_gateway_id: str
+        :param internet_gateway_id: The ID of the internet gateway to delete.
+
+        :type vpc_id: str
+        :param vpc_id: The ID of the VPC to attach to.
+
+        :rtype: Bool
+        :return: True if successful
+        """
+        params = {
+            'InternetGatewayId': internet_gateway_id,
+            'VpcId': vpc_id
+        }
+
+        return self.get_status('AttachInternetGateway', params)
+
+    def detach_internet_gateway(self, internet_gateway_id, vpc_id):
+        """
+        Detach an internet gateway from a specific VPC.
+
+        :type internet_gateway_id: str
+        :param internet_gateway_id: The ID of the internet gateway to delete.
+
+        :type vpc_id: str
+        :param vpc_id: The ID of the VPC to attach to.
+
+        :rtype: Bool
+        :return: True if successful
+        """
+        params = {
+            'InternetGatewayId': internet_gateway_id,
+            'VpcId': vpc_id
+        }
+
+        return self.get_status('DetachInternetGateway', params)
 
     # Customer Gateways
 

--- a/boto/vpc/internetgateway.py
+++ b/boto/vpc/internetgateway.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2009-2010 Mitch Garnaat http://garnaat.org/
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+"""
+Represents an Internet Gateway
+"""
+
+from boto.ec2.ec2object import TaggedEC2Object
+from boto.resultset import ResultSet
+
+class InternetGateway(TaggedEC2Object):
+    def __init__(self, connection=None):
+        TaggedEC2Object.__init__(self, connection)
+        self.id = None
+        self.attachments = []
+
+    def __repr__(self):
+        return 'InternetGateway:%s' % self.id
+
+    def startElement(self, name, attrs, connection):
+        result = super(InternetGateway, self).startElement(name, attrs, connection)
+
+        if result is not None:
+            # Parent found an interested element, just return it
+            return result
+
+        if name == 'attachmentSet':
+            self.attachments = ResultSet([('item', InternetGatewayAttachment)])
+            return self.attachments
+        else:
+            return None
+
+    def endElement(self, name, value, connection):
+        if name == 'internetGatewayId':
+            self.id = value
+        else:
+            setattr(self, name, value)
+
+class InternetGatewayAttachment(object):
+    def __init__(self, connection=None):
+        self.vpc_id = None
+        self.state = None
+
+    def __repr__(self):
+        return 'InternetGatewayAttachment:%s' % self.vpc_id
+
+    def startElement(self, name, attrs, connection):
+        return None
+
+    def endElement(self, name, value, connection):
+        if name == 'vpcId':
+            self.vpc_id = value
+        elif name == 'state':
+            self.state = value


### PR DESCRIPTION
This adds support for internet gateways to the VPC package. The methods below are implemented:
- get_all_internet_gateways
- create_internet_gateway
- delete_internet_gateway
- attach_internet_gateway
- detach_internet_gateway
