### PR TITLE
Helper For Multipart Uploads From A Single File

### DIFF
--- a/boto/s3/multipart.py
+++ b/boto/s3/multipart.py
@@ -330,7 +330,7 @@ class MultiPartUpload(object):
             # Make a 'fake file' that only reads a portion of the whole
             # file, from start to end.
             ff = FakeFile(fp, start, end)
-            self.upload_part_from_file(ff, count, headers, replace, None, 10, policy)
+            self.upload_part_from_file(ff, count, headers, replace, cb, num_cb, policy)
             # Now, get where we are in the original file, and see how
             # much is apparently left
             if fp.tell() < end:


### PR DESCRIPTION
I ended up implementing this for an in-house solution more or less in response to an article I saw suggesting that one shell out to the Unix 'split' command.

And while I've read that larger file uploads are /supposed/ to be supported, I've never gotten an upload more than 100MB or so to work, and this approach has been able to handle the ~GB keys we've needed to store here.

At any rate, I'm not sure if you'll find it helpful/useful, but I figured someone else might be able to use it.

Cheers!
