### PR TITLE
Adds keyword arguments for members of the BlockDeviceType object.

### DIFF
--- a/boto/ec2/blockdevicemapping.py
+++ b/boto/ec2/blockdevicemapping.py
@@ -22,16 +22,25 @@
 
 class BlockDeviceType(object):
 
-    def __init__(self, connection=None):
+    def __init__(self,
+                 connection=None,
+                 ephemeral_name=None,
+                 no_device=False,
+                 volume_id=None,
+                 snapshot_id=None,
+                 status=None,
+                 attach_time=None,
+                 delete_on_termination=False,
+                 size=None):
         self.connection = connection
-        self.ephemeral_name = None
-        self.no_device = False
-        self.volume_id = None
-        self.snapshot_id = None
-        self.status = None
-        self.attach_time = None
-        self.delete_on_termination = False
-        self.size = None
+        self.ephemeral_name = ephemeral_name
+        self.no_device = no_device
+        self.volume_id = volume_id
+        self.snapshot_id = snapshot_id
+        self.status = status
+        self.attach_time = attach_time
+        self.delete_on_termination = delete_on_termination
+        self.size = size
 
     def startElement(self, name, attrs, connection):
         pass


### PR DESCRIPTION
So that block devices type can be specified more concisely,
while maintaining the same defaults that were previously set
in the init.

e.g., this patch allows:

``` python
block_device_map = {
  '/dev/sdb': BlockDeviceType(ephemeral_name='ephemeral0'),
  '/dev/sdc': BlockDeviceType(ephemeral_name='ephemeral1')
}
```

instead of:

``` python
sdb = BlockDeviceType()
sdb.ephemeral_name = 'ephemeral0'
sdc = BlockDeviceType()
sdc.ephemeral_name = 'ephemeral1'
block_device_map = {
  '/dev/sdb': sdb
  '/dev/sdc': sdc
}
```
