### PR TITLE
Fix connection leak with bucket.get_key() on certain failures.

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -173,10 +173,10 @@ class Bucket(object):
         response = self.connection.make_request('HEAD', self.name, key_name,
                                                 headers=headers,
                                                 query_args=query_args)
+        response.read()
         # Allow any success status (2xx) - for example this lets us
         # support Range gets, which return status 206:
         if response.status/100 == 2:
-            response.read()
             k = self.key_class(self)
             provider = self.connection.provider
             k.metadata = boto.utils.get_aws_metadata(response.msg, provider)
@@ -201,7 +201,6 @@ class Bucket(object):
             return k
         else:
             if response.status == 404:
-                response.read()
                 return None
             else:
                 raise self.connection.provider.storage_response_error(


### PR DESCRIPTION
- Boto internally keeps a pool of connections for re-use. Connections
  where the body has not been read yet are deemed not ready and stay
  in the pool. HEAD Object failures such as 403 were not reading
  their body so were never ready and stay in the pool.

This shouldn't effect the unit tests, but here is a run.

./test.py -t s3
--- running S3Connection tests ---
--- tests completed ---
.................--- running S3Encryption tests ---
--- tests completed ---
## .............

Ran 30 tests in 192.358s

OK
