### PR TITLE
Centralize InstanceType names.

### DIFF
--- a/boto/ec2/__init__.py
+++ b/boto/ec2/__init__.py
@@ -14,7 +14,7 @@
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
 # ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
@@ -25,13 +25,17 @@ service from AWS.
 """
 from boto.ec2.connection import EC2Connection
 
+InstanceTypes = ['t1.micro', 'm1.small', 'm1.medium', 'm1.large', 'm1.xlarge',
+                'c1.medium', 'c1.xlarge', 'm2.xlarge', 'm2.2xlarge',
+                'm2.4xlarge', 'cc1.4xlarge', 'cc2.8xlarge', 'cg1.4xlarge']
+
 def regions(**kw_params):
     """
     Get all available regions for the EC2 service.
     You may pass any of the arguments accepted by the EC2Connection
     object's constructor as keyword arguments and they will be
     passed along to the EC2Connection object.
-        
+
     :rtype: list
     :return: A list of :class:`boto.ec2.regioninfo.RegionInfo`
     """
@@ -40,14 +44,14 @@ def regions(**kw_params):
 
 def connect_to_region(region_name, **kw_params):
     """
-    Given a valid region name, return a 
+    Given a valid region name, return a
     :class:`boto.ec2.connection.EC2Connection`.
     Any additional parameters after the region_name are passed on to
     the connect method of the region object.
 
     :type: str
     :param region_name: The name of the region to connect to.
-    
+
     :rtype: :class:`boto.ec2.connection.EC2Connection` or ``None``
     :return: A connection to the given region, or None if an invalid region
              name is given
@@ -56,7 +60,7 @@ def connect_to_region(region_name, **kw_params):
         if region.name == region_name:
             return region.connect(**kw_params)
     return None
-    
+
 def get_region(region_name, **kw_params):
     """
     Find and return a :class:`boto.ec2.regioninfo.RegionInfo` object
@@ -73,4 +77,4 @@ def get_region(region_name, **kw_params):
         if region.name == region_name:
             return region
     return None
-    
+

--- a/boto/ec2/buyreservation.py
+++ b/boto/ec2/buyreservation.py
@@ -14,7 +14,7 @@
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
 # ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
@@ -22,11 +22,7 @@
 import boto.ec2
 from boto.sdb.db.property import StringProperty, IntegerProperty
 from boto.manage import propget
-
-InstanceTypes = ['m1.small', 'm1.large', 'm1.xlarge',
-                 'c1.medium', 'c1.xlarge', 'm2.xlarge',
-                 'm2.2xlarge', 'm2.4xlarge', 'cc1.4xlarge',
-                 't1.micro']
+from boto.ec2 import InstanceTypes
 
 class BuyReservation(object):
 
@@ -52,7 +48,7 @@ class BuyReservation(object):
             prop = StringProperty(name='zone', verbose_name='EC2 Availability Zone',
                                   choices=self.ec2.get_all_zones)
             params['zone'] = propget.get(prop)
-            
+
     def get(self, params):
         self.get_region(params)
         self.ec2 = params['region'].connect()

--- a/boto/manage/server.py
+++ b/boto/manage/server.py
@@ -15,7 +15,7 @@
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
 # ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
@@ -35,10 +35,7 @@ from boto.ec2.keypair import KeyPair
 import os, time, StringIO
 from contextlib import closing
 from boto.exception import EC2ResponseError
-
-InstanceTypes = ['m1.small', 'm1.large', 'm1.xlarge',
-                 'c1.medium', 'c1.xlarge',
-                 'm2.2xlarge', 'm2.4xlarge']
+from boto.ec2 import InstanceTypes
 
 class Bundler(object):
 
@@ -134,7 +131,7 @@ class CommandLineGetter(object):
             if ami.location.find('pyami') >= 0:
                 my_amis.append((ami.location, ami))
         return my_amis
-    
+
     def get_region(self, params):
         region = params.get('region', None)
         if isinstance(region, str) or isinstance(region, unicode):
@@ -171,7 +168,7 @@ class CommandLineGetter(object):
             prop = StringProperty(name='zone', verbose_name='EC2 Availability Zone',
                                   choices=self.ec2.get_all_zones)
             params['zone'] = propget.get(prop)
-            
+
     def get_ami_id(self, params):
         valid = False
         while not valid:
@@ -271,20 +268,20 @@ class Server(Model):
         """
         Create a new instance based on the specified configuration file or the specified
         configuration and the passed in parameters.
-        
-        If the config_file argument is not None, the configuration is read from there. 
+
+        If the config_file argument is not None, the configuration is read from there.
         Otherwise, the cfg argument is used.
-        
+
         The config file may include other config files with a #import reference. The included
-        config files must reside in the same directory as the specified file. 
-        
-        The logical_volume argument, if supplied, will be used to get the current physical 
-        volume ID and use that as an override of the value specified in the config file. This 
-        may be useful for debugging purposes when you want to debug with a production config 
-        file but a test Volume. 
-        
-        The dictionary argument may be used to override any EC2 configuration values in the 
-        config file. 
+        config files must reside in the same directory as the specified file.
+
+        The logical_volume argument, if supplied, will be used to get the current physical
+        volume ID and use that as an override of the value specified in the config file. This
+        may be useful for debugging purposes when you want to debug with a production config
+        file but a test Volume.
+
+        The dictionary argument may be used to override any EC2 configuration values in the
+        config file.
         """
         if config_file:
             cfg = Config(path=config_file)
@@ -304,7 +301,7 @@ class Server(Model):
         zone = params.get('zone')
         # deal with possibly passed in logical volume:
         if logical_volume != None:
-           cfg.set('EBS', 'logical_volume_name', logical_volume.name) 
+           cfg.set('EBS', 'logical_volume_name', logical_volume.name)
         cfg_fp = StringIO.StringIO()
         cfg.write(cfg_fp)
         # deal with the possibility that zone and/or keypair are strings read from the config file:
@@ -328,7 +325,7 @@ class Server(Model):
             print 'Waiting for instance to start so we can set its elastic IP address...'
             # Sometimes we get a message from ec2 that says that the instance does not exist.
             # Hopefully the following delay will giv eec2 enough time to get to a stable state:
-            time.sleep(5) 
+            time.sleep(5)
             while instance.update() != 'running':
                 time.sleep(1)
             instance.use_ip(elastic_ip)
@@ -346,7 +343,7 @@ class Server(Model):
             l.append(s)
             i += 1
         return l
-    
+
     @classmethod
     def create_from_instance_id(cls, instance_id, name, description=''):
         regions = boto.ec2.regions()
@@ -393,7 +390,7 @@ class Server(Model):
                         s.put()
                         servers.append(s)
         return servers
-    
+
     def __init__(self, id=None, **kw):
         Model.__init__(self, id, **kw)
         self.ssh_key_file = None
@@ -421,7 +418,7 @@ class Server(Model):
                                             self._instance = instance
                             except EC2ResponseError:
                                 pass
-                            
+
     def _status(self):
         status = ''
         if self._instance:
@@ -553,4 +550,4 @@ class Server(Model):
         return self.run('apt-get -y install %s' % pkg)
 
 
-    
+

--- a/boto/mashups/order.py
+++ b/boto/mashups/order.py
@@ -14,7 +14,7 @@
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
 # ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
@@ -30,11 +30,10 @@ from boto.mashups.iobject import IObject
 from boto.pyami.config import Config
 from boto.sdb.persist import get_domain, set_domain
 import time, StringIO
-
-InstanceTypes = ['m1.small', 'm1.large', 'm1.xlarge', 'c1.medium', 'c1.xlarge']
+from boto.ec2 import InstanceTypes
 
 class Item(IObject):
-    
+
     def __init__(self):
         self.region = None
         self.name = None
@@ -84,7 +83,7 @@ class Item(IObject):
         else:
             l = [(z, z.name, z.state) for z in self.ec2.get_all_zones()]
             self.zone = self.choose_from_list(l, prompt='Choose Availability Zone')
-            
+
     def set_ami(self, ami=None):
         if ami:
             self.ami = ami
@@ -172,7 +171,7 @@ class Order(IObject):
 
     def display(self):
         print 'This Order consists of the following items'
-        print 
+        print
         print 'QTY\tNAME\tTYPE\nAMI\t\tGroups\t\t\tKeyPair'
         for item in self.items:
             print '%s\t%s\t%s\t%s\t%s\t%s' % (item.quantity, item.name, item.instance_type,
@@ -206,6 +205,6 @@ class Order(IObject):
             return s[0]
         else:
             return s
-        
 
-    
+
+


### PR DESCRIPTION
Add cc2.8xlarge and cg1.4xlarge to instance options

All instances specified at
http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/instance-types.html#AvailableInstanceTypes
are now in the boto.ec2.InstanceTypes list.

Fixes issue #543
