### PR TITLE
Various fixes for delete_keys() as follows:

### DIFF
--- a/boto/s3/multidelete.py
+++ b/boto/s3/multidelete.py
@@ -114,12 +114,16 @@ class MultiDeleteResult(object):
         the quiet flag was specified in the request, this list will
         be empty because only error responses would be returned.
 
+    :ivar skipped: A list of keys that could not be deleted due
+                   to the 1000 limit.
+
     :ivar errors: A list of unsuccessfully deleted objects.
     """
 
     def __init__(self, bucket=None):
         self.bucket = None
         self.deleted = []
+        self.skipped = []
         self.errors = []
 
     def startElement(self, name, attrs, connection):
@@ -128,13 +132,11 @@ class MultiDeleteResult(object):
             self.deleted.append(d)
             return d
         elif name == 'Error':
-            d = Error()
-            self.deleted.append(d)
-            return d
+            e = Error()
+            self.errors.append(e)
+            return e
         return None
 
     def endElement(self, name, value, connection):
         setattr(self, name, value)
-        
-
-
+ 


### PR DESCRIPTION
Mitch,

Happy New Year. First day back in the office. I had some time to test the implementation today and found fixed some bugs. Top 4 are bugs. Final 2 make things more usable in my opinion. Tested using a mix of Japanese and ascii names on versioned buckets.
- missing version_id so it was always passing %s.
- unicode issue with Japanese from a resultset.
- must be at least one object to delete to run Amazon delete multiple object api.
- Error results were mistakenly added as Deleted objects in result.
- Added Prefixes and unknown objects as errors (instead of silently dropping)
  Check the code/message and change as you would like.
- Length check was breaking for resultsets so added a new
  instance variable called skipped to the Result for
  each key over 1000. Caller can then optionally just
  recall using skipped keys using something like.
  
    rs = bucket.list_versions()
    while rs:
        res = bucket.delete_keys(rs, quiet=True)
        rs = res.skipped
