### PR TITLE
A slightly better error message in layer2.

### DIFF
--- a/boto/dynamodb/layer2.py
+++ b/boto/dynamodb/layer2.py
@@ -179,7 +179,7 @@ class Layer2(object):
             elif False not in map(is_str, val):
                 dynamodb_type = 'SS'
         else:
-            raise TypeError('Unsupported type "%s"' % val)
+            raise TypeError('Unsupported type "%s" for value "%s"' % (type(val), val))
         return dynamodb_type
 
     def dynamize_value(self, val):


### PR DESCRIPTION
Improved TypeError message to include the type of the object, not just its value. This bit me when I was passing a datetime object to store in DynamoDB. The error message read like:

``` python
'Unsupported type "2012-01-31 17:17:04.163851"'
```

which looks like a legit string.
