### PR TITLE
Generate API docs for boto.cloudformation.connection

### DIFF
--- a/docs/source/ref/cloudformation.rst
+++ b/docs/source/ref/cloudformation.rst
@@ -11,6 +11,13 @@ boto.cloudformation
    :members:   
    :undoc-members:
 
+boto.cloudformation.connection
+------------------------------
+
+.. automodule:: boto.cloudformation.connection
+   :members:
+   :undoc-members:
+
 boto.cloudformation.stack
 -------------------------
 


### PR DESCRIPTION
The boto.cloudformation.connection.CloudFormationConnection class has helpful documentation that I think is worth generating.
