### PR TITLE
Allow caller to override provider in the connection object.

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -470,10 +470,14 @@ class AWSAuthConnection(object):
                 timeout = config.getint('Boto', 'http_socket_timeout')
                 self.http_connection_kwargs['timeout'] = timeout
 
-        self.provider = Provider(provider,
-                                 aws_access_key_id,
-                                 aws_secret_access_key,
-                                 security_token)
+        if isinstance(provider, Provider):
+            # Allow overriding Provider
+            self.provider = provider
+        else:
+            self.provider = Provider(provider,
+                                     aws_access_key_id,
+                                     aws_secret_access_key,
+                                     security_token)
 
         # allow config file to override default host
         if self.provider.host:


### PR DESCRIPTION
Our client application needs to have some more control over the provider object but I don't see any way to do that right now. I think this patch is not so bad and is backward compatible. I'm looking for some comments on this patch. I'm using it right now in our tool and it seems simple and works well.

Let me know what you think.

Tom.
