### PR TITLE
SES UTF-8 encoding error

### DIFF
--- a/boto/ses/connection.py
+++ b/boto/ses/connection.py
@@ -79,7 +79,7 @@ class SESConnection(AWSAuthConnection):
         params['Action'] = action
 
         for k, v in params.items():
-            if isinstance(v, basestring):
+            if isinstance(v, unicode):  # UTF-8 encode only if it's Unicode
                 params[k] = v.encode('utf-8')
 
         response = super(SESConnection, self).make_request(


### PR DESCRIPTION
UTF-8 encode strings only if they are Python Unicode type. Otherwise, UTF-8 encoded `str` type will raise UnicodeDecodeError. 
