### PR TITLE
XmlHandler's list/item markers should propagate to all child elements

### DIFF
--- a/boto/jsonresponse.py
+++ b/boto/jsonresponse.py
@@ -134,12 +134,14 @@ class ListElement(list):
     def startElement(self, name, attrs, connection):
         for lm in self.list_marker:
             if name.endswith(lm):
-                l = ListElement(self.connection, name, self.item_marker,
+                l = ListElement(self.connection, name, self.list_marker,
+                                self.item_marker,
                                 pythonize_name=self.pythonize_name)
                 setattr(self, self.get_name(name), l)
                 return l
         if name in self.item_marker:
             e = Element(self.connection, name, parent=self,
+                        self.list_marker, self.item_marker,
                         pythonize_name=self.pythonize_name)
             self.append(e)
             return e


### PR DESCRIPTION
XmlHandlers are currently incapable of parsing structures that contain nested lists correctly because elements don't always pass their list_marker and item_marker lists to their children, causing those lists to revert to their default values when the parser is already building a ListElement.

For example, try parsing this response with list_markers = ['euca:registered', 'euca:instances'] and list_items = ['euca:item']:

``` xml
<?xml version="1.0"?>
<euca:DescribeNodesResponseType xmlns:euca="http://msgs.eucalyptus.com">
  <euca:ConfigurationMessage>
    <euca:_return>true</euca:_return>
    <euca:_services/>
    <euca:_disabledServices/>
    <euca:_notreadyServices/>
  </euca:ConfigurationMessage>
  <euca:registered>
    <euca:item>
      <euca:name>192.168.37.9</euca:name>
      <euca:clusterName>zone01cc01</euca:clusterName>
      <euca:instances>
        <euca:item>
          <euca:entry>i-E3BC3F7E</euca:entry>
        </euca:item>
        <euca:item>
          <euca:entry>i-C294423D</euca:entry>
        </euca:item>
      </euca:instances>
    </euca:item>
  </euca:registered>
</euca:DescribeNodesResponseType>
```

Parsing that XML without this patch yields this dict, which fails to convert 'euca:instances' to a list:

``` python
{u'euca:DescribeNodesResponseType': {u'euca:ConfigurationMessage': {u'euca:_disabledServices': {},
                                                                    u'euca:_notreadyServices': {},
                                                                    u'euca:_return': u'true',
                                                                    u'euca:_services': {}},
                                     u'euca:registered': [{u'euca:clusterName': u'zone01cc01',
                                                           u'euca:instances': {u'euca:item': {u'euca:entry': u'i-C294423D'}},
                                                           u'euca:name': u'192.168.37.9'}]}}
```

With the patch, 'euca:instances' points to a list as one would expect:

``` python
{u'euca:DescribeNodesResponseType': {u'euca:ConfigurationMessage': {u'euca:_disabledServices': {},
                                                                    u'euca:_notreadyServices': {},
                                                                    u'euca:_return': u'true',
                                                                    u'euca:_services': {}},
                                     u'euca:registered': [{u'euca:clusterName': u'zone01cc01',
                                                           u'euca:instances': [{u'euca:entry': u'i-E3BC3F7E'},
                                                                               {u'euca:entry': u'i-C294423D'}],
                                                           u'euca:name': u'192.168.37.9'}]}}
```
