### PR TITLE
DynamoDB exceptions for security token expiration and invalid item keys

### DIFF
--- a/boto/dynamodb/exceptions.py
+++ b/boto/dynamodb/exceptions.py
@@ -1,11 +1,19 @@
 """
 Exceptions that are specific to the dynamodb module.
 """
-from boto.exception import BotoServerError
+from boto.exception import BotoServerError, BotoClientError
 
 class DynamoDBExpiredTokenError(BotoServerError):
     """
     Raised when a DynamoDB security token expires. This is generally boto's
     (or the user's) notice to renew their DynamoDB security tokens.
+    """
+    pass
+
+
+class DynamoDBKeyNotFoundError(BotoClientError):
+    """
+    Raised when attempting to retrieve or interact with an item whose key
+    can't be found.
     """
     pass

--- a/boto/dynamodb/layer1.py
+++ b/boto/dynamodb/layer1.py
@@ -231,8 +231,13 @@ class Layer1(AWSAuthConnection):
         if consistent_read:
             data['ConsistentRead'] = True
         json_input = json.dumps(data)
-        return self.make_request('GetItem', json_input,
-                                 object_hook=object_hook)
+        response = self.make_request('GetItem', json_input,
+                                     object_hook=object_hook)
+        if not response.has_key('Item'):
+            raise dynamodb_exceptions.DynamoDBKeyNotFoundError(
+                "Key does not exist."
+            )
+        return response
         
     def batch_get_item(self, request_items):
         """

--- a/tests/dynamodb/test_layer1.py
+++ b/tests/dynamodb/test_layer1.py
@@ -26,6 +26,7 @@ Tests for Layer1 of DynamoDB
 
 import unittest
 import time
+from boto.dynamodb.exceptions import DynamoDBKeyNotFoundError
 from boto.dynamodb.layer1 import Layer1
 
 class DynamoDBLayer1Test (unittest.TestCase):
@@ -109,6 +110,12 @@ class DynamoDBLayer1Test (unittest.TestCase):
         result = c.get_item(table_name, key=key1, consistent_read=True)
         for name in item1_data:
             assert name in result['Item']
+
+        # Try to get an item that does not exist.
+        invalid_key = {'HashKeyElement': {hash_key_type: 'bogus_key'},
+                       'RangeKeyElement': {range_key_type: item1_range}}
+        self.assertRaises(DynamoDBKeyNotFoundError,
+                          c.get_item, table_name, key=invalid_key)
 
         # Try retrieving only select attributes
         attributes = ['Message', 'Views']

--- a/tests/dynamodb/test_layer2.py
+++ b/tests/dynamodb/test_layer2.py
@@ -26,6 +26,7 @@ Tests for Layer2 of Amazon DynamoDB
 
 import unittest
 import time
+from boto.dynamodb.exceptions import DynamoDBKeyNotFoundError
 from boto.dynamodb.layer2 import Layer2
 from boto.dynamodb.utils import get_dynamodb_type
 
@@ -86,6 +87,10 @@ class DynamoDBLayer2Test (unittest.TestCase):
 
         item1 = table.new_item(item1_key, item1_range, item1_attrs)
         item1.put()
+
+        # Try to get an item that does not exist.
+        self.assertRaises(DynamoDBKeyNotFoundError,
+                          table.get_item, 'bogus_key', item1_range)
 
         # Now do a consistent read and check results
         item1_copy = table.get_item(item1_key, item1_range,


### PR DESCRIPTION
Adds the following two exceptions:
- DynamoDBExpiredTokenError - Raised by Layer1.make_request() when security token expires.
- DynamoDBKeyNotFoundError - Raised by Layer1.get_item() when an invalid key is passed.
