### PR TITLE
Implement new Amazon Delete Multiple Object API

### DIFF
--- a/boto/utils.py
+++ b/boto/utils.py
@@ -70,7 +70,7 @@ except ImportError:
     _hashfn = md5.md5
 
 # List of Query String Arguments of Interest
-qsa_of_interest = ['acl', 'defaultObjectAcl', 'location', 'logging', 
+qsa_of_interest = ['acl', 'defaultObjectAcl', 'delete', 'location', 'logging',
                    'partNumber', 'policy', 'requestPayment', 'torrent', 
                    'versioning', 'versionId', 'versions', 'website', 
                    'uploads', 'uploadId', 'response-content-type', 


### PR DESCRIPTION
Hi all,

I had a little bit of free time today so I decided to implement the new Amazon API for deleting multiple objects in one request. I have tested it and it seems to work well. Should not have broken anything as it's quite isolated.

Example usage:

```
rs = bucket.list_versions()
probs = bucket.delete_multiple(rs)
for key in probs:
    try:
        print key.Code, "deleting", "%s:%s" % (key.name, key.version_id)
    except:
        print "Error deleting", key
```

Or a mixed list of strings and tuples...

```
keys = ["a", "b", ("c", "versionidhere"), ("c", "versionidhere"), "d"]
bucket.delete_multiple(keys)
```

Have fun!
