### PR TITLE
sqs get_queue called with an empty string returns a random queue

### DIFF
--- a/boto/sqs/connection.py
+++ b/boto/sqs/connection.py
@@ -277,7 +277,7 @@ class SQSConnection(AWSQueryConnection):
     def get_queue(self, queue_name):
         rs = self.get_all_queues(queue_name)
         for q in rs:
-            if q.url.endswith(queue_name):
+            if q.name == queue_name:
                 return q
         return None
 


### PR DESCRIPTION
If get_queue was called with an empty string it returned the first
queue. Also for queue names like 'bob' where get_queue was called with
'b' it returned 'bob'.
