### PR TITLE
In provider.py, STORAGE_CLASS_HEADER_KEY gets set to None, which is

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -559,7 +559,9 @@ class Bucket(object):
         if src_version_id:
             src += '?version_id=%s' % src_version_id
         headers = {provider.copy_source_header : str(src)}
-        headers[provider.storage_class_header] = storage_class
+        # make sure storage_class_header key exists before accessing it
+        if provider.storage_class_header:
+            headers[provider.storage_class_header] = storage_class
         if metadata:
             headers[provider.metadata_directive_header] = 'REPLACE'
             headers = boto.utils.merge_meta(headers, metadata, provider)

--- a/tests/s3/test_gsconnection.py
+++ b/tests/s3/test_gsconnection.py
@@ -176,4 +176,39 @@ class GSConnectionTest (unittest.TestCase):
         # now delete bucket
         time.sleep(5)
         c.delete_bucket(bucket)
+        # test copying a key from one bucket to another
+        # create two new, empty buckets
+        bucket_name_1 = 'test1-%d' % int(time.time())
+        bucket_name_2 = 'test2-%d' % int(time.time())
+        bucket1 = c.create_bucket(bucket_name_1)
+        bucket2 = c.create_bucket(bucket_name_2)
+        # verify buckets got created 
+        bucket1 = c.get_bucket(bucket_name_1)
+        bucket2 = c.get_bucket(bucket_name_2)
+        # create a key in bucket1 and give it some content
+        k1 = bucket1.new_key()
+        assert isinstance(k1, bucket1.key_class)
+        key_name = 'foobar'
+        k1.name = key_name
+        s = 'This is a test.'
+        k1.set_contents_from_string(s)
+        # copy the new key from bucket1 to bucket2
+        k1.copy(bucket_name_2, key_name) 
+        # now copy the contents from bucket2 to a local file
+        k2 = bucket2.lookup(key_name)
+        assert isinstance(k2, bucket2.key_class)
+        fp = open('foobar', 'wb')
+        k2.get_contents_to_file(fp)
+        fp.close()
+        fp = open('foobar')
+        # check to make sure content read is identical to original
+        assert s == fp.read(), 'move test failed!'
+        fp.close()
+        # delete keys
+        bucket1.delete_key(k1)
+        bucket2.delete_key(k2)
+        # delete test buckets
+        c.delete_bucket(bucket1)
+        c.delete_bucket(bucket2)
+        
         print '--- tests completed ---'


### PR DESCRIPTION
propagated to self.storage_class_header. In s3/bucket.py, the copy_key()
method uses that attribute without making sure it's not None, which leads
to downstream problems when the request is sent to httplib. The simple fix
is to check for non-null value before using provider.storage_class_header
as a dictionary key. It might be worthwhile, at some point in the future,
to store the headers in a dictionary instead of a discrete set of named
class attributes, because the former would lend itself to programmatically
avoiding null values, instead of having to add a bunch of if statements
throughout the code.
