### PR TITLE
bug fix for table generator in dynamodb.layer2

### DIFF
--- a/boto/dynamodb/layer2.py
+++ b/boto/dynamodb/layer2.py
@@ -63,7 +63,7 @@ def table_generator(tgen):
             pass
         elif 'LastEvaluatedKey' in response:
             lek = response['LastEvaluatedKey']
-            esk = tgen.layer2.dynamize_last_evaluated_key(lek)
+            esk = tgen.table.layer2.dynamize_last_evaluated_key(lek)
             tgen.kwargs['exclusive_start_key'] = esk
         else:
             break


### PR DESCRIPTION
simple fix. scan was broken for last evaluated key case.
