### PR TITLE
Avoid a badly-timed SIGINT from calling sys.exit

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -726,8 +726,6 @@ class AWSAuthConnection(object):
                     boto.log.debug('Redirecting: %s' % scheme + '://' + request.host + request.path)
                     connection = self.get_http_connection(request.host, scheme == 'https')
                     continue
-            except KeyboardInterrupt:
-                sys.exit('Keyboard Interrupt')
             except self.http_exceptions, e:
                 for unretryable in self.http_unretryable_exceptions:
                     if isinstance(e, unretryable):


### PR DESCRIPTION
Inclusion of that code was probably unintentional to begin with.

Would manifest as (without overridden signal handlers): SIGINT causing
sudden termination of a Python process when unlucky.

Signed-off-by: Daniel Farina drfarina@acm.org
