### PR TITLE
DynamoDB's create_schema() now supports passing a python type object

### DIFF
--- a/boto/dynamodb/types.py
+++ b/boto/dynamodb/types.py
@@ -27,11 +27,12 @@ Python types and vice-versa.
 
 
 def is_num(n):
-    return isinstance(n, (int, long, float, bool))
+    types = (int, long, float, bool)
+    return isinstance(n, types) or n in types
 
 
 def is_str(n):
-    return isinstance(n, basestring)
+    return isinstance(n, basestring) or (isinstance(n, type) and issubclass(n, basestring))
 
 
 def convert_num(s):


### PR DESCRIPTION
...in addition to a sample value for hash and range keys

So that you can do something like this:

import boto
conn = boto.connect_dynamodb()
schema = conn.create_schema('my_hash_key', str, 'my_range_key', float)
