### PR TITLE
format the item_list, deleted the character u before item. Like as input:

### DIFF
--- a/boto/mashups/iobject.py
+++ b/boto/mashups/iobject.py
@@ -39,6 +39,7 @@ class IObject(object):
         while not choice:
             n = 1
             choices = []
+            item_list =[ str(x) for x in item_list ] 
             for item in item_list:
                 if isinstance(item, str):
                     print '[%d] %s' % (n, item)


### PR DESCRIPTION
format the item_list, deleted the character u before item. Like as input:  [u'i-526ee232', u'i-546ee234', u'i-2c6ee24c'], will output ['i-526ee232', 'i-546ee234', 'i-2c6ee24c'], otherwise will exception: "ValueError: too many values to unpack"
