### PR TITLE
Fixed delete_listener on a load balancer object

### DIFF
--- a/boto/ec2/elb/loadbalancer.py
+++ b/boto/ec2/elb/loadbalancer.py
@@ -167,10 +167,8 @@ class LoadBalancer(object):
     def delete_listeners(self, listeners):
         return self.connection.delete_load_balancer_listeners(self.name, listeners)
 
-    def delete_listener(self, inPort, outPort=None, proto="tcp"):
-        if outPort == None:
-            outPort = inPort
-        return self.delete_listeners([(inPort, outPort, proto)])
+    def delete_listener(self, inPort):
+        return self.delete_listeners([inPort])
 
     def delete_policy(self, policy_name):
         """


### PR DESCRIPTION
On a load balancer object delete_listener calls through to delete_listeners and ultimately connection.delete_load_balancer_listeners which expects a list of source ports only. The delete_listener function was passing a tuple of source port, dest port and protocol and thus would never work.
This change makes it pass only the source port. I've also removed the additional parameters since they're no longer used and this makes it a breaking api change. Since the function could never have worked I'm assuming no one else has ever been using it.
The change could be altered to not break api by leaving the parameters in the call but not using them.
