### PR TITLE
Allow S3 anonymous requests per-connection.

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -97,6 +97,19 @@ class HmacKeys(object):
         hmac.update(string_to_sign)
         return base64.encodestring(hmac.digest()).strip()
 
+class AnonAuthHandler(AuthHandler, HmacKeys):
+    """
+    Implements Anonymous requests.
+    """
+    
+    capability = ['anon']
+    
+    def __init__(self, host, config, provider):
+        AuthHandler.__init__(self, host, config, provider)
+        
+    def add_auth(self, http_request, **kwargs):
+        pass
+
 class HmacAuthV1Handler(AuthHandler, HmacKeys):
     """    Implements the HMAC request signing used by S3 and GS."""
     
@@ -126,19 +139,6 @@ class HmacAuthV1Handler(AuthHandler, HmacKeys):
         headers['Authorization'] = ("%s %s:%s" %
                                     (auth_hdr,
                                      self._provider.access_key, b64_hmac))
-
-class AnonAuthV1Handler(AuthHandler, HmacKeys):
-    """    Implements the Anonymous request without signing as used by S3."""
-    
-    capability = ['s3-anon']
-    
-    def __init__(self, host, config, provider):
-        AuthHandler.__init__(self, host, config, provider)
-        
-    def add_auth(self, http_request, **kwargs):
-        headers = http_request.headers
-        if not headers.has_key('Date'):
-            headers['Date'] = formatdate(usegmt=True)
 
 class HmacAuthV2Handler(AuthHandler, HmacKeys):
     """

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -155,7 +155,7 @@ class S3Connection(AWSAuthConnection):
 
     def _required_auth_capability(self):
         if self.anon:
-            return ['s3-anon']
+            return ['anon']
         else:
             return ['s3']
 


### PR DESCRIPTION
- add "anon=False" parameter to S3Connection object.
- using anon=True requests s3-anon auth capability.
- new Anon auth handler implements s3-auth capability.
- anon=True overrides any credentials in the environment,
  config or indeed passed in on the connection.
- normal requests without credentials still fail as
  anon=False is the default behaviour.
