### PR TITLE
Don't give tuples to the lambda operator

### DIFF
--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -280,7 +280,7 @@ class MTurkConnection(AWSQueryConnection):
         page_size = 100
         search_rs = self.search_hits(page_size=page_size)
         total_records = int(search_rs.TotalNumResults)
-        get_page_hits = lambda(page): self.search_hits(page_size=page_size, page_number=page)
+        get_page_hits = lambda page: self.search_hits(page_size=page_size, page_number=page)
         page_nums = self._get_pages(page_size, total_records)
         hit_sets = itertools.imap(get_page_hits, page_nums)
         return itertools.chain.from_iterable(hit_sets)


### PR DESCRIPTION
The lambda operator doesn't actually take a tuple as its first parameter.  mturk.connection has some extra parentheses that make it dangerously close to doing so if the code is later added, so this commit drops them.
