### PR TITLE
EC2 security group -- bulk upload of cidr_ips

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -2153,12 +2153,11 @@ class EC2Connection(AWSQueryConnection):
         if to_port is not None:
             params['IpPermissions.1.ToPort'] = to_port
         if cidr_ip:
-            if type(cidr_ip) == list:
-                for i, single_cidr_ip in enumerate(cidr_ip):
-                    params['IpPermissions.1.IpRanges.%d.CidrIp' % (i+1)] = \
-                        single_cidr_ip
-            else:
-                params['IpPermissions.1.IpRanges.1.CidrIp'] = cidr_ip
+            if type(cidr_ip) != list:
+                cidr_ip = [cidr_ip]
+            for i, single_cidr_ip in enumerate(cidr_ip):
+                params['IpPermissions.1.IpRanges.%d.CidrIp' % (i+1)] = \
+                    single_cidr_ip
 
         return self.get_status('AuthorizeSecurityGroupIngress',
                                params, verb='POST')

--- a/boto/ec2/securitygroup.py
+++ b/boto/ec2/securitygroup.py
@@ -166,13 +166,12 @@ class SecurityGroup(TaggedEC2Object):
                                                           to_port,
                                                           cidr_ip)
         if status:
-            if type(cidr_ip) == list:
-                for single_cidr_ip in cidr_ip:
-                    self.add_rule(ip_protocol, from_port, to_port, src_group_name,
-                                  src_group_owner_id, single_cidr_ip)
-            else:
+            if type(cidr_ip) != list:
+                cidr_ip = [cidr_ip]
+            for single_cidr_ip in cidr_ip:
                 self.add_rule(ip_protocol, from_port, to_port, src_group_name,
-                              src_group_owner_id, cidr_ip)
+                              src_group_owner_id, single_cidr_ip)
+
         return status
 
     def revoke(self, ip_protocol=None, from_port=None, to_port=None,


### PR DESCRIPTION
 Allow for authorizing a list of cidr_ips (much more efficient than looping over calls to securitygroup.authorize()).

 Maintains backwards compatibility with authorizing a single cidr_ip string.
