### PR TITLE
Set the initiated date in the multipart when parsing the XML.

### DIFF
--- a/boto/s3/multipart.py
+++ b/boto/s3/multipart.py
@@ -184,6 +184,8 @@ class MultiPartUpload(object):
                 self.is_truncated = True
             else:
                 self.is_truncated = False
+        elif name == 'Initiated':
+            self.initiated = value
         else:
             setattr(self, name, value)
 


### PR DESCRIPTION
The initiated variable was always None in the MultipartUpload. This fix makes it available (as a string similar to other date handling returned in resultsets).
