### PR TITLE
Updated the default EMR AMI version.

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -245,9 +245,8 @@ class EmrConnection(AWSQueryConnection):
             should be enabled.
 
         :type hadoop_version: str
-        :param hadoop_version: Version of Hadoop to use. If ami_version
-            is not set, defaults to '0.20' for backwards compatibility
-            with older versions of boto.
+        :param hadoop_version: Version of Hadoop to use. This no longer
+        defaults to '0.20' and now uses the AMI default. 
 
         :type steps: list(boto.emr.Step)
         :param steps: List of steps to add with the job
@@ -280,11 +279,6 @@ class EmrConnection(AWSQueryConnection):
         :rtype: str
         :return: The jobflow id
         """
-        # hadoop_version used to default to '0.20', but this won't work
-        # on later AMI versions, so only default if it ami_version isn't set.
-        if not (hadoop_version or ami_version):
-            hadoop_version = '0.20'
-
         params = {}
         if action_on_failure:
             params['ActionOnFailure'] = action_on_failure


### PR DESCRIPTION
The "1.0" AMI is currently the default for EMR - it'd be nice to see it move to "latest" in order to pick up all the improvements that got made and to avoid some of the issues with the old AMI.
