### PR TITLE
Fix for Python2.5/httplib and hmac-v3-http signing issue.

### DIFF
--- a/boto/dynamodb/layer1.py
+++ b/boto/dynamodb/layer1.py
@@ -122,6 +122,7 @@ class Layer1(AWSAuthConnection):
         """
         headers = {'X-Amz-Target': '%s_%s.%s' % (self.ServiceName,
                                                  self.Version, action),
+                   'Host': self.region.endpoint,
                    'Content-Type': 'application/x-amz-json-1.0',
                    'Content-Length': str(len(body))}
         http_request = self.build_base_http_request('POST', '/', '/',

--- a/boto/swf/layer1.py
+++ b/boto/swf/layer1.py
@@ -92,6 +92,7 @@ class Layer1(AWSAuthConnection):
         :raises: ``SWFResponseError`` if response status is not 200.
         """
         headers = {'X-Amz-Target': '%s.%s' % (self.ServiceName, action),
+                   'Host': self.region.endpoint,
                    'Content-Type': 'application/json; charset=UTF-8',
                    'Content-Encoding': 'amz-1.0',
                    'Content-Length': str(len(body))}


### PR DESCRIPTION
This change is to fix Python2.5/httplib and hmac-v3-http signing problem as described in https://github.com/boto/boto/issues/582

JUSTIFICATION:
There a change in httplib from Python2.5 to 2.6 in how the 'Host:' header is added to if it's not readily present in 'headers' dict - (compare http://tinyurl.com/d5haf4a with http://tinyurl.com/dx3g5ne )
- In 2.5, an absent "Host:" header is added with "swf.us-east-1.amazonaws.com:443" value (boto assumes "swf.us-east-1.amazonaws.com" and signs for it, which causes a signing exception),
- In 2.6 and beyond, header is added as "swf.us-east-1.amazonaws.com" which boto signs correctly.
  The solution for both Python versions is to add "Host:" header explicitly.

TESTING: Boto 2.3.0 on Python2.5-2.7: 

BEFORE: 

```
Python 2.5.6 (r256:88840, Apr  4 2012, 14:55:39) 
[GCC 4.6.1] on linux3
Type "help", "copyright", "credits" or "license" for more information.
>>> import boto.swf
>>> l1 = boto.swf.connect_to_region('us-east-1', aws_access_key_id=ACCESS, aws_secret_access_key=SECRET)
>>> l1.list_domains('REGISTERED')
{u'message': u'The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.', u'__type': u'com.amazon.coral.service#InvalidSignatureException'}

Python 2.7.2+ (default, Oct  4 2011, 20:03:08) 
[GCC 4.6.1] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import boto.swf
>>> l1 = boto.swf.connect_to_region('us-east-1', aws_access_key_id=ACCESS, aws_secret_access_key=SECRET)
>>> l1.list_domains('REGISTERED')
{'domainInfos': ... }
>>> 
```

AFTER:

```
Python 2.5.6 (r256:88840, Apr  4 2012, 14:55:39) 
[GCC 4.6.1] on linux3
Type "help", "copyright", "credits" or "license" for more information.
>>> import boto.swf
>>> l1 = boto.swf.connect_to_region('us-east-1', aws_access_key_id=ACCESS, aws_secret_access_key=SECRET)
>>> l1.list_domains('REGISTERED')
{u'domainInfos': ... }
```

(Python2.6-2.7 still working fine as per above).
