### PR TITLE
Fix bucket.list() which can repeat the same keys when delimiter is used.

### DIFF
--- a/boto/resultset.py
+++ b/boto/resultset.py
@@ -48,6 +48,7 @@ class ResultSet(list):
             self.markers = []
         self.marker = None
         self.key_marker = None
+        self.next_marker = None  # avail when delimiter used
         self.next_key_marker = None
         self.next_version_id_marker = None
         self.version_id_marker = None
@@ -76,6 +77,8 @@ class ResultSet(list):
             self.marker = value
         elif name == 'KeyMarker':
             self.key_marker = value
+        elif name == 'NextMarker':
+            self.next_marker = value
         elif name == 'NextKeyMarker':
             self.next_key_marker = value
         elif name == 'VersionIdMarker':

--- a/boto/s3/bucketlistresultset.py
+++ b/boto/s3/bucketlistresultset.py
@@ -31,7 +31,7 @@ def bucket_lister(bucket, prefix='', delimiter='', marker='', headers=None):
         for k in rs:
             yield k
         if k:
-            marker = k.name
+            marker = rs.next_marker or k.name
         more_results= rs.is_truncated
         
 class BucketListResultSet:

--- a/tests/s3/test_bucket.py
+++ b/tests/s3/test_bucket.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2011 Mitch Garnaat http://garnaat.org/
+# All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+"""
+Some unit tests for the S3 Bucket
+"""
+
+import unittest
+import time
+from boto.s3.connection import S3Connection
+
+class S3BucketTest (unittest.TestCase):
+
+    def setUp(self):
+        self.conn = S3Connection()
+        self.bucket_name = 'bucket-%d' % int(time.time())
+        self.bucket = self.conn.create_bucket(self.bucket_name)
+
+    def tearDown(self):
+        for key in self.bucket:
+            key.delete()
+        self.bucket.delete()
+
+    def test_next_marker(self):
+        expected = ["a/", "b", "c"]
+        for key_name in expected:
+            key = self.bucket.new_key(key_name)
+            key.set_contents_from_string(key_name)
+
+        # Normal list of first 2 keys will have
+        # no NextMarker set, so we use last key to iterate
+        # last element will be "b" so no issue.
+        rs = self.bucket.get_all_keys(max_keys=2)
+        for element in rs:
+            pass
+        self.assertEqual(element.name, "b")
+        self.assertEqual(rs.next_marker, None)
+
+        # list using delimiter of first 2 keys will have
+        # a NextMarker set (when truncated). As prefixes
+        # are grouped together at the end, we get "a/" as
+        # last element, but luckily we have next_marker.
+        rs = self.bucket.get_all_keys(max_keys=2, delimiter="/")
+        for element in rs:
+            pass
+        self.assertEqual(element.name, "a/")
+        self.assertEqual(rs.next_marker, "b")
+
+        # ensure bucket.list() still works by just
+        # popping elements off the front of expected.
+        rs = self.bucket.list()
+        for element in rs:
+            self.assertEqual(element.name, expected.pop(0))
+        self.assertEqual(expected, [])

--- a/tests/test.py
+++ b/tests/test.py
@@ -33,6 +33,7 @@ from sqs.test_connection import SQSConnectionTest
 from s3.test_connection import S3ConnectionTest
 from s3.test_versioning import S3VersionTest
 from s3.test_encryption import S3EncryptionTest
+from s3.test_bucket import S3BucketTest
 from s3.test_multidelete import S3MultiDeleteTest
 from s3.test_multipart import S3MultiPartUploadTest
 from s3.test_gsconnection import GSConnectionTest
@@ -91,6 +92,7 @@ def suite(testsuite="all"):
         tests.addTest(unittest.makeSuite(S3EncryptionTest))
         tests.addTest(unittest.makeSuite(S3MultiDeleteTest))
         tests.addTest(unittest.makeSuite(S3MultiPartUploadTest))
+        tests.addTest(unittest.makeSuite(S3BucketTest))
     elif testsuite == "ssl":
         tests.addTest(unittest.makeSuite(CertValidationTest))
     elif testsuite == "s3ver":
@@ -100,6 +102,7 @@ def suite(testsuite="all"):
         tests.addTest(unittest.makeSuite(S3EncryptionTest))
         tests.addTest(unittest.makeSuite(S3MultiDeleteTest))
         tests.addTest(unittest.makeSuite(S3MultiPartUploadTest))
+        tests.addTest(unittest.makeSuite(S3BucketTest))
     elif testsuite == "gs":
         tests.addTest(unittest.makeSuite(GSConnectionTest))
     elif testsuite == "sqs":


### PR DESCRIPTION
bucket.list will repeat the same keys multiple times when the following is true:
- delimiter is set.
- returned set is truncated.
- returned set contains common prefixes.

A typical example is:
  "a/", "c0000", "c0001", ..., "c1000"

As common prefixes are listed last by AWS, prefix "a/"
will be listed last. The first loop will return 1000 keys
of which the last is "a/". Therefore the next loop will
start listing keys "c0000" onwards thus repeating those
set of keys twice. Amazon returns the NextMarker to help
avoid this but its only available when the set is
truncated and a delimiter was used.
