### PR TITLE
Error in lss3 when it tried to print last_modified time of a Prefix

### DIFF
--- a/bin/lss3
+++ b/bin/lss3
@@ -12,6 +12,7 @@ def sizeof_fmt(num):
 def list_bucket(b, prefix=None):
     """List everything in a bucket"""
     from boto.s3.prefix import Prefix
+    from boto.s3.key import Key
     total = 0
     query = b
     if prefix:
@@ -34,7 +35,14 @@ def list_bucket(b, prefix=None):
                         mode = "-rwxr--"
                     elif g.permission == "FULL_CONTROL":
                         mode = "-rwxrwx"
-        print "%s\t%s\t%010s\t%s" % (mode, k.last_modified, sizeof_fmt(size), k.name)
+        if isinstance(k, Key):
+           print "%s\t%s\t%010s\t%s" % (mode, k.last_modified,
+                 sizeof_fmt(size), k.name)
+        else:
+           #If it's not a Key object, it doesn't have a last_modified time, so
+           #print nothing instead
+           print "%s\t%s\t%010s\t%s" % (mode, ' '*24,
+              sizeof_fmt(size), k.name)
         total += size
     print "="*80
     print "\t\tTOTAL:  \t%010s \t%i Files" % (sizeof_fmt(total), num)
@@ -56,7 +64,7 @@ if __name__ == "__main__":
                 pairs.append([name, None])
             if pairs[-1][0].lower() != pairs[-1][0]:
                 mixedCase = True
-    
+
     if mixedCase:
         s3 = boto.connect_s3(calling_format=OrdinaryCallingFormat())
     else:


### PR DESCRIPTION
Fixed an error in lss3 where printing Prefixes tried to print their last_modified time, which does not exist
