### PR TITLE
Never reuse HTTPConnections on Google App Engine

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -167,8 +167,15 @@ class HostConnectionPool(object):
         This is ugly, reading a private instance variable, but the
         state we care about isn't available in any public methods.
         """
-        response = conn._HTTPConnection__response
-        return (response is None) or response.isclosed()
+        if ON_APP_ENGINE:
+            # Google App Engine implementation of HTTPConnection doesn't contain
+            # _HTTPConnection__response attribute. Moreover, it's not possible
+            # to determine if given connection is ready. Reusing connections
+            # simply doesn't make sense with App Engine urlfetch service.
+            return False
+        else:
+            response = conn._HTTPConnection__response
+            return (response is None) or response.isclosed()
 
     def clean(self):
         """


### PR DESCRIPTION
Hi guys,

I was getting an `AttributeError` exception in `HostConnectionPool._conn_ready()`. Google App Engine reimplementation of `HTTPConnection` doesn't contain `_HTTPConnection__response` attribute. I now simply return `False` in this method, because `HTTPConnection` reuse doesn't bring any benefit on App Engine anyway.

I have also slightly improved `ON_APP_ENGINE` detection - it didn't properly detect running on Google App Engine development server.

Let me know if this patch meets your criteria, thanks!

Best regards,
Kamil Klimkiewicz
