### PR TITLE
Accept single unicode instance id as a query param

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -872,7 +872,7 @@ class AWSQueryConnection(AWSAuthConnection):
         return self._mexe(http_request)
 
     def build_list_params(self, params, items, label):
-        if isinstance(items, str):
+        if isinstance(items, str) or isinstance(items, unicode):
             items = [items]
         for i in range(1, len(items) + 1):
             params['%s.%d' % (label, i)] = items[i - 1]


### PR DESCRIPTION
By convention, boto.ec2.connection.EC2Connection methods
get_all_instances() and get_all_instance_status() accepts a string
instance id or a list of instance ids.  Unfortunately the id from a
boto.ec2.instance.Instance cannot be used, because a unicode instance
id causes the method call to fail. Now an Instance id works.
