### PR TITLE
Sphinx doc fixes

### DIFF
--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -110,12 +110,21 @@ class AutoScaleConnection(AWSQueryConnection):
         return ['ec2']
 
     def build_list_params(self, params, items, label):
-        """ items is a list of dictionaries or strings:
-                [{'Protocol' : 'HTTP',
-                 'LoadBalancerPort' : '80',
-                 'InstancePort' : '80'},..] etc.
-             or
-                ['us-east-1b',...]
+        """
+        Items is a list of dictionaries or strings::
+
+            [
+                {
+                    'Protocol' : 'HTTP',
+                    'LoadBalancerPort' : '80',
+                    'InstancePort' : '80'
+                },
+                ..
+            ] etc.
+
+        or::
+
+            ['us-east-1b',...]
         """
         # different from EC2 list params
         for i in xrange(1, len(items)+1):
@@ -328,12 +337,9 @@ class AutoScaleConnection(AWSQueryConnection):
         """
         Deletes a previously scheduled action.
 
-        type scheduled_action_name: str
-        param scheduled_action_name: The name of the action you want
-                                     to delete.
-
-        type autoscale_group: str
-        param autoscale_group: The name of the autoscale group.
+        :param str scheduled_action_name: The name of the action you want
+            to delete.
+        :param str autoscale_group: The name of the autoscale group.
         """
         params = {'ScheduledActionName' : scheduled_action_name}
         if autoscale_group:
@@ -345,12 +351,9 @@ class AutoScaleConnection(AWSQueryConnection):
         Terminates the specified instance. The desired group size can
         also be adjusted, if desired.
 
-        :type instance_id: str
-        :param instance_id: The ID of the instance to be terminated.
-
-        :type decrement_capacity: bool
-        :param decrement_capacity: Whether to decrement the size of the
-                                  autoscaling group or not.
+        :param str instance_id: The ID of the instance to be terminated.
+        :param bool decrement_capacity: Whether to decrement the size of the
+            autoscaling group or not.
         """
         params = {'InstanceId' : instance_id}
         if decrement_capacity:

--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -390,10 +390,10 @@ class CloudWatchConnection(AWSQueryConnection):
         is specified for some, but not all, of the arguments, the remaining 
         arguments are repeated a corresponding number of times.
 
-        :type namespace: string
+        :type namespace: str
         :param namespace: The namespace of the metric.
 
-        :type name: string or list
+        :type name: str or list
         :param name: The name of the metric.
 
         :type value: float or list
@@ -401,28 +401,27 @@ class CloudWatchConnection(AWSQueryConnection):
 
         :type timestamp: datetime or list
         :param timestamp: The time stamp used for the metric. If not specified, 
-                          the default value is set to the time the metric data 
-                          was received.
+            the default value is set to the time the metric data was received.
         
         :type unit: string or list
         :param unit: The unit of the metric.  Valid Values: Seconds | 
-                     Microseconds | Milliseconds | Bytes | Kilobytes | 
-                     Megabytes | Gigabytes | Terabytes | Bits | Kilobits | 
-                     Megabits | Gigabits | Terabits | Percent | Count | 
-                     Bytes/Second | Kilobytes/Second | Megabytes/Second | 
-                     Gigabytes/Second | Terabytes/Second | Bits/Second | 
-                     Kilobits/Second | Megabits/Second | Gigabits/Second | 
-                     Terabits/Second | Count/Second | None
+            Microseconds | Milliseconds | Bytes | Kilobytes |
+            Megabytes | Gigabytes | Terabytes | Bits | Kilobits |
+            Megabits | Gigabits | Terabits | Percent | Count |
+            Bytes/Second | Kilobytes/Second | Megabytes/Second |
+            Gigabytes/Second | Terabytes/Second | Bits/Second |
+            Kilobits/Second | Megabits/Second | Gigabits/Second |
+            Terabits/Second | Count/Second | None
         
         :type dimensions: dict
         :param dimensions: Add extra name value pairs to associate 
-                           with the metric, i.e.:
-                           {'name1': value1, 'name2': (value2, value3)}
+            with the metric, i.e.:
+            {'name1': value1, 'name2': (value2, value3)}
         
         :type statistics: dict or list
-        :param statistics: Use a statistic set instead of a value, for example
-                           {'maximum': 30, 'minimum': 1,
-                            'samplecount': 100, 'sum': 10000}
+        :param statistics: Use a statistic set instead of a value, for example::
+
+            {'maximum': 30, 'minimum': 1, 'samplecount': 100, 'sum': 10000}
         """
         params = {'Namespace': namespace}
         self.build_put_params(params, name, value=value, timestamp=timestamp,

--- a/boto/route53/connection.py
+++ b/boto/route53/connection.py
@@ -45,10 +45,14 @@ HZXML = """<?xml version="1.0" encoding="UTF-8"?>
 #boto.set_stream_logger('dns')
 
 class Route53Connection(AWSAuthConnection):
-
     DefaultHost = 'route53.amazonaws.com'
+    """The default Route53 API endpoint to connect to."""
+
     Version = '2011-05-05'
+    """Route53 API version."""
+
     XMLNameSpace = 'https://route53.amazonaws.com/doc/2011-05-05/'
+    """XML schema for this Route53 API version."""
 
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  port=None, proxy=None, proxy_port=None,
@@ -76,12 +80,9 @@ class Route53Connection(AWSAuthConnection):
         Returns a Python data structure with information about all
         Hosted Zones defined for the AWS account.
 
-        :type start_marker: int
-        :param start_marker: start marker to pass when fetching additional
-        results after a truncated list
-
-        :type zone_list: list
-        :param zone_list: a HostedZones list to prepend to results
+        :param int start_marker: start marker to pass when fetching additional
+                                 results after a truncated list
+        :param list zone_list: a HostedZones list to prepend to results
         """
         params = {}
         if start_marker:
@@ -209,30 +210,30 @@ class Route53Connection(AWSAuthConnection):
 
         :type type: str
         :param type: The type of resource record set to begin the record
-                     listing from.  Valid choices are:
+            listing from.  Valid choices are:
 
-                     * A
-                     * AAAA
-                     * CNAME
-                     * MX
-                     * NS
-                     * PTR
-                     * SOA
-                     * SPF
-                     * SRV
-                     * TXT
+                * A
+                * AAAA
+                * CNAME
+                * MX
+                * NS
+                * PTR
+                * SOA
+                * SPF
+                * SRV
+                * TXT
 
-                     Valid values for weighted resource record sets:
+            Valid values for weighted resource record sets:
 
-                     * A
-                     * AAAA
-                     * CNAME
-                     * TXT
+                * A
+                * AAAA
+                * CNAME
+                * TXT
 
-                     Valid values for Zone Apex Aliases:
+            Valid values for Zone Apex Aliases:
 
-                     * A
-                     * AAAA
+                * A
+                * AAAA
 
         :type name: str
         :param name: The first name in the lexicographic ordering of domain

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -941,14 +941,14 @@ class Bucket(object):
 
         :rtype: dict
         :returns: A dictionary containing a Python representation
-                  of the XML response from S3. The overall structure is:
+            of the XML response from S3. The overall structure is:
 
             * WebsiteConfiguration
     
               * IndexDocument
     
                 * Suffix : suffix that is appended to request that
-                is for a "directory" on the website endpoint
+                  is for a "directory" on the website endpoint
                 * ErrorDocument
     
                   * Key : name of object to serve when an error occurs

--- a/boto/sdb/connection.py
+++ b/boto/sdb/connection.py
@@ -33,12 +33,10 @@ class ItemThread(threading.Thread):
     """
     A threaded :class:`Item <boto.sdb.item.Item>` retriever utility class. 
     Retrieved :class:`Item <boto.sdb.item.Item>` objects are stored in the
-    ``items`` instance variable after 
-    :py:meth:`run() <run>` is called. 
+    ``items`` instance variable after :py:meth:`run() <run>` is called.
     
-    .. tip:: 
-        The item retrieval will not start until the 
-        :func:`run() <boto.sdb.connection.ItemThread.run>` method is called.
+    .. tip:: The item retrieval will not start until
+        the :func:`run() <boto.sdb.connection.ItemThread.run>` method is called.
     """
     def __init__(self, name, domain_name, item_names):
         """

--- a/boto/sdb/db/model.py
+++ b/boto/sdb/db/model.py
@@ -188,14 +188,16 @@ class Model(object):
             self._manager.load_object(self)
 
     def put(self, expected_value=None):
-        """Save this object as it is, with an optional expected value
+        """
+        Save this object as it is, with an optional expected value
+
         :param expected_value: Optional tuple of Attribute, and Value that 
             must be the same in order to save this object. If this 
             condition is not met, an SDBResponseError will be raised with a
             Confict status code.
         :type expected_value: tuple or list
         :return: This object
-        :rtype: :class:boto.sdb.db.model.Model
+        :rtype: :class:`boto.sdb.db.model.Model`
         """
         self._manager.save_object(self, expected_value)
         return self
@@ -203,12 +205,13 @@ class Model(object):
     save = put
 
     def put_attributes(self, attrs):
-        """Save just these few attributes, not the
-        whole object
+        """
+        Save just these few attributes, not the whole object
+
         :param attrs: Attributes to save, key->value dict
         :type attrs: dict
         :return: self
-        :rtype: :class:boto.sdb.db.model.Model
+        :rtype: :class:`boto.sdb.db.model.Model`
         """
         assert(isinstance(attrs, dict)), "Argument must be a dict of key->values to save"
         for prop_name in attrs:
@@ -220,12 +223,13 @@ class Model(object):
         return self
 
     def delete_attributes(self, attrs):
-        """Delete just these attributes,
-        not the whole object.
+        """
+        Delete just these attributes, not the whole object.
+
         :param attrs: Attributes to save, as a list of string names
         :type attrs: list
         :return: self
-        :rtype: :class:boto.sdb.db.model.Model
+        :rtype: :class:`boto.sdb.db.model.Model`
         """
         assert(isinstance(attrs, list)), "Argument must be a list of names of keys to delete."
         self._manager.domain.delete_attributes(self.id, attrs)

--- a/boto/sdb/item.py
+++ b/boto/sdb/item.py
@@ -31,11 +31,9 @@ class Item(dict):
     The keys on instances of this object correspond to attributes that are
     stored on the SDB item. 
     
-    .. tip::
-        While it is possible to instantiate this class directly, you may want
-        to use the convenience methods on :py:class:`boto.sdb.domain.Domain`
-        for that purpose. For example, 
-        :py:meth:`boto.sdb.domain.Domain.get_item`.
+    .. tip:: While it is possible to instantiate this class directly, you may
+        want to use the convenience methods on :py:class:`boto.sdb.domain.Domain`
+        for that purpose. For example, :py:meth:`boto.sdb.domain.Domain.get_item`.
     """
     def __init__(self, domain, name='', active=False):
         """

--- a/boto/sts/credentials.py
+++ b/boto/sts/credentials.py
@@ -22,11 +22,11 @@
 
 class Credentials(object):
     """
-    ivar access_key: The AccessKeyID.
-    ivar secret_key: The SecretAccessKey.
-    ivar session_token: The session token that must be passed with
-                        requests to use the temporary credentials
-    ivar expiration: The timestamp for when the credentials will expire
+    :ivar access_key: The AccessKeyID.
+    :ivar secret_key: The SecretAccessKey.
+    :ivar session_token: The session token that must be passed with
+                         requests to use the temporary credentials
+    :ivar expiration: The timestamp for when the credentials will expire
     """
 
     def __init__(self, parent=None):
@@ -55,10 +55,10 @@ class Credentials(object):
     
 class FederationToken(object):
     """
-    ivar credentials: A Credentials object containing the credentials.
-    ivar federated_user_arn: ARN specifying federated user using credentials.
-    ivar federated_user_id: The ID of the federated user using credentials.
-    ivar packed_policy_size: A percentage value indicating the size of
+    :ivar credentials: A Credentials object containing the credentials.
+    :ivar federated_user_arn: ARN specifying federated user using credentials.
+    :ivar federated_user_id: The ID of the federated user using credentials.
+    :ivar packed_policy_size: A percentage value indicating the size of
                              the policy in packed form
     """
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,35 +9,56 @@ offered by Amazon Web Services.
 
 Currently, this includes:
 
-- Compute
- - Elastic Compute Cloud (EC2)
- - Elastic MapReduce (EMR)
- - Auto Scaling
-- Content Delivery
- - CloudFront
-- Database
- - SimpleDB
- - Relational Data Services (RDS)
-- Deployment and Management
- - CloudFormation
-- Identity & Access
- - Identity and Access Management (IAM)
-- Messaging
- - Simple Queue Service (SQS)
- - Simple Notificaiton Service (SNS)
- - Simple Email Service (SES)
-- Monitoring
- - CloudWatch
-- Networking
- - Route 53
- - Virtual Private Cloud (VPC)
- - Elastic Load Balancing (ELB)
-- Payments & Billing
- - Flexible Payments Service (FPS)
-- Storage
- - Simple Storage Service (S3)
-- Workforce
- - Mechanical Turk
+* Compute
+
+  * Elastic Compute Cloud (EC2)
+  * Elastic MapReduce (EMR)
+  * Auto Scaling
+
+* Content Delivery
+
+  * CloudFront
+
+* Database
+
+  * SimpleDB
+  * Relational Data Services (RDS)
+
+* Deployment and Management
+
+  * CloudFormation
+
+* Identity & Access
+
+  * Identity and Access Management (IAM)
+
+* Messaging
+
+  * Simple Queue Service (SQS)
+  * Simple Notificaiton Service (SNS)
+  * Simple Email Service (SES)
+
+* Monitoring
+
+  * CloudWatch
+
+* Networking
+
+  * Route 53
+  * Virtual Private Cloud (VPC)
+  * Elastic Load Balancing (ELB)
+
+* Payments & Billing
+
+  * Flexible Payments Service (FPS)
+
+* Storage
+
+  * Simple Storage Service (S3)
+
+* Workforce
+
+  * Mechanical Turk
 
 The boto source repository is at http://github.com/boto
 

--- a/docs/source/ref/ecs.rst
+++ b/docs/source/ref/ecs.rst
@@ -11,13 +11,6 @@ boto.ecs
    :members:   
    :undoc-members:
 
-boto.iam.response
------------------
-
-.. automodule:: boto.iam.response
-   :members:   
-   :undoc-members:
-
 boto.ecs.item
 ----------------------------
 

--- a/docs/source/ref/route53.rst
+++ b/docs/source/ref/route53.rst
@@ -5,29 +5,22 @@ route53
 =======
 
 
-boto.route53
-------------
-
-.. automodule:: boto.route53
-   :members:   
-   :undoc-members:
-
 boto.route53.connection
--------------------
+-----------------------
 
 .. automodule:: boto.route53.connection
    :members:   
    :undoc-members:
 
- boto.route53.hostedzone
-----------------------------
+boto.route53.hostedzone
+------------------------
 
 .. automodule:: boto.route53.hostedzone
    :members:   
    :undoc-members:
 
 boto.route53.exception
--------------------------
+----------------------
 
 .. automodule:: boto.route53.exception
    :members:   

--- a/docs/source/ref/sts.rst
+++ b/docs/source/ref/sts.rst
@@ -11,12 +11,12 @@ boto.sts
    :members:   
    :undoc-members:
 
-.. autoclass:: boto.sts.SNSConnection
+.. autoclass:: boto.sts.STSConnection
    :members:
    :undoc-members:
 
 boto.sts.credentials
-----------------
+--------------------
 
 .. automodule:: boto.sts.credentials
    :members:   


### PR DESCRIPTION
Docstring and RST fixes to get us back to Sphinx builds without warnings or errors. Fixes handful of formattin issues, and restores route53 and some other things that weren't rendering.
