### PR TITLE
Adding support for incremental md5 computation for resumed uploads

### DIFF
--- a/boto/gs/resumable_upload_handler.py
+++ b/boto/gs/resumable_upload_handler.py
@@ -409,7 +409,6 @@ class ResumableUploadHandler(object):
                     md5sum.update(chunk)
                     bytes_to_go -= len(chunk)
 
-                key=key
                 if conn.debug >= 1:
                     print 'Resuming transfer.'
             except ResumableUploadException, e:


### PR DESCRIPTION
Catching md5sum" up with previously uploaded content to seed it for
the actual transfer, and then incrementally updating the md5sum as
bytes are uploaded. Also adding md5sum rollback support in the event
of an retryable exception. In addition to speedying up resumed uploads
(especially where the previous uploaded portion is small with respect
to the file size), this also simplfies the md5 logic as we use the
incremental md5 in all cases now.
