### PR TITLE
Make SSLError retryable

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -428,7 +428,6 @@ class AWSAuthConnection(object):
         # define subclasses of the above that are not retryable.
         self.http_unretryable_exceptions = []
         if HAVE_HTTPS_CONNECTION:
-            self.http_unretryable_exceptions.append(ssl.SSLError)
             self.http_unretryable_exceptions.append(
                     https_connection.InvalidCertificateException)
 


### PR DESCRIPTION
Make SSLError retryable.

It seems to be a transient error and I get it a lot even when accessing S3 from EC2 with what one would expect to be close to optimal network access conditions.
