### PR TITLE
Fall back to plain text launch config user data

### DIFF
--- a/boto/ec2/autoscale/launchconfig.py
+++ b/boto/ec2/autoscale/launchconfig.py
@@ -173,7 +173,10 @@ class LaunchConfiguration(object):
         elif name == 'RamdiskId':
             self.ramdisk_id = value
         elif name == 'UserData':
-            self.user_data = base64.b64decode(value)
+            try:
+                self.user_data = base64.b64decode(value)
+            except TypeError:
+                self.user_data = value
         elif name == 'LaunchConfigurationARN':
             self.launch_configuration_arn = value
         elif name == 'InstanceMonitoring':


### PR DESCRIPTION
In cases where launch configurations aren't returned as base64-encoded
strings, Boto would raise an exception when b64decode() fails.  This
patch catches that exception, and falls back to loading the user data
string as plain text.

I came across this problem when trying to load certain launch configurations originally created by other tools.  Dumping the XML to log files, I discovered that the user data coming from AWS isn't always base64 decoded, although I could not find a correlation with other tools to figure out when or why this happens.  Either way, since this seems to be a possibility for others as well, I figure it makes sense to have Boto fall back to loading plain text rather than exploding.
