### PR TITLE
to_xml() always gets the first 1000 parts twice. Remove extra call.

### DIFF
--- a/boto/s3/multipart.py
+++ b/boto/s3/multipart.py
@@ -142,7 +142,6 @@ class MultiPartUpload(object):
         return part_lister(self)
 
     def to_xml(self):
-        self.get_all_parts()
         s = '<CompleteMultipartUpload>\n'
         for part in self:
             s += '  <Part>\n'


### PR DESCRIPTION
Save some bandwidth on multipartupload complete.
