### PR TITLE
Much reduced and clarified EC2 tutorial

### DIFF
--- a/docs/source/ec2_tut.rst
+++ b/docs/source/ec2_tut.rst
@@ -48,7 +48,8 @@ you have your security group all setup. In this case we can use the keyword argu
 
 The main caveat with the above call is that it is possible to request an instance type that is not compatible with the 
 provided AMI (for example, the instance was created for a 64-bit instance and you choose a m1.small instance_type).
-For more details on the plethora of possible keyword parameters, be sure to check out boto's EC2 API documentation_
+For more details on the plethora of possible keyword parameters, be sure to check out boto's EC2 API documentation_.
+
 .. _documentation: http://boto.cloudhackers.com/en/latest/ref/ec2.html
 
 Stopping Instances


### PR DESCRIPTION
@gtaylor I pruned a lot of ancillary (even if educational) content as well as providing clarified versions of the "bread and butter" EC2 tasks. The main object was to get a developer new boto up and running fast. Other major EC2 topics can be covered in a separate tutorial.
