### PR TITLE
urllib.quote_plus brake headers

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -351,7 +351,7 @@ class HTTPRequest(object):
         for key in self.headers:
             val = self.headers[key]
             if isinstance(val, unicode):
-                self.headers[key] = urllib.quote_plus(val.encode('utf-8'))
+                self.headers[key] = val.encode('utf-8')
 
         connection._auth_handler.add_auth(self, **kwargs)
 


### PR DESCRIPTION
urllib.quote_plus brake headers, 
e.g., header { "content-type": u"image/png" } will became { "content-type": "image%2Fpng" }

You shouldn't perform urlencode at this level of library.
