### PR TITLE
Add version info to complete multipartupload and support canned-acls directly.

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -1427,6 +1427,14 @@ class Bucket(object):
             resp = CompleteMultiPartUpload(self)
             h = handler.XmlHandler(resp, self)
             xml.sax.parseString(body, h)
+            # Use a dummy key to parse various response headers
+            # for versioning, encryption info and then explicitly
+            # set the completed MPU object values from key.
+            k = self.key_class(self)
+            k.handle_version_headers(response)
+            k.handle_encryption_headers(response)
+            resp.version_id = k.version_id
+            resp.encrypted = k.encrypted
             return resp
         else:
             raise self.connection.provider.storage_response_error(

--- a/boto/s3/multipart.py
+++ b/boto/s3/multipart.py
@@ -35,6 +35,8 @@ class CompleteMultiPartUpload(object):
                      is contained
      * key_name - The name of the new, completed key
      * etag - The MD5 hash of the completed, combined upload
+     * version_id - The version_id of the completed upload
+     * encrypted - The value of the encryption header
     """
 
     def __init__(self, bucket=None):
@@ -43,6 +45,8 @@ class CompleteMultiPartUpload(object):
         self.bucket_name = None
         self.key_name = None
         self.etag = None
+        self.version_id = None
+        self.encrypted = None
 
     def __repr__(self):
         return '<CompleteMultiPartUpload: %s.%s>' % (self.bucket_name,


### PR DESCRIPTION
This pull request has 2 commits.
- add canned-acl policy parameter to multipart init api
- parse the version-id and encryption headers on the multpart upload complete command and make the information available in the response object.
