### PR TITLE
Fix bug, dynamize last evaluated key value in dyanmodb layer2 scan

### DIFF
--- a/boto/dynamodb/layer2.py
+++ b/boto/dynamodb/layer2.py
@@ -658,7 +658,8 @@ class Layer2(object):
             if response is True:
                 pass
             elif response.has_key("LastEvaluatedKey"):
-                exclusive_start_key = response['LastEvaluatedKey']
+                last_evaluated_key = response['LastEvaluatedKey']
+                exclusive_start_key = self.dynamize_item(last_evaluated_key)
             else:
                 break
 


### PR DESCRIPTION
currently causes 400 error, easily reproducible, scan a table from layer2 with request_limit=1 
