### PR TITLE
Fix tag parsing for network interface objects.

### DIFF
--- a/boto/ec2/networkinterface.py
+++ b/boto/ec2/networkinterface.py
@@ -111,6 +111,9 @@ class NetworkInterface(TaggedEC2Object):
         return 'NetworkInterface:%s' % self.id
 
     def startElement(self, name, attrs, connection):
+        retval = TaggedEC2Object.startElement(self, name, attrs, connection)
+        if retval is not None:
+            return retval
         if name == 'groupSet':
             self.groups = ResultSet([('item', Group)])
             return self.groups


### PR DESCRIPTION
 Unbreaks many methods, get_all_network_interfaces for example. Simple fix.
