### PR TITLE
Added 'delete_attributes' to Model

### DIFF
--- a/boto/sdb/db/model.py
+++ b/boto/sdb/db/model.py
@@ -219,6 +219,19 @@ class Model(object):
         self.reload()
         return self
 
+    def delete_attributes(self, attrs):
+        """Delete just these attributes,
+        not the whole object.
+        :param attrs: Attributes to save, as a list of string names
+        :type attrs: list
+        :return: self
+        :rtype: :class:boto.sdb.db.model.Model
+        """
+        assert(isinstance(attrs, list)), "Argument must be a list of names of keys to delete."
+        self._manager.domain.delete_attributes(self.id, attrs)
+        self.reload()
+        return self
+
     save_attributes = put_attributes
         
     def delete(self):


### PR DESCRIPTION
I found that I needed to be able to set a property on a model to an empty list or dict without saving the entire model, but that put_attributes wouldn't let me do that directly.  As such, I added 'delete_attributes', which takes a list of key names, to let me do that easily.
