### PR TITLE
I was trying to use the s3.get_lifecycle_config() call and it didn't work... this fixes the issue I found

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -1130,7 +1130,7 @@ class Bucket(object):
         body = response.read()
         boto.log.debug(body)
         if response.status == 200:
-            lifecycle = Lifecycle(self)
+            lifecycle = Lifecycle()
             h = handler.XmlHandler(lifecycle, self)
             xml.sax.parseString(body, h)
             return lifecycle


### PR DESCRIPTION
- avoid a bad initialization that never returns
  With the "self" argument it loops forever though I didn't tracked down
  why. Not sure what the code was trying to do initializing a list with a
  bucket that no code looks at, but it allocated 30 megs a second on my
  box till it started swapping.
  With this patch it seems to work, come back promptly.

;;altoplano
