### PR TITLE
Add support to set capabilities during the creation of a CloudFormation stack

### DIFF
--- a/boto/cloudformation/connection.py
+++ b/boto/cloudformation/connection.py
@@ -65,7 +65,7 @@ class CloudFormationConnection(AWSQueryConnection):
 
     def create_stack(self, stack_name, template_body=None, template_url=None,
             parameters=[], notification_arns=[], disable_rollback=False,
-            timeout_in_minutes=None):
+            timeout_in_minutes=None, capabilities=[]):
         """
         Creates a CloudFormation Stack as specified by the template.
 
@@ -98,6 +98,10 @@ class CloudFormationConnection(AWSQueryConnection):
                             spend creating itself. If this timeout is exceeded,
                             the Stack will enter the CREATE_FAILED state
 
+        :type capabilities: list
+        :param capabilities: The list of capabilities you want to allow in
+                            the stack
+
         :rtype: string
         :return: The unique Stack ID
         """
@@ -114,6 +118,9 @@ class CloudFormationConnection(AWSQueryConnection):
             for i, (key, value) in enumerate(parameters):
                 params['Parameters.member.%d.ParameterKey' % (i+1)] = key
                 params['Parameters.member.%d.ParameterValue' % (i+1)] = value
+        if len(capabilities) > 0:
+            for i, value in enumerate(capabilities):
+                params['Capabilities.member.%d' % (i+1)] = value
         if len(notification_arns) > 0:
             self.build_list_params(params, notification_arns, "NotificationARNs.member")
         if timeout_in_minutes:


### PR DESCRIPTION
This patch exposes a new parameter called "capabilities" in boto.cloudformation.connection.CloudFormationConnection.create_stack(...), for details of the parameters see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html
