### PR TITLE
slick53 methods grafted onto to boto route53 connection

### DIFF
--- a/boto/route53/connection.py
+++ b/boto/route53/connection.py
@@ -15,23 +15,21 @@
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
 # ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
 
 import xml.sax
-import time
 import uuid
 import urllib
 import boto
 from boto.connection import AWSAuthConnection
 from boto import handler
-from boto.resultset import ResultSet
+from boto.route53.record import ResourceRecordSets
 import boto.jsonresponse
 import exception
-import hostedzone
 
 HZXML = """<?xml version="1.0" encoding="UTF-8"?>
 <CreateHostedZoneRequest xmlns="%(xmlns)s">
@@ -41,7 +39,7 @@ HZXML = """<?xml version="1.0" encoding="UTF-8"?>
     <Comment>%(comment)s</Comment>
   </HostedZoneConfig>
 </CreateHostedZoneRequest>"""
-        
+
 #boto.set_stream_logger('dns')
 
 class Route53Connection(AWSAuthConnection):
@@ -110,7 +108,7 @@ class Route53Connection(AWSAuthConnection):
     def get_hosted_zone(self, hosted_zone_id):
         """
         Get detailed information about a particular Hosted Zone.
-        
+
         :type hosted_zone_id: str
         :param hosted_zone_id: The unique identifier for the Hosted Zone
 
@@ -133,7 +131,7 @@ class Route53Connection(AWSAuthConnection):
         """
         Create a new Hosted Zone.  Returns a Python data structure with
         information about the newly created Hosted Zone.
-        
+
         :type domain_name: str
         :param domain_name: The name of the domain. This should be a
             fully-specified domain, and should end with a final period
@@ -153,7 +151,7 @@ class Route53Connection(AWSAuthConnection):
             use that.
 
         :type comment: str
-        :param comment: Any comments you want to include about the hosted      
+        :param comment: Any comments you want to include about the hosted
             zone.
 
         """
@@ -179,7 +177,7 @@ class Route53Connection(AWSAuthConnection):
             raise exception.DNSServerError(response.status,
                                            response.reason,
                                            body)
-        
+
     def delete_hosted_zone(self, hosted_zone_id):
         uri = '/%s/hostedzone/%s' % (self.Version, hosted_zone_id)
         response = self.make_request('DELETE', uri)
@@ -201,7 +199,7 @@ class Route53Connection(AWSAuthConnection):
         """
         Retrieve the Resource Record Sets defined for this Hosted Zone.
         Returns the raw XML data returned by the Route53 call.
-        
+
         :type hosted_zone_id: str
         :param hosted_zone_id: The unique identifier for the Hosted Zone
 
@@ -318,3 +316,245 @@ class Route53Connection(AWSAuthConnection):
         h = boto.jsonresponse.XmlHandler(e, None)
         h.parse(body)
         return e
+
+    ######################### Slick53 Code Below #########################
+
+    def create_zone(self, name):
+        """ Create new hosted zone."""
+        zone = self.create_hosted_zone(name)
+        return Zone(self, zone['CreateHostedZoneResponse']['HostedZone'])
+
+    def get_zone(self, name):
+        """ Retrieve the hosted zone supplied by name."""
+        for zone in self.get_zones():
+            if name == zone.name[:-1]:
+                return zone
+
+    def get_zones(self):
+        """ Retrieve a list of all hosted zones."""
+        zones = self.get_all_hosted_zones()
+        return [Zone(self, zone) for zone in zones['ListHostedZonesResponse']['HostedZones']]
+
+    def _make_qualified(self, value):
+        """ Turn unqualified domain names into qualified ones."""
+        if type(value) in [list, tuple, set]:
+            new_list = []
+            for record in value:
+                if record and not record[-1] == '.':
+                    new_list.append("%s." % record)
+                else:
+                    new_list.append(record)
+            return new_list
+        else:
+            value = value.strip()
+            if value and not value[-1] == '.':
+                value = "%s." % value
+            return value
+
+default_ttl = 60
+
+def repr_record_set(self):
+    record_list = ','.join([record.__repr__() for record in self])
+    return '[%s]' % record_list
+
+ResourceRecordSets.__repr__ = repr_record_set
+
+class Zone(object):
+    def __init__(self, route53connection, zone_dict):
+        self.route53connection = route53connection
+        for key in zone_dict:
+            if key == 'Id':
+                self.id = zone_dict['Id'].replace('/hostedzone/','')
+            else:
+                self.__setattr__(key.lower(), zone_dict[key])
+
+    def __repr__(self):
+        return '<Zone:%s>' % self.name
+
+    def add_record(self, resource_type, name, value, ttl=60, comment=""):
+        """Add a new record to a zone"""
+        changes = ResourceRecordSets(self.route53connection, self.id, comment)
+        change = changes.add_change("CREATE", name, resource_type, ttl)
+        if type(value) in [list, tuple, set]:
+            for record in value:
+                change.add_value(record)
+        else:
+            change.add_value(value)
+        Status(self.route53connection,
+               changes.commit()['ChangeResourceRecordSetsResponse']['ChangeInfo'])
+
+    def update_record(self, resource_type, name, old_value, new_value, old_ttl, new_ttl=None, comment=""):
+        new_ttl = new_ttl or default_ttl
+        changes = ResourceRecordSets(self.route53connection, self.id, comment)
+        change = changes.add_change("DELETE", name, resource_type, old_ttl)
+        if type(old_value) in [list, tuple, set]:
+            for record in old_value:
+                change.add_value(record)
+        else:
+            change.add_value(old_value)
+        change = changes.add_change('CREATE', name, resource_type, new_ttl)
+        if type(new_value) in [list, tuple, set]:
+            for record in new_value:
+                change.add_value(record)
+        else:
+            change.add_value(new_value)
+        Status(self.route53connection,
+               changes.commit()['ChangeResourceRecordSetsResponse']['ChangeInfo'])
+
+    def delete_record(self, resource_type, name, value, ttl=None, comment=""):
+        """Delete a record from a zone"""
+        ttl = ttl or default_ttl
+        changes = ResourceRecordSets(self.route53connection, self.id, comment)
+        change = changes.add_change("DELETE", name, resource_type, ttl)
+        if type(value) in [list, tuple, set]:
+            for record in value:
+                change.add_value(record)
+        else:
+            change.add_value(value)
+        Status(self.route53connection,
+               changes.commit()['ChangeResourceRecordSetsResponse']['ChangeInfo'])
+
+    def add_cname(self, name, value, ttl=None, comment=""):
+        ttl = ttl or default_ttl
+        name = self.route53connection._make_qualified(name)
+        value = self.route53connection._make_qualified(value)
+        return self.add_record(resource_type='CNAME',
+                               name=name,
+                               value=value,
+                               ttl=ttl,
+                               comment=comment)
+
+    def add_a(self, name, value, ttl=None, comment=""):
+        """Add an A record to the zone."""
+        ttl = ttl or default_ttl
+        name = self.route53connection._make_qualified(name)
+        return self.add_record(resource_type='A',
+                               name=name,
+                               value=value,
+                               ttl=ttl,
+                               comment=comment)
+
+    def add_mx(self, records, ttl=None, comment=""):
+        """Add an MX record to the zone."""
+        ttl = ttl or default_ttl
+        records = self.route53connection._make_qualified(records)
+        return self.add_record(resource_type='MX',
+                               name=self.name,
+                               value=records,
+                               ttl=ttl,
+                               comment=comment)
+
+    def get_cname(self, name):
+        """ Get the given CNAME record."""
+        name = self.route53connection._make_qualified(name)
+        for record in self.get_records():
+            if record.name == name and record.type == 'CNAME':
+                return record
+
+    def get_a(self, name):
+        """ Get the given A record."""
+        name = self.route53connection._make_qualified(name)
+        for record in self.get_records():
+            if record.name == name and record.type == 'A':
+                return record
+
+    def get_mx(self):
+        """ Get all MX records."""
+        for record in self.get_records():
+            if record.type == 'MX':
+                return record
+
+    def update_cname(self, name, value, ttl=None, comment=""):
+        """ Update the given CNAME record to a new value and ttl."""
+        name = self.route53connection._make_qualified(name)
+        value = self.route53connection._make_qualified(value)
+        old_record = self.get_cname(name)
+        ttl = ttl or old_record.ttl
+        return self.update_record(resource_type='CNAME',
+                                  name=name,
+                                  old_value=old_record.resource_records,
+                                  new_value=value,
+                                  old_ttl=old_record.ttl,
+                                  new_ttl=ttl,
+                                  comment=comment)
+
+    def update_a(self, name, value, ttl=None, comment=""):
+        """ Update the given A record to a new value and ttl."""
+        name = self.route53connection._make_qualified(name)
+        old_record = self.get_a(name)
+        ttl = ttl or old_record.ttl
+        return self.update_record(resource_type='A',
+                                  name=name,
+                                  old_value=old_record.resource_records,
+                                  new_value=value,
+                                  old_ttl=old_record.ttl,
+                                  new_ttl=ttl,
+                                  comment=comment)
+
+    def update_mx(self, value, ttl=None, comment=""):
+        """ Update the MX records to the new value and ttl."""
+        value = self.route53connection._make_qualified(value)
+        old_record = self.get_mx()
+        ttl = ttl or old_record.ttl
+        return self.update_record(resource_type='MX',
+                                  name=self.name,
+                                  old_value=old_record.resource_records,
+                                  new_value=value,
+                                  old_ttl=old_record.ttl,
+                                  new_ttl=ttl,
+                                  comment=comment)
+
+    def delete_cname(self,name):
+        """ Delete the given CNAME record for this zone."""
+        record = self.get_cname(self.route53connection._make_qualified(name))
+        return self.delete_record(resource_type=record.type,
+                                  name=record.name,
+                                  value=record.resource_records,
+                                  ttl=record.ttl)
+
+    def delete_a(self,name):
+        """ Delete the given A record for this zone."""
+        record = self.get_a(self.route53connection._make_qualified(name))
+        return self.delete_record(resource_type=record.type,
+                                  name=record.name,
+                                  value=record.resource_records,
+                                  ttl=record.ttl)
+
+    def delete_mx(self):
+        """ Delete all MX records for the zone."""
+        record = self.get_mx()
+        return self.delete_record(resource_type=record.type,
+                                  name=record.name,
+                                  value=record.resource_records,
+                                  ttl=record.ttl)
+
+    def get_records(self, type=None):
+        """ Get a list of all records for this zone."""
+        return self.route53connection.get_all_rrsets(self.id, type=type)
+
+    def delete(self):
+        """ Delete this zone."""
+        self.route53connection.delete_hosted_zone(self.id)
+
+    def get_nameservers(self):
+        """ Get the list of nameservers for this zone."""
+        return [record.resource_records for record in self.get_records() if record.type == 'NS']
+
+
+class Status(object):
+    def __init__(self, route53connection, change_dict):
+        self.route53connection = route53connection
+        for key in change_dict:
+            if key == 'Id':
+                self.__setattr__(key.lower(), change_dict[key].replace('/change/',''))
+            else:
+                self.__setattr__(key.lower(), change_dict[key])
+
+    def update(self):
+        """ Update the status of this request."""
+        status = self.route53connection.get_change(self.id)['GetChangeResponse']['ChangeInfo']['Status']
+        self.status = status
+        return status
+
+    def __repr__(self):
+        return '<Status:%s>' % self.status

--- a/boto/route53/test/test_slick53_additions.py
+++ b/boto/route53/test/test_slick53_additions.py
@@ -1,0 +1,67 @@
+import unittest
+from boto.route53.connection import Route53Connection
+
+class TestRoute53(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        route53 = Route53Connection()
+        zone = route53.get_zone('example.com')
+        if zone is not None:
+            zone.delete()
+        self.zone = route53.create_zone('example.com')
+
+    def test_nameservers(self):
+        self.zone.get_nameservers()
+
+    def test_a(self):
+        self.zone.add_a('example.com', '102.11.23.1', 80)
+        record = self.zone.get_a('example.com')
+        self.assertEquals(record.name, u'example.com.')
+        self.assertEquals(record.resource_records, [u'102.11.23.1'])
+        self.assertEquals(record.ttl, u'80')
+        self.zone.update_a('example.com', '186.143.32.2', '800')
+        record = self.zone.get_a('example.com')
+        self.assertEquals(record.name, u'example.com.')
+        self.assertEquals(record.resource_records, [u'186.143.32.2'])
+        self.assertEquals(record.ttl, u'800')
+
+    def test_cname(self):
+        self.zone.add_cname('www.example.com', 'webserver.example.com', 200)
+        record = self.zone.get_cname('www.example.com')
+        self.assertEquals(record.name, u'www.example.com.')
+        self.assertEquals(record.resource_records, [u'webserver.example.com.'])
+        self.assertEquals(record.ttl, u'200')
+        self.zone.update_cname('www.example.com', 'web.example.com', 45)
+        record = self.zone.get_cname('www.example.com')
+        self.assertEquals(record.name, u'www.example.com.')
+        self.assertEquals(record.resource_records, [u'web.example.com.'])
+        self.assertEquals(record.ttl, u'45')
+
+    def test_mx(self):
+        self.zone.add_mx(['10 mx1.example.com', '20 mx2.example.com'], 1000)
+        record = self.zone.get_mx()
+        self.assertEquals(set(record.resource_records),
+                          set([u'10 mx1.example.com.', u'20 mx2.example.com.']))
+        self.assertEquals(record.ttl, u'1000')
+        self.zone.update_mx(['10 mail1.example.com', '20 mail2.example.com'], 50)
+        record = self.zone.get_mx()
+        self.assertEquals(set(record.resource_records),
+                          set([u'10 mail1.example.com.', '20 mail2.example.com.']))
+        self.assertEquals(record.ttl, u'50')
+
+    def test_get_records(self):
+        self.zone.get_records()
+
+    def test_get_zones(self):
+        route53 = Route53Connection()
+        route53.get_zones()
+
+    @classmethod
+    def tearDownClass(self):
+        self.zone.delete_a('example.com')
+        self.zone.delete_cname('www.example.com')
+        self.zone.delete_mx()
+        self.zone.delete()
+
+if __name__ == '__main__':
+    unittest.main(verbosity=3)


### PR DESCRIPTION
As mentioned on the boto email list, I'd like to see slick53's more intuitive methods available in the boto package.  Aside from minor changes to make the code more idiomatic, I've basically left the code alone, though I may revisit it pending review of this request.

There are some basic unit tests.

If accepted, I'll submit some changes to the docs.
