### PR TITLE
Fix invalid Dimension parameter generation

### DIFF
--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -113,17 +113,20 @@ class CloudWatchConnection(AWSQueryConnection):
 
     def build_dimension_param(self, dimension, params):
         prefix = 'Dimensions.member'
-        for i, dim_name in enumerate(dimension):
+        i=0
+        for dim_name in dimension:
             dim_value = dimension[dim_name]
             if dim_value:
                 if isinstance(dim_value, basestring):
                     dim_value = [dim_value]
-                for j, value in enumerate(dim_value):
-                    params['%s.%d.Name.%d' % (prefix, i+1, j+1)] = dim_name
-                    params['%s.%d.Value.%d' % (prefix, i+1, j+1)] = value
+                for value in dim_value:
+                    params['%s.%d.Name' % (prefix, i+1)] = dim_name
+                    params['%s.%d.Value' % (prefix, i+1)] = value
+                    i += 1
             else:
                 params['%s.%d.Name' % (prefix, i+1)] = dim_name
-    
+                i += 1
+
     def build_list_params(self, params, items, label):
         if isinstance(items, basestring):
             items = [items]

--- a/tests/ec2/cloudwatch/test_connection.py
+++ b/tests/ec2/cloudwatch/test_connection.py
@@ -120,8 +120,8 @@ class CloudWatchConnectionTest(unittest.TestCase):
         expected_params = {
             'MetricData.member.1.MetricName': 'N',
             'MetricData.member.1.Value': 1,
-            'MetricData.member.1.Dimensions.member.1.Name.1': 'D',
-            'MetricData.member.1.Dimensions.member.1.Value.1': 'V',
+            'MetricData.member.1.Dimensions.member.1.Name': 'D',
+            'MetricData.member.1.Dimensions.member.1.Value': 'V',
             }
         self.assertEqual(params, expected_params)
 
@@ -132,12 +132,12 @@ class CloudWatchConnectionTest(unittest.TestCase):
         expected_params = {
             'MetricData.member.1.MetricName': 'N',
             'MetricData.member.1.Value': 1,
-            'MetricData.member.1.Dimensions.member.1.Name.1': 'D',
-            'MetricData.member.1.Dimensions.member.1.Value.1': 'V',
+            'MetricData.member.1.Dimensions.member.1.Name': 'D',
+            'MetricData.member.1.Dimensions.member.1.Value': 'V',
             'MetricData.member.2.MetricName': 'M',
             'MetricData.member.2.Value': 2,
-            'MetricData.member.2.Dimensions.member.1.Name.1': 'D',
-            'MetricData.member.2.Dimensions.member.1.Value.1': 'V',
+            'MetricData.member.2.Dimensions.member.1.Name': 'D',
+            'MetricData.member.2.Dimensions.member.1.Value': 'V',
             }
         self.assertEqual(params, expected_params)
 
@@ -148,12 +148,12 @@ class CloudWatchConnectionTest(unittest.TestCase):
         expected_params = {
             'MetricData.member.1.MetricName': 'N',
             'MetricData.member.1.Value': 1,
-            'MetricData.member.1.Dimensions.member.1.Name.1': 'D',
-            'MetricData.member.1.Dimensions.member.1.Value.1': 'V',
+            'MetricData.member.1.Dimensions.member.1.Name': 'D',
+            'MetricData.member.1.Dimensions.member.1.Value': 'V',
             'MetricData.member.2.MetricName': 'N',
             'MetricData.member.2.Value': 2,
-            'MetricData.member.2.Dimensions.member.1.Name.1': 'D',
-            'MetricData.member.2.Dimensions.member.1.Value.1': 'W',
+            'MetricData.member.2.Dimensions.member.1.Name': 'D',
+            'MetricData.member.2.Dimensions.member.1.Value': 'W',
             }
         self.assertEqual(params, expected_params)
 
@@ -170,14 +170,14 @@ class CloudWatchConnectionTest(unittest.TestCase):
         expected_params = {
             'MetricData.member.1.MetricName': 'N',
             'MetricData.member.1.Value': 1,
-            'MetricData.member.1.Dimensions.member.1.Name.1': 'D1',
-            'MetricData.member.1.Dimensions.member.1.Value.1': 'V',
-            'MetricData.member.1.Dimensions.member.2.Name.1': 'D2',
-            'MetricData.member.1.Dimensions.member.2.Value.1': 'W',
+            'MetricData.member.1.Dimensions.member.1.Name': 'D1',
+            'MetricData.member.1.Dimensions.member.1.Value': 'V',
+            'MetricData.member.1.Dimensions.member.2.Name': 'D2',
+            'MetricData.member.1.Dimensions.member.2.Value': 'W',
             }
         self.assertEqual(params, expected_params)
 
-    def test_build_get_params_multiple_parameter_dimension(self):
+    def test_build_get_params_multiple_parameter_dimension1(self):
         from collections import OrderedDict
         self.maxDiff = None
         c = CloudWatchConnection()
@@ -185,10 +185,28 @@ class CloudWatchConnectionTest(unittest.TestCase):
         dimensions = OrderedDict((("D1", "V"), ("D2", "W")))
         c.build_dimension_param(dimensions, params)
         expected_params = {
-            'Dimensions.member.1.Name.1': 'D1',
-            'Dimensions.member.1.Value.1': 'V',
-            'Dimensions.member.2.Name.1': 'D2',
-            'Dimensions.member.2.Value.1': 'W',
+            'Dimensions.member.1.Name': 'D1',
+            'Dimensions.member.1.Value': 'V',
+            'Dimensions.member.2.Name': 'D2',
+            'Dimensions.member.2.Value': 'W',
+            }
+        self.assertEqual(params, expected_params)
+
+    def test_build_get_params_multiple_parameter_dimension2(self):
+        from collections import OrderedDict
+        self.maxDiff = None
+        c = CloudWatchConnection()
+        params = {}
+        dimensions = OrderedDict((("D1", ["V1", "V2"]), ("D2", "W"), ("D3", None)))
+        c.build_dimension_param(dimensions, params)
+        expected_params = {
+            'Dimensions.member.1.Name': 'D1',
+            'Dimensions.member.1.Value': 'V1',
+            'Dimensions.member.2.Name': 'D1',
+            'Dimensions.member.2.Value': 'V2',
+            'Dimensions.member.3.Name': 'D2',
+            'Dimensions.member.3.Value': 'W',
+            'Dimensions.member.4.Name': 'D3',
             }
         self.assertEqual(params, expected_params)
 


### PR DESCRIPTION
According AWS documentation Dimension parameter is a struct with fields Name and Value, where
Name and Value are strings, but not a list of strings.

(See http://docs.amazonwebservices.com/AmazonCloudWatch/latest/APIReference/API_Dimension.html),

Therefore result of CloudWatchConnection.build_dimension_param() with arguments

{ "Param1": ["Value1", "Value2"] }

should be

{ "Dimension.1.Name" :"Param1",
  "Dimension.1.Value": Value1",
  "Dimension.2.Name": "Param1",
  "Dimension.2.Value": "Param2" },

instead of

{ "Dimension.1.Name.1" : "Param1",
  "Dimension.1.Value.1": "Value1",
  "Dimension.1.Name.2": "Param1",
  "Dimansion.1.Value.2": "Value2" }

I've tested a various requests with Amazon CloudWatch service.

Amazon CloudWatch service accepts wrong values (dimensions with lists instead of strings), but doesn't process requests correctly.

Looks like this service read only last element from Value list.

It means that dimension:

{ "Name": "A", "Value": ["B", "C"]  }

is a same as

{ "Name": "A", "Value": "C" }

P.S. Pull request #472 was a more correct then #470.
