### PR TITLE
Allow modifying instance security groups (needed for VPC)

### DIFF
--- a/boto/ec2/instance.py
+++ b/boto/ec2/instance.py
@@ -374,15 +374,17 @@ class Instance(TaggedEC2Object):
 
         :type attribute: string
         :param attribute: The attribute you wish to change.
-                          AttributeName - Expected value (default)
-                          instanceType - A valid instance type (m1.small)
-                          kernel - Kernel ID (None)
-                          ramdisk - Ramdisk ID (None)
-                          userData - Base64 encoded String (None)
-                          disableApiTermination - Boolean (true)
-                          instanceInitiatedShutdownBehavior - stop|terminate
-                          rootDeviceName - device name (None)
-                          sourceDestCheck - Boolean (true)
+
+                          * AttributeName - Expected value (default)
+                          * InstanceType - A valid instance type (m1.small)
+                          * Kernel - Kernel ID (None)
+                          * Ramdisk - Ramdisk ID (None)
+                          * UserData - Base64 encoded String (None)
+                          * DisableApiTermination - Boolean (true)
+                          * InstanceInitiatedShutdownBehavior - stop|terminate
+                          * RootDeviceName - device name (None)
+                          * SourceDestCheck - Boolean (true)
+                          * GroupSet - Set of Security Groups or IDs
 
         :type value: string
         :param value: The new value for the attribute


### PR DESCRIPTION
allow modifying security groups via instance.modify_attribute and modify_instance_attribute. In order to accomplish this it was necessary to switch to the new calling format for ModifyInstanceAttribute. Also, add groupSet to the documentation for instance.get_attribute and get_instance_attribute

http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-ModifyInstanceAttribute.html

I also found the pull request https://github.com/boto/boto/pull/723 that uses the new calling convention but does not handle the security groups modification.
