### PR TITLE
Add a prefix to b.list() so s3put/s3multiput don't list the whole bucket

### DIFF
--- a/bin/s3multiput
+++ b/bin/s3multiput
@@ -256,7 +256,7 @@ def main():
             if not quiet:
                 print 'Getting list of existing keys to check against'
             keys = []
-            for key in b.list():
+            for key in b.list(get_key_name(path, prefix)):
                 keys.append(key.name)
         for root, dirs, files in os.walk(path):
             for ignore in ignore_dirs:

--- a/bin/s3put
+++ b/bin/s3put
@@ -162,7 +162,7 @@ def main():
                 if not quiet:
                     print 'Getting list of existing keys to check against'
                 keys = []
-                for key in b.list():
+                for key in b.list(get_key_name(path, prefix)):
                     keys.append(key.name)
             for root, dirs, files in os.walk(path):
                 for ignore in ignore_dirs:


### PR DESCRIPTION
Listing the whole bucket to avoid overwriting keys is extremely
inefficient (especially for buckets will millions or billions of
objects). Use the path provided by the user to add a prefix to b.list()
so that the keyspace is reduced to just the area we're trying to sync.
