### PR TITLE
Adding more granular error handling to boto.ses.

### DIFF
--- a/boto/ses/exceptions.py
+++ b/boto/ses/exceptions.py
@@ -1,0 +1,35 @@
+"""
+Various exceptions that are specific to the SES module.
+"""
+from boto.exception import BotoServerError
+
+class SESAddressNotVerifiedError(BotoServerError):
+    """
+    Raised when a "Reply-To" address has not been validated in SES yet.
+    """
+    pass
+
+
+class SESAddressBlacklistedError(BotoServerError):
+    """
+    After you attempt to send mail to an address, and delivery repeatedly
+    fails, said address is blacklisted for at least 24 hours. The blacklisting
+    eventually expires, and you are able to attempt delivery again. If you
+    attempt to send mail to a blacklisted email, this is raised.
+    """
+    pass
+
+
+class SESDailyQuotaExceededError(BotoServerError):
+    """
+    Your account's daily (rolling 24 hour total) allotment of outbound emails
+    has been exceeded.
+    """
+    pass
+
+
+class SESMaxSendingRateExceededError(BotoServerError):
+    """
+    Your account's requests/second limit has been exceeded.
+    """
+    pass


### PR DESCRIPTION
Raises more specific exceptions for the various SES errors. Since almost every error in SES shares HTTP error code 400, we have to get yucky and search for the common error messages in the XML response. We could probably parse the XML and check the <Message> tag, but I'm not really sure that'd get us much, other than slightly more complicated code.

Documentation for these new exceptions will be following in the future. Feel free to merge now or after. I'll write it either way.
