### PR TITLE
Use sorted(foo) instead of foo.sort() afterwards

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -215,11 +215,10 @@ class HmacAuthV3HTTPHandler(AuthHandler, HmacKeys):
         case, sorting them in alphabetical order and then joining
         them into a string, separated by newlines.
         """
-        l = ['%s:%s'%(n.lower().strip(),
-                      headers_to_sign[n].strip()) for n in headers_to_sign]
-        l.sort()
+        l = sorted(['%s:%s'%(n.lower().strip(),
+                    headers_to_sign[n].strip()) for n in headers_to_sign])
         return '\n'.join(l)
-        
+
     def string_to_sign(self, http_request):
         """
         Return the canonical StringToSign as well as a dict
@@ -349,8 +348,7 @@ class QuerySignatureV2AuthHandler(QuerySignatureHelper, AuthHandler):
             params['SignatureMethod'] = 'HmacSHA1'
         if self._provider.security_token:
             params['SecurityToken'] = self._provider.security_token
-        keys = params.keys()
-        keys.sort()
+        keys = sorted(params.keys())
         pairs = []
         for key in keys:
             val = boto.utils.get_utf8_value(params[key])

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -1710,10 +1710,9 @@ class EC2Connection(AWSQueryConnection):
             if temp.__contains__(t) == False:
                 temp.append(t)
 
-        target_backup_times = temp
-        # make the oldeest dates first, and make sure the month start
+        # sort to make the oldest dates first, and make sure the month start
         # and last four week's start are in the proper order
-        target_backup_times.sort()
+        target_backup_times = sorted(temp)
 
         # get all the snapshots, sort them by date and time, and
         # organize them into one array for each volume:
@@ -2799,8 +2798,7 @@ class EC2Connection(AWSQueryConnection):
     # Tag methods
 
     def build_tag_param_list(self, params, tags):
-        keys = tags.keys()
-        keys.sort()
+        keys = sorted(tags.keys())
         i = 1
         for key in keys:
             value = tags[key]

--- a/boto/fps/connection.py
+++ b/boto/fps/connection.py
@@ -213,8 +213,7 @@ class FPSConnection(AWSQueryConnection):
 
         safestr = lambda x: x is not None and str(x) or ''
         safequote = lambda x: urllib.quote(safestr(x), safe='~')
-        payload = [(k, safequote(v)) for k, v in kw.items()]
-        payload.sort()
+        payload = sorted([(k, safequote(v)) for k, v in kw.items()])
 
         encoded = lambda p: '&'.join([k + '=' + v for k, v in p])
         canonical = '\n'.join(['GET', endpoint, base, encoded(payload)])

--- a/boto/sdb/connection.py
+++ b/boto/sdb/connection.py
@@ -139,8 +139,7 @@ class SDBConnection(AWSQueryConnection):
 
     def _build_name_value_list(self, params, attributes, replace=False,
                               label='Attribute'):
-        keys = attributes.keys()
-        keys.sort()
+        keys = sorted(attributes.keys())
         i = 1
         for key in keys:
             value = attributes[key]

--- a/boto/services/result.py
+++ b/boto/services/result.py
@@ -57,8 +57,7 @@ class ResultProcessor:
             self.latest_time = end_time
 
     def log_message(self, msg, path):
-        keys = msg.keys()
-        keys.sort()
+        keys = sorted(msg.keys())
         if not self.log_fp:
             self.log_fp = open(os.path.join(path, self.LogFileName), 'a')
             line = ','.join(keys)

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -112,8 +112,7 @@ def canonical_string(method, path, headers, expires=None,
     if expires:
         interesting_headers['date'] = str(expires)
 
-    sorted_header_keys = interesting_headers.keys()
-    sorted_header_keys.sort()
+    sorted_header_keys = sorted(interesting_headers.keys())
 
     buf = "%s\n" % method
     for key in sorted_header_keys:

--- a/tests/db/test_lists.py
+++ b/tests/db/test_lists.py
@@ -66,8 +66,7 @@ class TestLists(object):
         item.save()
         time.sleep(3)
         t = SimpleListModel.get_by_id(t.id)
-        i1 = item['strs']
-        i1.sort()
+        i1 = sorted(item['strs'])
         i2 = t.strs
         i2.sort()
         assert(i1 == i2)


### PR DESCRIPTION
Several places in the code assign a list somewhere and immediately call their sort() methods.  This fix replaces these with one-line assignments of sorted(orig_list).
