### PR TITLE
Fix bug in attach network interface

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -2918,7 +2918,7 @@ class EC2Connection(AWSQueryConnection):
         """
         params = {'NetworkInterfaceId' : network_interface_id,
                   'InstanceId' : instance_id,
-                  'Deviceindex' : device_index}
+                  'DeviceIndex' : device_index}
         return self.get_status('AttachNetworkInterface', params, verb='POST')
 
     def detach_network_interface(self, network_interface_id, force=False):


### PR DESCRIPTION
The DeviceIndex parameter requires the 'i' to be upper case
