### PR TITLE
Long form options in s3put script didn't work

### DIFF
--- a/bin/cq
+++ b/bin/cq
@@ -31,8 +31,8 @@ def usage():
 def main():
     try:
         opts, args = getopt.getopt(sys.argv[1:], 'hcq:o:t:r:',
-                                   ['help', 'clear', 'queue',
-                                    'output', 'timeout', 'region'])
+                                   ['help', 'clear', 'queue=',
+                                    'output=', 'timeout=', 'region='])
     except:
         usage()
         sys.exit(2)

--- a/bin/s3multiput
+++ b/bin/s3multiput
@@ -195,8 +195,8 @@ def main():
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], 'a:b:c::d:g:hi:np:qs:wr',
-                                   ['access_key', 'bucket', 'callback', 'debug', 'help', 'grant',
-                                    'ignore', 'no_op', 'prefix', 'quiet', 'secret_key', 'no_overwrite',
+                                   ['access_key=', 'bucket=', 'callback=', 'debug=', 'help', 'grant=',
+                                    'ignore=', 'no_op', 'prefix=', 'quiet', 'secret_key=', 'no_overwrite',
                                     'reduced'])
     except:
         usage()

--- a/bin/s3put
+++ b/bin/s3put
@@ -96,9 +96,9 @@ def main():
     try:
         opts, args = getopt.getopt(
                 sys.argv[1:], 'a:b:c::d:g:hi:np:qs:vwr',
-                ['access_key', 'bucket', 'callback', 'debug', 'help', 'grant',
-                 'ignore', 'no_op', 'prefix', 'quiet', 'secret_key',
-                 'no_overwrite', 'reduced']
+                ['access_key=', 'bucket=', 'callback=', 'debug=', 'help',
+                 'grant=', 'ignore=', 'no_op', 'prefix=', 'quiet',
+                 'secret_key=', 'no_overwrite', 'reduced']
                 )
     except:
         usage()


### PR DESCRIPTION
According to the getopt docs, long form options must have a "=" after the name in the options list in order for it to expect arguments.
