### PR TITLE
More SES error-handling work

### DIFF
--- a/boto/ses/connection.py
+++ b/boto/ses/connection.py
@@ -143,6 +143,14 @@ class SESConnection(AWSAuthConnection):
             # Recipient address ends with a dot/period. This is invalid.
             ExceptionToRaise = ses_exceptions.SESDomainEndsWithDotError
             exc_reason = "Domain ends with dot."
+        elif "Local address contains control or whitespace" in body:
+            # I think this pertains to the recipient address.
+            ExceptionToRaise = ses_exceptions.SESLocalAddressCharacterError
+            exc_reason = "Local address contains control or whitespace."
+        elif "Illegal address" in body:
+            # A clearly mal-formed address.
+            ExceptionToRaise = ses_exceptions.SESIllegalAddressError
+            exc_reason = "Illegal address"
         else:
             # This is either a common AWS error, or one that we don't devote
             # its own exception to.

--- a/boto/ses/exceptions.py
+++ b/boto/ses/exceptions.py
@@ -3,14 +3,24 @@ Various exceptions that are specific to the SES module.
 """
 from boto.exception import BotoServerError
 
-class SESAddressNotVerifiedError(BotoServerError):
+class SESError(BotoServerError):
+    """
+    Sub-class all SES-related errors from here. Don't raise this error
+    directly from anywhere. The only thing this gets us is the ability to
+    catch SESErrors separately from the more generic, top-level
+    BotoServerError exception.
+    """
+    pass
+
+
+class SESAddressNotVerifiedError(SESError):
     """
     Raised when a "Reply-To" address has not been validated in SES yet.
     """
     pass
 
 
-class SESAddressBlacklistedError(BotoServerError):
+class SESAddressBlacklistedError(SESError):
     """
     After you attempt to send mail to an address, and delivery repeatedly
     fails, said address is blacklisted for at least 24 hours. The blacklisting
@@ -20,7 +30,7 @@ class SESAddressBlacklistedError(BotoServerError):
     pass
 
 
-class SESDailyQuotaExceededError(BotoServerError):
+class SESDailyQuotaExceededError(SESError):
     """
     Your account's daily (rolling 24 hour total) allotment of outbound emails
     has been exceeded.
@@ -28,15 +38,29 @@ class SESDailyQuotaExceededError(BotoServerError):
     pass
 
 
-class SESMaxSendingRateExceededError(BotoServerError):
+class SESMaxSendingRateExceededError(SESError):
     """
     Your account's requests/second limit has been exceeded.
     """
     pass
 
 
-class SESDomainEndsWithDotError(BotoServerError):
+class SESDomainEndsWithDotError(SESError):
     """
     Recipient's email address' domain ends with a period/dot.
+    """
+    pass
+
+
+class SESLocalAddressCharacterError(SESError):
+    """
+    An address contained a control or whitespace character.
+    """
+    pass
+
+
+class SESIllegalAddressError(SESError):
+    """
+    Raised when an illegal address is encountered.
     """
     pass


### PR DESCRIPTION
Continued improvement on SES error handling. Added two new specific exceptions to the list that we raise as SES Errors:
- SESLocalAddressCharacterError
- SESIllegalAddressError

Also, all SES-related errors now inherit from a newly created SESError exception. SESError is a child of BotoServerError, so this will be backwards compatible. The reasoning for adding this is to allow people to more easily separate SES errors from the larger pool of generic BotoServerError exceptions. For example:

``` python
try:
    # Something is done here
except SESError as exc:
    # Only interested in SES errors!
    print exc.message
```
