### PR TITLE
Adding SESDomainEndsWithDotError

### DIFF
--- a/boto/ses/connection.py
+++ b/boto/ses/connection.py
@@ -139,6 +139,10 @@ class SESConnection(AWSAuthConnection):
             # Your account has sent above its allowed requests a second rate.
             ExceptionToRaise = ses_exceptions.SESMaxSendingRateExceededError
             exc_reason = "Maximum sending rate exceeded."
+        elif "Domain ends with dot." in body:
+            # Recipient address ends with a dot/period. This is invalid.
+            ExceptionToRaise = ses_exceptions.SESDomainEndsWithDotError
+            exc_reason = "Domain ends with dot."
         else:
             # This is either a common AWS error, or one that we don't devote
             # its own exception to.

--- a/boto/ses/exceptions.py
+++ b/boto/ses/exceptions.py
@@ -33,3 +33,10 @@ class SESMaxSendingRateExceededError(BotoServerError):
     Your account's requests/second limit has been exceeded.
     """
     pass
+
+
+class SESDomainEndsWithDotError(BotoServerError):
+    """
+    Recipient's email address' domain ends with a period/dot.
+    """
+    pass


### PR DESCRIPTION
Ran into this once or twice in production, also want to be able to handle this instead of the generic BotoServerError. This will let people avoid re-trying a failed email send.
