### PR TITLE
Fixing Item in DynamoDB - range key is optional. Tests included.

### DIFF
--- a/boto/dynamodb/item.py
+++ b/boto/dynamodb/item.py
@@ -51,7 +51,7 @@ class Item(dict):
                                              
     @property
     def range_key(self):
-        return self[self._range_key_name]
+        return self.get(self._range_key_name)
                                              
     @property
     def hash_key_name(self):


### PR DESCRIPTION
Range keys are optional in DynamoDB. If an Item's range key is None, accessing it raised a KeyError. Unit tests previously didn't catch it because the table had bot a hash and a range key. I've updated the test to create another table without a range key.
