### PR TITLE
mturk.connection.create_qualification_type() had an incorrect assert.

### DIFF
--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -909,6 +909,4 @@ class QuestionFormAnswer(BaseAutoResultElement):
         if name == 'QuestionIdentifier':
             self.qid = value
         elif name in ['FreeText', 'SelectionIdentifier', 'OtherSelectionText'] and self.qid:
-            self.fields.append((self.qid,value))
-        elif name == 'Answer':
-            self.qid = None
+            self.fields.append( value )


### PR DESCRIPTION
mturk.connection.create_qualification_type() had the line:
    assert(test is False)
but the variable 'test' defaults to None, not False, so the assert failed.  This is now fixed.
