### PR TITLE
Missing prefixes in the multipart upload listings.

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -437,7 +437,8 @@ class Bucket(object):
         :return: The result from S3 listing the uploads requested
         
         """
-        return self._get_all([('Upload', MultiPartUpload)],
+        return self._get_all([('Upload', MultiPartUpload),
+                              ('CommonPrefixes', Prefix)],
                              'uploads', headers, **params)
 
     def new_key(self, key_name=None):


### PR DESCRIPTION
- when delimiter is specified common prefixes can sometimes
  be returned but they were missing from the resultset.
