### PR TITLE
Make BotoServerError play nicely with JSON bodies

### DIFF
--- a/boto/exception.py
+++ b/boto/exception.py
@@ -85,7 +85,7 @@ class BotoServerError(StandardError):
             try:
                 h = handler.XmlHandler(self, self)
                 xml.sax.parseString(self.body, h)
-            except xml.sax.SAXParseException, pe:
+            except (TypeError, xml.sax.SAXParseException), pe:
                 # Remove unparsable message body so we don't include garbage
                 # in exception. But first, save self.body in self.error_message
                 # because occasionally we get error messages from Eucalyptus


### PR DESCRIPTION
Adjusting BotoServerError.**init** to play nicely with JSON->dict 'body' values.
