### PR TITLE
Fix for http://code.google.com/p/boto/issues/detail?id=361

### DIFF
--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -94,7 +94,7 @@ class MTurkConnection(AWSQueryConnection):
         if qual_req is not None:
             params.update(qual_req.get_as_params())
 
-        return self._process_request('RegisterHITType', params)
+        return self._process_request('RegisterHITType', params, [('HITTypeId', HITType)])
 
     def set_email_notification(self, hit_type, email, event_types=None):
         """
@@ -819,6 +819,17 @@ class HIT(BaseAutoResultElement):
 
     # are we there yet?
     expired = property(_has_expired)
+
+class HITType(BaseAutoResultElement):
+    """
+    Class to extract an HITType structure from a response (used in
+    ResultSet)
+    
+    Will have attributes named as per the Developer Guide, 
+    e.g. HITTypeId
+    """
+    
+    pass
 
 class Qualification(BaseAutoResultElement):
     """


### PR DESCRIPTION
I wanted to use MTurk's API and (re)found this bug -  http://code.google.com/p/boto/issues/detail?id=361

register_hit_type() returns a empty list, which is useless (the response should contain the HITTypeId. 
I did what seems correct in the spirit of ResultSet, but let me know if I should change something
