### PR TITLE
add ec2_connect_endpoint convenience method

### DIFF
--- a/boto/__init__.py
+++ b/boto/__init__.py
@@ -28,6 +28,7 @@ import boto.plugin
 import os, re, sys
 import logging
 import logging.config
+import urlparse
 from boto.exception import InvalidUriError
 
 __version__ = '2.1.1'
@@ -354,6 +355,40 @@ def connect_euca(host=None, aws_access_key_id=None, aws_secret_access_key=None,
     return EC2Connection(aws_access_key_id, aws_secret_access_key,
                          region=reg, port=port, path=path,
                          is_secure=is_secure, **kwargs)
+
+def connect_ec2_endpoint(url, aws_access_key_id=None, aws_secret_access_key=None, 
+                         **kwargs):
+    """
+    Connect to an EC2 Api endpoint.  Additional arguments are passed
+    through to connect_ec2.
+
+    :type url: string
+    :param url: A url for the ec2 api endpoint to connect to
+
+    :type aws_access_key_id: string
+    :param aws_access_key_id: Your AWS Access Key ID
+
+    :type aws_secret_access_key: string
+    :param aws_secret_access_key: Your AWS Secret Access Key
+
+    :rtype: :class:`boto.ec2.connection.EC2Connection`
+    :return: A connection to Eucalyptus server
+    """
+    from boto.ec2.regioninfo import RegionInfo
+
+    purl = urlparse.urlparse(url)
+    kwargs['port'] = purl.port
+    kwargs['host'] = purl.hostname
+    kwargs['path'] = purl.path
+    if not 'is_secure' in kwargs:
+        kwargs['is_secure'] = (purl.scheme == "https")
+
+    kwargs['region'] = RegionInfo(name = purl.hostname,
+        endpoint = purl.hostname)
+    kwargs['aws_access_key_id']=aws_access_key_id
+    kwargs['aws_secret_access_key']=aws_secret_access_key
+
+    return(connect_ec2(**kwargs))
 
 def connect_walrus(host=None, aws_access_key_id=None, aws_secret_access_key=None,
                    port=8773, path='/services/Walrus', is_secure=False,


### PR DESCRIPTION
ec2_connect_endpoint just wraps ec2_connect, but takes a url for the end
point, and generates values for port, host, path, is_secure, and region
from that url.

Example:
 conn = boto.ec2_connect_endpoint("https://ec2.us-west-1.amazonaws.com")
 conn.describe_images()
