### PR TITLE
Conversion of Python booleans to numbers for DynamoDB

### DIFF
--- a/boto/dynamodb/layer2.py
+++ b/boto/dynamodb/layer2.py
@@ -32,7 +32,7 @@ Python types and vice-versa.
 """
 
 def is_num(n):
-    return (isinstance(n, (int, long, float)))
+    return isinstance(n, (int, long, float, bool))
 
 def is_str(n):
     return isinstance(n, basestring)
@@ -145,9 +145,19 @@ class Layer2(object):
         needs to be sent to Amazon DynamoDB.  If the type of the value
         is not supported, raise a TypeError
         """
+        def _str(val):
+            """
+            DynamoDB stores booleans as numbers. True is 1, False is 0.
+            This function converts Python booleans into DynamoDB friendly
+            representation.
+            """
+            if isinstance(val, bool):
+                return str(int(val))
+            return str(val)
+
         dynamodb_type = self.get_dynamodb_type(val)
         if dynamodb_type == 'N':
-            val = {dynamodb_type : str(val)}
+            val = {dynamodb_type : _str(val)}
         elif dynamodb_type == 'S':
             val = {dynamodb_type : val}
         elif dynamodb_type == 'NS':

--- a/tests/dynamodb/test_layer2.py
+++ b/tests/dynamodb/test_layer2.py
@@ -81,11 +81,16 @@ class DynamoDBLayer2Test (unittest.TestCase):
             'Views': 0,
             'Replies': 0,
             'Answered': 0,
+            'Public': True,
             'Tags': set(['index', 'primarykey', 'table']),
             'LastPostDateTime':  '12/9/2011 11:36:03 PM'}
 
         item1 = table.new_item(item1_key, item1_range, item1_attrs)
-        item1.put()
+        # make sure the put() succeeds
+        try:
+            item1.put()
+        except c.layer1.ResponseError, e:
+            raise Exception("Item put failed: %s" % e)
 
         # Try to get an item that does not exist.
         self.assertRaises(DynamoDBKeyNotFoundError,
@@ -187,6 +192,10 @@ class DynamoDBLayer2Test (unittest.TestCase):
         item3['IntAttr'] = integer_value
         item3['FloatAttr'] = float_value
 
+        # Test booleans
+        item3['TrueBoolean'] = True
+        item3['FalseBoolean'] = False
+
         # Test some set values
         integer_set = set([1,2,3,4,5])
         float_set = set([1.1, 2.2, 3.3, 4.4, 5.5])
@@ -202,6 +211,8 @@ class DynamoDBLayer2Test (unittest.TestCase):
         item4 = table.get_item(item3_key, item3_range, consistent_read=True)
         assert item4['IntAttr'] == integer_value
         assert item4['FloatAttr'] == float_value
+        assert item4['TrueBoolean'] == True
+        assert item4['FalseBoolean'] == False
         # The values will not necessarily be in the same order as when
         # we wrote them to the DB.
         for i in item4['IntSetAttr']:


### PR DESCRIPTION
Necessary to enable this:

`>>> Item(table, attrs={"is_member": True}).put()`

This is an update on pull request #514. I've added some docstrings and updated the layer2 unittest.
