### PR TITLE
KeyError for table.item_count and table.size_bytes after table creation

### DIFF
--- a/boto/dynamodb/table.py
+++ b/boto/dynamodb/table.py
@@ -15,7 +15,7 @@
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
 # ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
@@ -60,23 +60,23 @@ class Table(object):
     @property
     def name(self):
         return self._dict['TableName']
-    
+
     @property
     def create_time(self):
         return self._dict['CreationDateTime']
-    
+
     @property
     def status(self):
         return self._dict['TableStatus']
-    
+
     @property
     def item_count(self):
-        return self._dict['ItemCount']
-    
+        return self._dict.get('ItemCount', 0)
+
     @property
     def size_bytes(self):
-        return self._dict['TableSizeBytes']
-    
+        return self._dict.get('TableSizeBytes', 0)
+
     @property
     def schema(self):
         return self._schema
@@ -84,11 +84,11 @@ class Table(object):
     @property
     def read_units(self):
         return self._dict['ProvisionedThroughput']['ReadCapacityUnits']
-    
+
     @property
     def write_units(self):
         return self._dict['ProvisionedThroughput']['WriteCapacityUnits']
-    
+
     def update_from_response(self, response):
         """
         Update the state of the Table object based on the response
@@ -134,12 +134,12 @@ class Table(object):
 
         :type read_units: int
         :param read_units: The new value for ReadCapacityUnits.
-        
+
         :type write_units: int
         :param write_units: The new value for WriteCapacityUnits.
         """
         self.layer2.update_throughput(self, read_units, write_units)
-        
+
     def delete(self):
         """
         Delete this table and all items in it.  After calling this
@@ -157,12 +157,12 @@ class Table(object):
         :param hash_key: The HashKey of the requested item.  The
             type of the value must match the type defined in the
             schema for the table.
-        
+
         :type range_key: int|long|float|str|unicode
         :param range_key: The optional RangeKey of the requested item.
             The type of the value must match the type defined in the
             schema for the table.
-            
+
         :type attributes_to_get: list
         :param attributes_to_get: A list of attribute names.
             If supplied, only the specified attribute names will
@@ -182,7 +182,7 @@ class Table(object):
                                     attributes_to_get, consistent_read,
                                     item_class)
     lookup = get_item
-    
+
     def has_item(self, hash_key, range_key=None, consistent_read=False):
         """
         Checks the table to see if the Item with the specified ``hash_key``
@@ -231,7 +231,7 @@ class Table(object):
         :param hash_key: The HashKey of the new item.  The
             type of the value must match the type defined in the
             schema for the table.
-        
+
         :type range_key: int|long|float|str|unicode
         :param range_key: The optional RangeKey of the new item.
             The type of the value must match the type defined in the
@@ -240,12 +240,12 @@ class Table(object):
         :type attrs: dict
         :param attrs: A dictionary of key value pairs used to
             populate the new item.
-            
+
         :type item_class: Class
         :param item_class: Allows you to override the class used
             to generate the items. This should be a subclass of
             :class:`boto.dynamodb.item.Item`
-        
+
         """
         return item_class(self, hash_key, range_key, attrs)
 
@@ -256,7 +256,7 @@ class Table(object):
               item_class=Item):
         """
         Perform a query on the table.
-        
+
         :type hash_key: int|long|float|str|unicode
         :param hash_key: The HashKey of the requested item.  The
             type of the value must match the type defined in the
@@ -265,7 +265,7 @@ class Table(object):
         :type range_key_condition: dict
         :param range_key_condition: A dict where the key is either
             a scalar value appropriate for the RangeKey in the schema
-            of the database or a tuple of such values.  The value 
+            of the database or a tuple of such values.  The value
             associated with this key in the dict will be one of the
             following conditions:
 
@@ -274,7 +274,7 @@ class Table(object):
             The only condition which expects or will accept a tuple
             of values is 'BETWEEN', otherwise a scalar value should
             be used as the key in the dict.
-        
+
         :type attributes_to_get: list
         :param attributes_to_get: A list of attribute names.
             If supplied, only the specified attribute names will


### PR DESCRIPTION
The response from AWS upon creating a new table does not include the 'Table' dictionary, so the ItemCount and TableSizeBytes values do not get added to the _dict attribute immediately after the creation of a new table. This causes calls to the item_count and size_bytes properties to return KeyErrors.

This fix returns a zero for both attributes when either key does not exist within the _dict attribute. I decided on zero rather than on None due to the fact that calling describe_table on the newly created table returns zero for both of these attributes.
