### PR TITLE
Consistency update for expected_value

### DIFF
--- a/boto/dynamodb/item.py
+++ b/boto/dynamodb/item.py
@@ -106,12 +106,12 @@ class Item(dict):
         """
         self._updates[attr_name] = ("PUT", attr_value)
 
-    def save(self, expected_values=None, return_values=None):
+    def save(self, expected_value=None, return_values=None):
         """
         Commits pending updates to Amazon DynamoDB.
 
-        :type expected_values: dict
-        :param expected_values: A dictionary of name/value pairs that
+        :type expected_value: dict
+        :param expected_value: A dictionary of name/value pairs that
             you expect.  This dictionary should have name/value pairs
             where the name is the name of the attribute and the value is
             either the value you are expecting or False if you expect
@@ -127,14 +127,14 @@ class Item(dict):
             specified, the new versions of only the updated attributes are
             returned.
         """
-        self.table.layer2.update_item(self, expected_values, return_values)
+        self.table.layer2.update_item(self, expected_value, return_values)
         
     def delete(self, expected_value=None, return_values=None):
         """
         Delete the item from DynamoDB.
 
-        :type expected: dict
-        :param expected: A dictionary of name/value pairs that you expect.
+        :type expected_value: dict
+        :param expected_value: A dictionary of name/value pairs that you expect.
             This dictionary should have name/value pairs where the name
             is the name of the attribute and the value is either the value
             you are expecting or False if you expect the attribute not to
@@ -154,8 +154,8 @@ class Item(dict):
         Store a new item or completely replace an existing item
         in Amazon DynamoDB.
 
-        :type expected: dict
-        :param expected: A dictionary of name/value pairs that you expect.
+        :type expected_value: dict
+        :param expected_value: A dictionary of name/value pairs that you expect.
             This dictionary should have name/value pairs where the name
             is the name of the attribute and the value is either the value
             you are expecting or False if you expect the attribute not to

--- a/boto/dynamodb/layer2.py
+++ b/boto/dynamodb/layer2.py
@@ -450,8 +450,8 @@ class Layer2(object):
         :type item: :class:`boto.dynamodb.item.Item`
         :param item: The Item to write to Amazon DynamoDB.
         
-        :type expected: dict
-        :param expected: A dictionary of name/value pairs that you expect.
+        :type expected_value: dict
+        :param expected_value: A dictionary of name/value pairs that you expect.
             This dictionary should have name/value pairs where the name
             is the name of the attribute and the value is either the value
             you are expecting or False if you expect the attribute not to
@@ -482,8 +482,8 @@ class Layer2(object):
             and/or delete_attribute methods on this Item prior to calling
             this method.  Those queued changes are what will be updated.
 
-        :type expected_values: dict
-        :param expected_values: A dictionary of name/value pairs that you
+        :type expected_value: dict
+        :param expected_value: A dictionary of name/value pairs that you
             expect.  This dictionary should have name/value pairs where the
             name is the name of the attribute and the value is either the
             value you are expecting or False if you expect the attribute
@@ -519,8 +519,8 @@ class Layer2(object):
         :type item: :class:`boto.dynamodb.item.Item`
         :param item: The Item to delete from Amazon DynamoDB.
         
-        :type expected: dict
-        :param expected: A dictionary of name/value pairs that you expect.
+        :type expected_value: dict
+        :param expected_value: A dictionary of name/value pairs that you expect.
             This dictionary should have name/value pairs where the name
             is the name of the attribute and the value is either the value
             you are expecting or False if you expect the attribute not to


### PR DESCRIPTION
The commit 4e460715fafc1654e5915016c850449761098d79 uses expected_values instead of expected_value as a parameter in item.save(). Also docstrings use expected as the argument name.
