### PR TITLE
restore Python 2.5.x compatibility

### DIFF
--- a/boto/cloudfront/distribution.py
+++ b/boto/cloudfront/distribution.py
@@ -21,7 +21,10 @@
 
 import uuid
 import base64
-import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
 from boto.cloudfront.identity import OriginAccessIdentity
 from boto.cloudfront.object import Object, StreamingObject
 from boto.cloudfront.signers import ActiveTrustedSigners, TrustedSigners

--- a/tests/cloudfront/test_signed_urls.py
+++ b/tests/cloudfront/test_signed_urls.py
@@ -1,6 +1,9 @@
 
 import unittest
-import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
 from textwrap import dedent
 from boto.cloudfront.distribution import Distribution
 

--- a/tests/mturk/all_tests.py
+++ b/tests/mturk/all_tests.py
@@ -11,7 +11,7 @@ from hit_persistence import *
 
 doctest_suite = doctest.DocFileSuite(
 	*glob('*.doctest'),
-	optionflags=doctest.REPORT_ONLY_FIRST_FAILURE
+	**{'optionflags': doctest.REPORT_ONLY_FIRST_FAILURE}
 	)
 
 class Program(unittest.TestProgram):

--- a/tests/mturk/run-doctest.py
+++ b/tests/mturk/run-doctest.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import argparse
 import doctest
 


### PR DESCRIPTION
Somewhere along the line (8816be9a and 16ed9e2d, it looks like), boto stopped being compatibile with Python 2.5.x. Unfortunately, it's not always possible to upgrade.

This commit should restore 2.5.x compatibility. Everything compiles now, at least.
