### PR TITLE
only warn about group-id filters when value != sg-*

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -455,10 +455,13 @@ class EC2Connection(AWSQueryConnection):
             self.build_list_params(params, instance_ids, 'InstanceId')
         if filters:
             if 'group-id' in filters:
-                warnings.warn("The group-id filter now requires a security "
-                              "group identifier (sg-*) instead of a group "
-                              "name. To filter by group name use the "
-                              "'group-name' filter instead.", UserWarning)
+                gid = filters.get('group-id')
+                if not gid.startswith('sg-') or len(gid) != 11:
+                    warnings.warn(
+                        "The group-id filter now requires a security group "
+                        "identifier (sg-*) instead of a group name. To filter "
+                        "by group name use the 'group-name' filter instead.",
+                        UserWarning)
             self.build_filter_params(params, filters)
         return self.get_list('DescribeInstances', params,
                              [('item', Reservation)], verb='POST')
@@ -824,10 +827,13 @@ class EC2Connection(AWSQueryConnection):
             self.build_list_params(params, request_ids, 'SpotInstanceRequestId')
         if filters:
             if 'launch.group-id' in filters:
-                warnings.warn("The 'launch.group-id' filter now requires a "
-                              "security group id (sg-*) and no longer supports "
-                              "filtering by group name. Please update your "
-                              "filters accordingly.", UserWarning)
+                lgid = filters.get('launch.group-id')
+                if not lgid.startswith('sg-') or len(lgid) != 11:
+                    warnings.warn(
+                        "The 'launch.group-id' filter now requires a security "
+                        "group id (sg-*) and no longer supports filtering by "
+                        "group name. Please update your filters accordingly.",
+                        UserWarning)
             self.build_filter_params(params, filters)
         return self.get_list('DescribeSpotInstanceRequests', params,
                              [('item', SpotInstanceRequest)], verb='POST')


### PR DESCRIPTION
only show group-id filter warnings if the group-id passed by the user
doesn't appear to match the security group id pattern (e.g. starts with
'sg-' and contains 11 chars)
