### PR TITLE
Protect set_contents_from_file() against potential dataloss (Issue #630)

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -781,11 +781,12 @@ class Key(object):
     def set_contents_from_file(self, fp, headers=None, replace=True,
                                cb=None, num_cb=10, policy=None, md5=None,
                                reduced_redundancy=False, query_args=None,
-                               encrypt_key=False, size=None):
+                               encrypt_key=False, size=None, rewind=False):
         """
         Store an object in S3 using the name of the Key object as the
         key in S3 and the contents of the file pointed to by 'fp' as the
-        contents.
+        contents. The data is read from 'fp' from its current position until
+        'size' bytes have been read or EOF.
 
         :type fp: file
         :param fp: the file whose contents to upload
@@ -850,6 +851,15 @@ class Key(object):
                       file up into different ranges to be uploaded. If not
                       specified, the default behaviour is to read all bytes
                       from the file pointer. Less bytes may be available.
+
+        :type rewind: bool
+        :param rewind: (optional) If True, the file pointer (fp) will be 
+                       rewound to the start before any bytes are read from
+                       it. The default behaviour is False which reads from
+                       the current position of the file pointer (fp).
+
+        :rtype: int
+        :return: The number of bytes written to the key.
         """
         provider = self.bucket.connection.provider
         headers = headers or {}
@@ -857,6 +867,23 @@ class Key(object):
             headers[provider.acl_header] = policy
         if encrypt_key:
             headers[provider.server_side_encryption_header] = 'AES256'
+
+        if rewind:
+            # caller requests reading from beginning of fp.
+            fp.seek(0, os.SEEK_SET)
+        else:
+            spos = fp.tell()
+            fp.seek(0, os.SEEK_END)
+            if fp.tell() == spos:
+                fp.seek(0, os.SEEK_SET)
+                if fp.tell() != spos:
+                    # Raise an exception as this is likely a programming error
+                    # whereby there is data before the fp but nothing after it.
+                    fp.seek(spos)
+                    raise AttributeError(
+                     'fp is at EOF. Use rewind option or seek() to data start.')
+            # seek back to the correct position.
+            fp.seek(spos)
 
         if reduced_redundancy:
             self.storage_class = 'REDUCED_REDUNDANCY'
@@ -903,6 +930,8 @@ class Key(object):
             self.send_file(fp, headers=headers, cb=cb, num_cb=num_cb,
                            query_args=query_args, chunked_transfer=chunked_transfer,
                            size=size)
+            # return number of bytes written.
+            return self.size
 
     def set_contents_from_filename(self, filename, headers=None, replace=True,
                                    cb=None, num_cb=10, policy=None, md5=None,

--- a/tests/s3/test_key.py
+++ b/tests/s3/test_key.py
@@ -45,6 +45,36 @@ class S3KeyTest (unittest.TestCase):
             key.delete()
         self.bucket.delete()
 
+    def test_set_contents_from_file_dataloss(self):
+        # Create an empty stringio and write to it.
+        content = "abcde"
+        sfp = StringIO.StringIO()
+        sfp.write(content)
+        # Try set_contents_from_file() without rewinding sfp
+        k = self.bucket.new_key("k")
+        try:
+            k.set_contents_from_file(sfp)
+            self.fail("forgot to rewind so should fail.")
+        except AttributeError:
+            pass
+        # call with rewind and check if we wrote 5 bytes
+        k.set_contents_from_file(sfp, rewind=True)
+        self.assertEqual(k.size, 5)
+        # check actual contents by getting it.
+        kn = self.bucket.new_key("k")
+        ks = kn.get_contents_as_string()
+        self.assertEqual(ks, content)
+
+        # finally, try with a 0 length string
+        sfp = StringIO.StringIO()
+        k = self.bucket.new_key("k")
+        k.set_contents_from_file(sfp)
+        self.assertEqual(k.size, 0)
+        # check actual contents by getting it.
+        kn = self.bucket.new_key("k")
+        ks = kn.get_contents_as_string()
+        self.assertEqual(ks, "")
+        
     def test_set_contents_as_file(self):
         content="01234567890123456789"
         sfp = StringIO.StringIO(content)

--- a/tests/s3/test_resumable_uploads.py
+++ b/tests/s3/test_resumable_uploads.py
@@ -202,8 +202,15 @@ class ResumableUploadTests(unittest.TestCase):
         """
         Tests that non-resumable uploads work
         """
-        self.small_src_file.seek(0)
-        self.dst_key.set_contents_from_file(self.small_src_file)
+        # Seek to end incase its the first test.
+        self.small_src_file.seek(0, os.SEEK_END)
+        try:
+            self.dst_key.set_contents_from_file(self.small_src_file)
+            self.fail("should fail as need to rewind the filepointer")
+        except AttributeError:
+            pass
+        # Now try calling with a proper rewind.
+        self.dst_key.set_contents_from_file(self.small_src_file, rewind=True)
         self.assertEqual(self.small_src_file_size, self.dst_key.size)
         self.assertEqual(self.small_src_file_as_string,
                          self.dst_key.get_contents_as_string())


### PR DESCRIPTION
- Since boto 2.1, set_contents_from_file() stopped rewinding the
  file pointer to the start of the file to give the caller more
  control over what data was written. This is useful for multipart
  objects and other situations where you want to read from a
  certain offset in the file pointer. Some uses of this api however
  rely on the old rewind behaviour. In order to aid this transition
  to the new behaviour, the API will now throw an AttributeError
  exception if it detects the user is trying to read from the eof
  when valid data exists before the file pointer.
- Another addition is the rewind flag. If set to True, the API will
  rewind the file pointer before reading from it. The default is
  False.
- The set_contents_from_file() API now also returns the number of
  bytes written.
- Added a unit test to cover this issue and also updated Google Storage
  to get coverage.
