### PR TITLE
Adds content-disposition header to key

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -192,7 +192,7 @@ class Key(object):
                 elif name.lower() == 'cache-control':
                     self.cache_control = value
                 elif name.lower() == 'content-disposition':
-                    self.cache_control = value
+                    self.content_disposition = value
             self.handle_version_headers(self.resp)
             self.handle_encryption_headers(self.resp)
 


### PR DESCRIPTION
content-disposition header is not available as part of the key when the headers are fetched. This patch adds content-disposition as an attribute of key object and is visible to the app.
