### PR TITLE
Use listener protocol as specified by client

### DIFF
--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -160,7 +160,7 @@ class ELBConnection(AWSQueryConnection):
             protocol = listener[2].upper()
             params['Listeners.member.%d.LoadBalancerPort' % i] = listener[0]
             params['Listeners.member.%d.InstancePort' % i] = listener[1]
-            params['Listeners.member.%d.Protocol' % i] = protocol
+            params['Listeners.member.%d.Protocol' % i] = listener[2]
             if protocol == 'HTTPS' or protocol == 'SSL':
                 params['Listeners.member.%d.SSLCertificateId' % i] = listener[3]
         if zones:
@@ -207,7 +207,7 @@ class ELBConnection(AWSQueryConnection):
             protocol = listener[2].upper()
             params['Listeners.member.%d.LoadBalancerPort' % i] = listener[0]
             params['Listeners.member.%d.InstancePort' % i] = listener[1]
-            params['Listeners.member.%d.Protocol' % i] = protocol
+            params['Listeners.member.%d.Protocol' % i] = listener[2]
             if protocol == 'HTTPS' or protocol == 'SSL':
                 params['Listeners.member.%d.SSLCertificateId' % i] = listener[3]
         return self.get_status('CreateLoadBalancerListeners', params)


### PR DESCRIPTION
Follow-up to 1f11d4387a1eb98665f79ec3bf3557d97251fd0f

My apologies, I realized once I got home that I didn't quite end up where I wanted to.  The checks should use an upper-cased version of the input, but the final protocol sent to AWS should be the original input, not the upper-cased version.
