### PR TITLE
fix TypeError in formatting introduced on 01/26

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -750,9 +750,8 @@ class AWSAuthConnection(object):
                             boto.log.debug(msg)
                         continue
                 if response.status == 500 or response.status == 503:
-                    msg = 'Received %d response.  '
-                    msg += 'Retrying in %3.1f seconds' % (response.status,
-                                                          next_sleep)
+                    msg = 'Received %d response.  ' % response.status
+                    msg += 'Retrying in %3.1f seconds' % next_sleep
                     boto.log.debug(msg)
                     body = response.read()
                 elif response.status < 300 or response.status >= 400 or \


### PR DESCRIPTION
This fixes the following exception when server returns 500.

  File "/home/tpodowd/work/tmp/boto/boto/s3/key.py", line 1108, in get_contents_to_file
    response_headers=response_headers)
  File "/home/tpodowd/work/tmp/boto/boto/s3/key.py", line 1011, in get_file
    override_num_retries=override_num_retries)
  File "/home/tpodowd/work/tmp/boto/boto/s3/key.py", line 214, in open
    override_num_retries=override_num_retries)
  File "/home/tpodowd/work/tmp/boto/boto/s3/key.py", line 164, in open_read
    override_num_retries=override_num_retries)
  File "/home/tpodowd/work/tmp/boto/boto/s3/connection.py", line 440, in make_request
    override_num_retries=override_num_retries)
  File "/home/tpodowd/work/tmp/boto/boto/connection.py", line 829, in make_request
    return self._mexe(http_request, sender, override_num_retries)
  File "/home/tpodowd/work/tmp/boto/boto/connection.py", line 755, in _mexe
    next_sleep)
TypeError: not all arguments converted during string formatting
