### PR TITLE
Fix for #653 - SQS get_queue fails for IAM users with restricted access 

### DIFF
--- a/boto/sqs/connection.py
+++ b/boto/sqs/connection.py
@@ -291,11 +291,12 @@ class SQSConnection(AWSQueryConnection):
         :rtype: :py:class:`boto.sqs.queue.Queue` or ``None``
         :returns: The requested queue, or ``None`` if no match was found.
         """
-        rs = self.get_all_queues(queue_name)
-        for q in rs:
-            if q.url.endswith(queue_name):
-                return q
-        return None
+        params = {'QueueName': queue_name}
+        cls = Queue
+        try:
+            return self.get_object('GetQueueUrl', params, cls)
+        except SQSError:
+            return None
 
     lookup = get_queue
 


### PR DESCRIPTION
This fixes the issue by using the GetQueueUrl action instead of getting a list of queues and pulling the first matching queue. 

This may make a fix for issue #457 impossible.  Ideally, AWS would allow all users to ListQueues, and only return the queues they have access to.
