### PR TITLE
Please pull this one-line change so that RDS will provide MultiAZ in the DescribeDBInstancesResult.

### DIFF
--- a/boto/rds/__init__.py
+++ b/boto/rds/__init__.py
@@ -74,7 +74,7 @@ class RDSConnection(AWSQueryConnection):
 
     DefaultRegionName = 'us-east-1'
     DefaultRegionEndpoint = 'rds.amazonaws.com'
-    APIVersion = '2009-10-16'
+    APIVersion = '2010-04-01'
 
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,


### PR DESCRIPTION
use newer api version so that aws will tell us whether our db uses multiaz
