### PR TITLE
Added load_credential_tuple to boto.pyami.config.Config

### DIFF
--- a/boto/pyami/config.py
+++ b/boto/pyami/config.py
@@ -74,6 +74,21 @@ class Config(ConfigParser.SafeConfigParser):
                 except IOError:
                     warnings.warn('Unable to load AWS_CREDENTIAL_FILE (%s)' % full_path)
 
+    def load_credential_tuple(self, params):
+        """Load a credential tuple as is setup like the Java utilities"""
+        c_data = StringIO.StringIO()
+        cursor = iter(params)
+        c_data.write("[Credentials]\n")
+        for param in cursor:
+            if param == "AWSAccessKeyId":
+                c_data.write("aws_access_key_id = " + cursor.next() + "\n")
+            elif param == "AWSSecretKey":
+                c_data.write("aws_secret_access_key = " + cursor.next() + "\n")
+            else:
+                c_data.write(param + " = " + cursor.next() + "\n")
+        c_data.seek(0)
+        self.readfp(c_data)
+
     def load_credential_file(self, path):
         """Load a credential file as is setup like the Java utilities"""
         c_data = StringIO.StringIO()


### PR DESCRIPTION
I had a need to set different access/secrets per application, and not stored on the file system. Instead stored in the configuration for my applications. load_credential_tuple allowed me to do that.

I could have initialized a new Config() to replace boto.config where Config(fp=myStringIOObject). That may still be the more appropriate way, It just seemed like the Config object should be responsible for building the StringIO object.

Anyway, 

usage:

import boto
boto.config.load_credential_tuple(("aws_access_key_id", "my_key", "aws_secret_access_key", "my_secret"))
ses = boto.connect_ses()
ses.send_email("email1@example.com", "Credential Tuple Test", "lorem ipsum dolor sit amet", "email2@example.com")
