### PR TITLE
Add Table.has_item()

### DIFF
--- a/tests/dynamodb/test_layer2.py
+++ b/tests/dynamodb/test_layer2.py
@@ -109,6 +109,9 @@ class DynamoDBLayer2Test (unittest.TestCase):
         for attr_name in item1_small.attrs:
             assert attr_name in attributes
 
+        self.assertTrue(table.has_item(item1_key, range_key=item1_range,
+                                       consistent_read=True))
+
         # Try to delete the item with the wrong Expected value
         expected = {'Views': 1}
         try:
@@ -175,6 +178,9 @@ class DynamoDBLayer2Test (unittest.TestCase):
 
         # Now delete the items
         item1.delete()
+
+        self.assertFalse(table.has_item(item1_key, range_key=item1_range,
+                                       consistent_read=True))
         item2.delete()
         item3.delete()
 


### PR DESCRIPTION
Adds Table.has_item. May be a small bit faster in the case where you want to check for the existence of a key without touching the results from straight Table.get_item. Also is probably just something we're expected to at least offer, for the sake of being complete.

btw, feel free to change the name of this. I wasn't sure what to call it:
- has_item
- has_item_with_key
- has_key
- item_exists
- item_with_key_exists
