### PR TITLE
Modified the listener tuple to accept instance protocol value

### DIFF
--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -141,12 +141,13 @@ class ELBConnection(AWSQueryConnection):
         :param zones: The names of the availability zone(s) to add.
 
         :type listeners: List of tuples
-        :param listeners: Each tuple contains three or four values,
+        :param listeners: Each tuple contains four or five  values,
                           (LoadBalancerPortNumber, InstancePortNumber,
-                          Protocol, [SSLCertificateId])
+                          Protocol, Instance protocol, [SSLCertificateId])
                           where LoadBalancerPortNumber and InstancePortNumber
-                          are integer values between 1 and 65535, Protocol is a
-                          string containing either 'TCP', 'HTTP' or 'HTTPS';
+                          are integer values between 1 and 65535, Protocol and
+                          Instance protocol is a string containing either 'TCP',
+                          'HTTP' or 'HTTPS';
                           SSLCertificateID is the ARN of a AWS AIM certificate,
                           and must be specified when doing HTTPS.
 
@@ -159,8 +160,9 @@ class ELBConnection(AWSQueryConnection):
             params['Listeners.member.%d.LoadBalancerPort' % i] = listener[0]
             params['Listeners.member.%d.InstancePort' % i] = listener[1]
             params['Listeners.member.%d.Protocol' % i] = listener[2]
+            params['Listeners.member.%d.InstanceProtocol' % i] = listener[3]
             if listener[2]=='HTTPS':
-                params['Listeners.member.%d.SSLCertificateId' % i] = listener[3]
+                params['Listeners.member.%d.SSLCertificateId' % i] = listener[4]
         if zones:
             self.build_list_params(params, zones, 'AvailabilityZones.member.%d')
 
@@ -188,12 +190,13 @@ class ELBConnection(AWSQueryConnection):
         :param name: The name of the load balancer to create the listeners for
 
         :type listeners: List of tuples
-        :param listeners: Each tuple contains three values,
-                          (LoadBalancerPortNumber, InstancePortNumber, Protocol,
-                          [SSLCertificateId])
-                          where LoadBalancerPortNumber and InstancePortNumber are
-                          integer values between 1 and 65535, Protocol is a
-                          string containing either 'TCP', 'HTTP' or 'HTTPS';
+        :param listeners: Each tuple contains four or five  values,
+                          (LoadBalancerPortNumber, InstancePortNumber,
+                          Protocol, Instance protocol, [SSLCertificateId])
+                          where LoadBalancerPortNumber and InstancePortNumber
+                          are integer values between 1 and 65535, Protocol and
+                          Instance protocol is a string containing either 'TCP',
+                          'HTTP' or 'HTTPS';
                           SSLCertificateID is the ARN of a AWS AIM certificate,
                           and must be specified when doing HTTPS.
 
@@ -205,8 +208,9 @@ class ELBConnection(AWSQueryConnection):
             params['Listeners.member.%d.LoadBalancerPort' % i] = listener[0]
             params['Listeners.member.%d.InstancePort' % i] = listener[1]
             params['Listeners.member.%d.Protocol' % i] = listener[2]
+            params['Listeners.member.%d.InstanceProtocol' % i] = listener[3]
             if listener[2]=='HTTPS':
-                params['Listeners.member.%d.SSLCertificateId' % i] = listener[3]
+                params['Listeners.member.%d.SSLCertificateId' % i] = listener[4]
         return self.get_status('CreateLoadBalancerListeners', params)
 
 

--- a/boto/ec2/elb/listener.py
+++ b/boto/ec2/elb/listener.py
@@ -25,15 +25,18 @@ class Listener(object):
     """
 
     def __init__(self, load_balancer=None, load_balancer_port=0,
-                 instance_port=0, protocol='', ssl_certificate_id=None):
+                 instance_port=0, protocol='', instance_protocol = '', 
+                 ssl_certificate_id=None):
         self.load_balancer = load_balancer
         self.load_balancer_port = load_balancer_port
         self.instance_port = instance_port
         self.protocol = protocol
+        self.instance_protocol = instance_protocol
         self.ssl_certificate_id = ssl_certificate_id
 
     def __repr__(self):
-        r = "(%d, %d, '%s'" % (self.load_balancer_port, self.instance_port, self.protocol)
+        r = "(%d, %d, '%s', '%s'" % (self.load_balancer_port, \
+        self.instance_port, self.protocol, self.instance_protocol)
         if self.ssl_certificate_id:
             r += ', %s' % (self.ssl_certificate_id)
         r += ')'
@@ -49,13 +52,16 @@ class Listener(object):
             self.instance_port = int(value)
         elif name == 'Protocol':
             self.protocol = value
+        elif name == 'InstanceProtocol':
+            self.instance_protocol = value
         elif name == 'SSLCertificateId':
             self.ssl_certificate_id = value
         else:
             setattr(self, name, value)
 
     def get_tuple(self):
-        return self.load_balancer_port, self.instance_port, self.protocol
+        return (self.load_balancer_port, self.instance_port, self.protocol,
+        self.instance_protocol, self.ssl_certificate_id)
 
     def __getitem__(self, key):
         if key == 0:

--- a/boto/ec2/elb/loadbalancer.py
+++ b/boto/ec2/elb/loadbalancer.py
@@ -171,10 +171,14 @@ class LoadBalancer(object):
     def create_listeners(self, listeners):
         return self.connection.create_load_balancer_listeners(self.name, listeners)
 
-    def create_listener(self, inPort, outPort=None, proto="tcp"):
+    def create_listener(self, inPort, outPort=None, proto="tcp", instance_proto
+        = None, ssl_id = None):
         if outPort == None:
             outPort = inPort
-        return self.create_listeners([(inPort, outPort, proto)])
+        if instance_proto == None:
+            instance_proto = proto
+        return self.create_listeners([(inPort, outPort, proto, instance_proto,
+        ssl_id)])
 
     def delete_listeners(self, listeners):
         return self.connection.delete_load_balancer_listeners(self.name, listeners)

--- a/tests/ec2/elb/test_connection.py
+++ b/tests/ec2/elb/test_connection.py
@@ -54,7 +54,7 @@ class ELBConnectionTest(unittest.TestCase):
         c = ELBConnection()
         name = 'elb-boto-unit-test'
         availability_zones = ['us-east-1a']
-        listeners = [(80, 8000, 'HTTP')]
+        listeners = [(80, 8000, 'HTTP', 'HTTP', None)]
         balancer = c.create_load_balancer(name, availability_zones, listeners)
         self.assertEqual(balancer.name, name)
         self.assertEqual(balancer.availability_zones, availability_zones)
@@ -67,10 +67,10 @@ class ELBConnectionTest(unittest.TestCase):
         c = ELBConnection()
         name = 'elb-boto-unit-test'
         availability_zones = ['us-east-1a']
-        listeners = [(80, 8000, 'HTTP')]
+        listeners = [(80, 8000, 'HTTP', 'HTTP', None)]
         balancer = c.create_load_balancer(name, availability_zones, listeners)
 
-        more_listeners = [(443, 8001, 'HTTP')]
+        more_listeners = [(443, 8001, 'HTTP', 'HTTP', None)]
         c.create_load_balancer_listeners(name, more_listeners)
         balancers = c.get_all_load_balancers()
         self.assertEqual([lb.name for lb in balancers], [name])
@@ -83,7 +83,7 @@ class ELBConnectionTest(unittest.TestCase):
         c = ELBConnection()
         name = 'elb-boto-unit-test'
         availability_zones = ['us-east-1a']
-        listeners = [(80, 8000, 'HTTP'), (443, 8001, 'HTTP')]
+        listeners = [(80, 8000, 'HTTP', 'HTTP', None), (443, 8001, 'HTTP', 'HTTP', None)]
         balancer = c.create_load_balancer(name, availability_zones, listeners)
 
         balancers = c.get_all_load_balancers()


### PR DESCRIPTION
The previous implementation of listener was to accept a tuple with 3 or 4 values e.g. LB port, instance port, protocol and an optional ssl id. I modified it to accept instance protocol as well. This is required if you configure your LB to do HTTPS with client whereas the backend servers are on HTTP.

I have also modified the existing tests cases to reflect the same.