### PR TITLE
Fix for issue #537. 

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -26,6 +26,7 @@ import re
 import rfc822
 import StringIO
 import base64
+import urllib
 import boto.utils
 from boto.exception import BotoClientError
 from boto.provider import Provider
@@ -988,7 +989,7 @@ class Key(object):
             query_args.append('versionId=%s' % version_id)
         if response_headers:
             for key in response_headers:
-                query_args.append('%s=%s' % (key, response_headers[key]))
+                query_args.append('%s=%s' % (key, urllib.quote(response_headers[key])))
         query_args = '&'.join(query_args)
         self.open('r', headers, query_args=query_args,
                   override_num_retries=override_num_retries)

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -78,6 +78,12 @@ qsa_of_interest = ['acl', 'defaultObjectAcl', 'location', 'logging',
                    'response-cache-control', 'response-content-disposition',
                    'response-content-encoding']
 
+def unquote_v(nv):
+    if len(nv) == 1:
+        return nv
+    else:
+        return (nv[0], urllib.unquote(nv[1]))
+
 # generates the aws canonical string for the given parameters
 def canonical_string(method, path, headers, expires=None,
                      provider=None):
@@ -124,7 +130,7 @@ def canonical_string(method, path, headers, expires=None,
     if len(t) > 1:
         qsa = t[1].split('&')
         qsa = [ a.split('=') for a in qsa]
-        qsa = [ a for a in qsa if a[0] in qsa_of_interest ]
+        qsa = [ unquote_v(a) for a in qsa if a[0] in qsa_of_interest ]
         if len(qsa) > 0:
             qsa.sort(cmp=lambda x,y:cmp(x[0], y[0]))
             qsa = [ '='.join(a) for a in qsa ]


### PR DESCRIPTION
Hi Mitch,

This is my first ever pull request. Took a while to figure it out. Hope it works.

Tom.
1. query string parameter values must be urlencoded as they can
   contain spaces or other characters such as ? or = etc that
   would effect decoding on the server.
2. when creating the signature, the query string parameter values
   should be decoded.

Fixes requests such as:
  GET /key?response-content-language=en%2C%20jp
