### PR TITLE
Unbound local error in get_dynamodb_type when using set types. 

### DIFF
--- a/boto/dynamodb/layer2.py
+++ b/boto/dynamodb/layer2.py
@@ -183,6 +183,7 @@ class Layer2(object):
         the corresponding Amazon DynamoDB type.  If the value passed in is
         not a supported type, raise a TypeError.
         """
+        dynamodb_type = None
         if is_num(val):
             dynamodb_type = 'N'
         elif is_str(val):
@@ -192,7 +193,7 @@ class Layer2(object):
                 dynamodb_type = 'NS'
             elif False not in map(is_str, val):
                 dynamodb_type = 'SS'
-        else:
+        if dynamodb_type is None:
             raise TypeError('Unsupported type "%s" for value "%s"' % (type(val), val))
         return dynamodb_type
 


### PR DESCRIPTION
I am not 100% sure how this should work. It would appear DynamoDB only supports set types as long as they contain either ONLY strings or ONLY numbers. So this change supports that logic. If it works some other way, it should be reflected in the source here. I ran into this issue while implementing sets for pynamo: https://github.com/samuraisam/pynamo
