### PR TITLE
Include path in resumable upload request

### DIFF
--- a/boto/gs/resumable_upload_handler.py
+++ b/boto/gs/resumable_upload_handler.py
@@ -144,10 +144,7 @@ class ResumableUploadHandler(object):
         """
         parse_result = urlparse.urlparse(uri)
         if (parse_result.scheme.lower() not in ['http', 'https'] or
-            not parse_result.netloc or not parse_result.query):
-            raise InvalidUriError('Invalid tracker URI (%s)' % uri)
-        qdict = cgi.parse_qs(parse_result.query)
-        if not qdict or not 'upload_id' in qdict:
+            not parse_result.netloc):
             raise InvalidUriError('Invalid tracker URI (%s)' % uri)
         self.tracker_uri = uri
         self.tracker_uri_host = parse_result.netloc


### PR DESCRIPTION
If we start a resumable upload request:
POST /music.mp3 HTTP/1.1
Host: example.commondatastorage.googleapis.com
x-goog-resumable: start

We receive the following respose:
HTTP/1.1 201 Created
Location: https://example.commondatastorage.googleapis.com/music.mp3?upload_id=tvA0ExBntDa...gAAEnB2Uowrot

We should then start the upload with the following request:
PUT /music.mp3?upload_id=tvA0ExBntDa...gAAEnB2Uowrot HTTP/1.1
Host: example.commondatastorage.googleapis.com

However, boto throws away the path of the location uri and replaces it with the netloc and a slash, resulting in:

PUT /example.commondatastorage.googleapis.com/?upload_id=tvA0ExBntDa...gAAEnB2Uowrot HTTP/1.1
Host: example.commondatastorage.googleapis.com

Ran the following tests:
python -m s3.test_resumable_uploads
gsutil -D foo gs://bucket  # Verify path is in PUT request.
