### PR TITLE
DynamoDB Table object not correctly updating when calling update_throughput

### DIFF
--- a/boto/dynamodb/layer2.py
+++ b/boto/dynamodb/layer2.py
@@ -282,7 +282,7 @@ class Layer2(object):
         response = self.layer1.update_table(table.name,
                                             {'ReadCapacityUnits': read_units,
                                              'WriteCapacityUnits': write_units})
-        table.update_from_response(response['TableDescription'])
+        table.update_from_response(response)
         
     def delete_table(self, table):
         """


### PR DESCRIPTION
The `update_throughput` method of `Layer2` calls the `update_from_response`
method of `Table`, but instead of passing in the full response (as all
other similar calls to `update_from_response` do) it
passes in `response['TableDescription']`. Since `update_from_response`
looks for either the key 'Table' or 'TableDescription' in the response
object, neither is found and, therefore, the table's local attributes
are not updated and do not correctly reflect the changes that have
taken place on the server. This fix passes in the full response object
to `update_from_response` to resolve the issue.
