### PR TITLE
SES: Encode messages as UTF8 before base64 encoding

### DIFF
--- a/boto/ses/connection.py
+++ b/boto/ses/connection.py
@@ -278,7 +278,7 @@ class SESConnection(AWSAuthConnection):
 
         """
         params = {
-            'RawMessage.Data': base64.b64encode(raw_message),
+            'RawMessage.Data': base64.b64encode(raw_message.encode('utf-8')),
         }
 
         if source:


### PR DESCRIPTION
charset="utf-8" is already set in message headers. This encodes messages as UTF-8 before base64 encoding them, otherwise errors are thrown if non-ascii characters are in the message.
