### PR TITLE
Adding support for Oregon data center (as USWest2) in class boto.s3.connection.Location

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -127,6 +127,7 @@ class Location:
     DEFAULT = '' # US Classic Region
     EU = 'EU'
     USWest = 'us-west-1'
+    USWest2 = 'us-west-2'
     SAEast = 'sa-east-1'
     APNortheast = 'ap-northeast-1'
     APSoutheast = 'ap-southeast-1'


### PR DESCRIPTION
This makes the example shown in the document work easily with Oregon data center
