### PR TITLE
Add a config knob for connection stale duration for connection reuse.

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -232,6 +232,9 @@ class ConnectionPool(object):
         # The last time the pool was cleaned.
         self.last_clean_time = 0.0
         self.mutex = threading.Lock()
+        ConnectionPool.STALE_DURATION = \
+            config.getfloat('Boto', 'connection_stale_duration',
+                            ConnectionPool.STALE_DURATION)
 
     def size(self):
         """


### PR DESCRIPTION
- config is 'connection_stale_duration' in 'Boto' section. Hard coded
  source default value remains 60.0 seconds.
- Other S3 servers may close idle connections more aggressively than AWS.
  This configuration gives the user the option to adjust the time during
  which a connection can be reused from the boto pool.
- Tested with .boto config file existing and not existing.
