### PR TITLE
Added option `expires_in_absolute` to S3's `generate_url` method.

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -452,11 +452,13 @@ class Bucket(object):
         return self.key_class(self, key_name)
 
     def generate_url(self, expires_in, method='GET', headers=None,
-                     force_http=False, response_headers=None):
+                     force_http=False, response_headers=None,
+                     expires_in_absolute=False):
         return self.connection.generate_url(expires_in, method, self.name,
                                             headers=headers,
                                             force_http=force_http,
-                                            response_headers=response_headers)
+                                            response_headers=response_headers,
+                                            expires_in_absolute=expires_in_absolute)
 
     def delete_keys(self, keys, quiet=False, mfa_token=None, headers=None):
         """

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -279,10 +279,14 @@ class S3Connection(AWSAuthConnection):
 
 
     def generate_url(self, expires_in, method, bucket='', key='', headers=None,
-                     query_auth=True, force_http=False, response_headers=None):
+                     query_auth=True, force_http=False, response_headers=None,
+                     expires_in_absolute=False):
         if not headers:
             headers = {}
-        expires = int(time.time() + expires_in)
+        if expires_in_absolute:
+            expires = int(expires_in)
+        else:
+            expires = int(time.time() + expires_in)
         auth_path = self.calling_format.build_auth_path(bucket, key)
         auth_path = self.get_path(auth_path)
         # Arguments to override response headers become part of the canonical

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -419,7 +419,8 @@ class Key(object):
         return self.bucket.set_canned_acl('public-read', self.name, headers)
 
     def generate_url(self, expires_in, method='GET', headers=None,
-                     query_auth=True, force_http=False, response_headers=None):
+                     query_auth=True, force_http=False, response_headers=None,
+                     expires_in_absolute=False):
         """
         Generate a URL to access this key.
 
@@ -443,7 +444,8 @@ class Key(object):
                                                    self.bucket.name, self.name,
                                                    headers, query_auth,
                                                    force_http,
-                                                   response_headers)
+                                                   response_headers,
+                                                   expires_in_absolute)
 
     def send_file(self, fp, headers=None, cb=None, num_cb=10,
                   query_args=None, chunked_transfer=False):


### PR DESCRIPTION
When that option is setted True, `expires` treat as absolute time.
Default value is False for compatibility.

I want to use absolute time on `generate_url`.

Relative `expires` will change url every generation.
Browsers does not use cache if url was changed,
because there are anothrer resouces.

Fixed url make browser caching more effective.
You can use fixed url on using `expires_in_absolute` with True.
