### PR TITLE
Fix indentation - convert tabs to spaces in updated file from yesterday

### DIFF
--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -175,10 +175,10 @@ class AutoScaleConnection(AWSQueryConnection):
         Deletes the specified auto scaling group if the group has no instances
         and no scaling activities in progress.
         """
-	if(force_delete):
-		params = {'AutoScalingGroupName' : name, 'ForceDelete' : 'true'}
-	else:
-		params = {'AutoScalingGroupName' : name}
+        if(force_delete):
+            params = {'AutoScalingGroupName' : name, 'ForceDelete' : 'true'}
+        else:
+            params = {'AutoScalingGroupName' : name}
         return self.get_object('DeleteAutoScalingGroup', params, Request)
 
     def create_launch_configuration(self, launch_config):


### PR DESCRIPTION
Noticed after I switched vim instances that I had pushed this with tabs not spaces for indentation.
