### PR TITLE
Fix describe_alarms XML parsing.

### DIFF
--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -143,7 +143,7 @@ except ImportError:
 
 from boto.connection import AWSQueryConnection
 from boto.ec2.cloudwatch.metric import Metric
-from boto.ec2.cloudwatch.alarm import MetricAlarm, AlarmHistoryItem
+from boto.ec2.cloudwatch.alarm import MetricAlarm, MetricAlarms, AlarmHistoryItem
 from boto.ec2.cloudwatch.datapoint import Datapoint
 from boto.regioninfo import RegionInfo
 import boto
@@ -477,7 +477,7 @@ class CloudWatchConnection(AWSQueryConnection):
         if state_value:
             params['StateValue'] = state_value
         return self.get_list('DescribeAlarms', params,
-                             [('member', MetricAlarm)])
+                             [('MetricAlarms', MetricAlarms)])[0]
 
     def describe_alarm_history(self, alarm_name=None,
                                start_date=None, end_date=None,

--- a/boto/ec2/cloudwatch/alarm.py
+++ b/boto/ec2/cloudwatch/alarm.py
@@ -23,10 +23,30 @@
 from datetime import datetime
 from boto.resultset import ResultSet
 from boto.ec2.cloudwatch.listelement import ListElement
+
 try:
     import simplejson as json
 except ImportError:
     import json
+
+
+class MetricAlarms(list):
+    def __init__(self, connection=None):
+        """
+        Parses a list of MetricAlarms.
+        """
+        list.__init__(self)
+        self.connection = connection
+
+    def startElement(self, name, attrs, connection):
+        if name == 'member':
+            metric_alarm = MetricAlarm(connection)
+            self.append(metric_alarm)
+            return metric_alarm
+
+    def endElement(self, name, value, connection):
+        pass
+
 
 class MetricAlarm(object):
 
@@ -156,6 +176,11 @@ class MetricAlarm(object):
         elif name == 'OKActions':
             self.ok_actions = ListElement()
             return self.ok_actions
+        elif name == 'Dimensions':
+            # Do the import here to avoid circular imports
+            from boto.ec2.cloudwatch.metric import Dimension
+            self.dimensions = Dimension()
+            return self.dimensions
         else:
             pass
 


### PR DESCRIPTION
- The MetricAlarm elements are in a list of member
  elements and additionally contain other member elements.
- Thus we cannot use member elements by themselves to separate
  the returned MetricAlarms, we need to parse the entire MetricAlarm.
- With unit test against mock result.
- Fixes http://code.google.com/p/boto/issues/detail?id=544
