### PR TITLE
Handle lowercase protocols and check for 'SSL'

### DIFF
--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -157,10 +157,11 @@ class ELBConnection(AWSQueryConnection):
         params = {'LoadBalancerName' : name}
         for index, listener in enumerate(listeners):
             i = index + 1
+            protocol = listener[2].upper()
             params['Listeners.member.%d.LoadBalancerPort' % i] = listener[0]
             params['Listeners.member.%d.InstancePort' % i] = listener[1]
-            params['Listeners.member.%d.Protocol' % i] = listener[2]
-            if listener[2]=='HTTPS':
+            params['Listeners.member.%d.Protocol' % i] = protocol
+            if protocol == 'HTTPS' or protocol == 'SSL':
                 params['Listeners.member.%d.SSLCertificateId' % i] = listener[3]
         if zones:
             self.build_list_params(params, zones, 'AvailabilityZones.member.%d')
@@ -203,10 +204,11 @@ class ELBConnection(AWSQueryConnection):
         params = {'LoadBalancerName' : name}
         for index, listener in enumerate(listeners):
             i = index + 1
+            protocol = listener[2].upper()
             params['Listeners.member.%d.LoadBalancerPort' % i] = listener[0]
             params['Listeners.member.%d.InstancePort' % i] = listener[1]
-            params['Listeners.member.%d.Protocol' % i] = listener[2]
-            if listener[2] == 'HTTPS' or listener[2] == 'SSL':
+            params['Listeners.member.%d.Protocol' % i] = protocol
+            if protocol == 'HTTPS' or protocol == 'SSL':
                 params['Listeners.member.%d.SSLCertificateId' % i] = listener[3]
         return self.get_status('CreateLoadBalancerListeners', params)
 


### PR DESCRIPTION
In ec2.elb.ELBConnection, when processing listeners, neither
create_load_balancer() or create_load_balancer_listeners() properly
handle lower case protorol strings, which the AWS API accepts.  This
patch converts the protocol to upper case before comparing it to 'HTTPS'
or 'SSL'.

This patch also fixes an inconsistency where
create_load_balancer_listeners() checks for the 'SSL' protocol to attach
a certificate ID, while create_load_balanacer only checks for 'HTTPS'.
