### PR TITLE
When sending raw emails source is not required

### DIFF
--- a/boto/ses/connection.py
+++ b/boto/ses/connection.py
@@ -228,9 +228,11 @@ class SESConnection(AWSAuthConnection):
 
         """
         params = {
-            'Source': source,
             'RawMessage.Data': base64.b64encode(raw_message),
         }
+        
+        if source:
+            params['Source'] = source
 
         if destinations:
             self._build_list_params(params, destinations,


### PR DESCRIPTION
With the current code if you send without the source parameter you get this:

Error Response: <ErrorResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/"> <Error> <Type>Sender</Type> <Code>InvalidParameterValue</Code> <Message>Missing final '@domain'</Message> </Error> <RequestId>5f17f6cb-e55d-11e0-8eb3-05ee8efc71a8</RequestId> </ErrorResponse>
