### PR TITLE
Appease PEP8 spacing guidelines

### DIFF
--- a/boto/ec2/cloudwatch/alarm.py
+++ b/boto/ec2/cloudwatch/alarm.py
@@ -56,10 +56,10 @@ class MetricAlarm(object):
     INSUFFICIENT_DATA = 'INSUFFICIENT_DATA'
 
     _cmp_map = {
-                    '>='    :   'GreaterThanOrEqualToThreshold',
-                    '>'     :   'GreaterThanThreshold',
-                    '<'     :   'LessThanThreshold',
-                    '<='    :   'LessThanOrEqualToThreshold',
+                    '>=': 'GreaterThanOrEqualToThreshold',
+                    '>':  'GreaterThanThreshold',
+                    '<':  'LessThanThreshold',
+                    '<=': 'LessThanOrEqualToThreshold',
                }
     _rev_cmp_map = dict((v, k) for (k, v) in _cmp_map.iteritems())
 

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -118,7 +118,7 @@ class EC2Connection(AWSQueryConnection):
                 value = [value]
             j = 1
             for v in value:
-                params['Filter.%d.Value.%d' % (i,j)] = v
+                params['Filter.%d.Value.%d' % (i, j)] = v
                 j += 1
             i += 1
 

--- a/boto/manage/cmdshell.py
+++ b/boto/manage/cmdshell.py
@@ -54,7 +54,7 @@ class SSHClient(object):
                                          username=self.uname,
                                          pkey=self._pkey)
                 return
-            except socket.error, (value,message):
+            except socket.error, (value, message):
                 if value == 61 or value == 111:
                     print 'SSH Connection refused, will retry in 5 seconds'
                     time.sleep(5)

--- a/boto/manage/volume.py
+++ b/boto/manage/volume.py
@@ -194,7 +194,7 @@ class Volume(Model):
                     snapshot.date = boto.utils.parse_ts(snapshot.start_time)
                     snapshot.keep = True
                     snaps.append(snapshot)
-        snaps.sort(cmp=lambda x,y: cmp(x.date, y.date))
+        snaps.sort(cmp=lambda x, y: cmp(x.date, y.date))
         return snaps
 
     def attach(self, server=None):
@@ -376,7 +376,7 @@ class Volume(Model):
             for snap in partial_week[1:]:
                 snap.keep = False
         # Keep the first snapshot of each week for the previous 4 weeks
-        for i in range(0,4):
+        for i in range(0, 4):
             weeks_worth = self.get_snapshot_range(snaps, week_boundary-one_week, week_boundary)
             if len(weeks_worth) > 1:
                 for snap in weeks_worth[1:]:

--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -176,9 +176,9 @@ class MTurkConnection(AWSQueryConnection):
         
         # Handle basic required arguments and set up params dict
         params = {'Question': question_param.get_as_xml(),
-                  'LifetimeInSeconds' :
+                  'LifetimeInSeconds':
                       self.duration_as_seconds(lifetime),
-                  'MaxAssignments' : max_assignments,
+                  'MaxAssignments': max_assignments,
                   }
 
         # if hit type specified then add it
@@ -351,7 +351,7 @@ class MTurkConnection(AWSQueryConnection):
     def approve_assignment(self, assignment_id, feedback=None):
         """
         """
-        params = {'AssignmentId' : assignment_id,}
+        params = {'AssignmentId': assignment_id,}
         if feedback:
             params['RequesterFeedback'] = feedback
         return self._process_request('ApproveAssignment', params)
@@ -359,7 +359,7 @@ class MTurkConnection(AWSQueryConnection):
     def reject_assignment(self, assignment_id, feedback=None):
         """
         """
-        params = {'AssignmentId' : assignment_id,}
+        params = {'AssignmentId': assignment_id,}
         if feedback:
             params['RequesterFeedback'] = feedback
         return self._process_request('RejectAssignment', params)
@@ -367,7 +367,7 @@ class MTurkConnection(AWSQueryConnection):
     def get_hit(self, hit_id, response_groups=None):
         """
         """
-        params = {'HITId' : hit_id,}
+        params = {'HITId': hit_id,}
         # Handle optional response groups argument
         if response_groups:
             self.build_list_params(params, response_groups, 'ResponseGroup')
@@ -383,7 +383,7 @@ class MTurkConnection(AWSQueryConnection):
         Reviewing.  Similarly, only Reviewing HITs can be reverted back to a
         status of Reviewable.
         """
-        params = {'HITId' : hit_id,}
+        params = {'HITId': hit_id,}
         if revert:
             params['Revert'] = revert
         return self._process_request('SetHITAsReviewing', params)
@@ -405,7 +405,7 @@ class MTurkConnection(AWSQueryConnection):
         It is not possible to re-enable a HIT once it has been disabled.
         To make the work from a disabled HIT available again, create a new HIT.
         """
-        params = {'HITId' : hit_id,}
+        params = {'HITId': hit_id,}
         # Handle optional response groups argument
         if response_groups:
             self.build_list_params(params, response_groups, 'ResponseGroup')
@@ -422,7 +422,7 @@ class MTurkConnection(AWSQueryConnection):
         reviewable, then call GetAssignmentsForHIT to retrieve the
         assignments.  Disposing of a HIT removes the HIT from the
         results of a call to GetReviewableHITs.  """
-        params = {'HITId' : hit_id,}
+        params = {'HITId': hit_id,}
         return self._process_request('DisposeHIT', params)
 
     def expire_hit(self, hit_id):
@@ -439,7 +439,7 @@ class MTurkConnection(AWSQueryConnection):
         submitted, the expired HIT becomes"reviewable", and will be
         returned by a call to GetReviewableHITs.
         """
-        params = {'HITId' : hit_id,}
+        params = {'HITId': hit_id,}
         return self._process_request('ForceExpireHIT', params)
 
     def extend_hit(self, hit_id, assignments_increment=None, expiration_increment=None):
@@ -461,7 +461,7 @@ class MTurkConnection(AWSQueryConnection):
            (assignments_increment is not None and expiration_increment is not None):
             raise ValueError("Must specify either assignments_increment or expiration_increment, but not both")
 
-        params = {'HITId' : hit_id,}
+        params = {'HITId': hit_id,}
         if assignments_increment:
             params['MaxAssignmentsIncrement'] = assignments_increment
         if expiration_increment:
@@ -568,9 +568,9 @@ class MTurkConnection(AWSQueryConnection):
 
         """
 
-        params = {'Name' : name,
-                  'Description' : description,
-                  'QualificationTypeStatus' : status,
+        params = {'Name': name,
+                  'Description': description,
+                  'QualificationTypeStatus': status,
                   }
         if retry_delay is not None:
             params['RetryDelayInSeconds'] = retry_delay

--- a/boto/mturk/qualification.py
+++ b/boto/mturk/qualification.py
@@ -35,7 +35,7 @@ class Qualifications:
         for n, req in enumerate(self.requirements):
             reqparams = req.get_as_params()
             for rp in reqparams:
-                params['QualificationRequirement.%s.%s' % ((n+1),rp) ] = reqparams[rp]
+                params['QualificationRequirement.%s.%s' % ((n+1), rp) ] = reqparams[rp]
         return params
 
 

--- a/boto/mturk/question.py
+++ b/boto/mturk/question.py
@@ -250,8 +250,8 @@ class Constraint(object):
     def get_attributes(self):
         pairs = zip(self.attribute_names, self.attribute_values)
         attrs = ' '.join(
-            '%s="%d"' % (name,value)
-            for (name,value) in pairs
+            '%s="%d"' % (name, value)
+            for (name, value) in pairs
             if value is not None
             )
         return attrs

--- a/boto/provider.py
+++ b/boto/provider.py
@@ -65,93 +65,93 @@ STORAGE_RESPONSE_ERROR = 'StorageResponseError'
 class Provider(object):
 
     CredentialMap = {
-        'aws' : ('aws_access_key_id', 'aws_secret_access_key'),
-        'google' : ('gs_access_key_id', 'gs_secret_access_key'),
+        'aws':    ('aws_access_key_id', 'aws_secret_access_key'),
+        'google': ('gs_access_key_id',  'gs_secret_access_key'),
     }
 
     AclClassMap = {
-        'aws' : Policy,
-        'google' : ACL
+        'aws':    Policy,
+        'google': ACL
     }
 
     CannedAclsMap = {
-        'aws' : CannedS3ACLStrings,
-        'google' : CannedGSACLStrings
+        'aws':    CannedS3ACLStrings,
+        'google': CannedGSACLStrings
     }
 
     HostKeyMap = {
-        'aws' : 's3',
-        'google' : 'gs'
+        'aws':    's3',
+        'google': 'gs'
     }
 
     ChunkedTransferSupport = {
-        'aws' : False,
-        'google' : True
+        'aws':    False,
+        'google': True
     }
 
     # If you update this map please make sure to put "None" for the
     # right-hand-side for any headers that don't apply to a provider, rather
     # than simply leaving that header out (which would cause KeyErrors).
     HeaderInfoMap = {
-        'aws' : {
-            HEADER_PREFIX_KEY : AWS_HEADER_PREFIX,
-            METADATA_PREFIX_KEY : AWS_HEADER_PREFIX + 'meta-',
-            ACL_HEADER_KEY : AWS_HEADER_PREFIX + 'acl',
-            AUTH_HEADER_KEY : 'AWS',
-            COPY_SOURCE_HEADER_KEY : AWS_HEADER_PREFIX + 'copy-source',
-            COPY_SOURCE_VERSION_ID_HEADER_KEY : AWS_HEADER_PREFIX +
+        'aws': {
+            HEADER_PREFIX_KEY: AWS_HEADER_PREFIX,
+            METADATA_PREFIX_KEY: AWS_HEADER_PREFIX + 'meta-',
+            ACL_HEADER_KEY: AWS_HEADER_PREFIX + 'acl',
+            AUTH_HEADER_KEY: 'AWS',
+            COPY_SOURCE_HEADER_KEY: AWS_HEADER_PREFIX + 'copy-source',
+            COPY_SOURCE_VERSION_ID_HEADER_KEY: AWS_HEADER_PREFIX +
                                                 'copy-source-version-id',
-            COPY_SOURCE_RANGE_HEADER_KEY : AWS_HEADER_PREFIX +
+            COPY_SOURCE_RANGE_HEADER_KEY: AWS_HEADER_PREFIX +
                                            'copy-source-range',
-            DATE_HEADER_KEY : AWS_HEADER_PREFIX + 'date',
-            DELETE_MARKER_HEADER_KEY : AWS_HEADER_PREFIX + 'delete-marker',
-            METADATA_DIRECTIVE_HEADER_KEY : AWS_HEADER_PREFIX +
+            DATE_HEADER_KEY: AWS_HEADER_PREFIX + 'date',
+            DELETE_MARKER_HEADER_KEY: AWS_HEADER_PREFIX + 'delete-marker',
+            METADATA_DIRECTIVE_HEADER_KEY: AWS_HEADER_PREFIX +
                                             'metadata-directive',
-            RESUMABLE_UPLOAD_HEADER_KEY : None,
-            SECURITY_TOKEN_HEADER_KEY : AWS_HEADER_PREFIX + 'security-token',
-            SERVER_SIDE_ENCRYPTION_KEY : AWS_HEADER_PREFIX + 'server-side-encryption',
-            VERSION_ID_HEADER_KEY : AWS_HEADER_PREFIX + 'version-id',
-            STORAGE_CLASS_HEADER_KEY : AWS_HEADER_PREFIX + 'storage-class',
-            MFA_HEADER_KEY : AWS_HEADER_PREFIX + 'mfa',
+            RESUMABLE_UPLOAD_HEADER_KEY: None,
+            SECURITY_TOKEN_HEADER_KEY: AWS_HEADER_PREFIX + 'security-token',
+            SERVER_SIDE_ENCRYPTION_KEY: AWS_HEADER_PREFIX + 'server-side-encryption',
+            VERSION_ID_HEADER_KEY: AWS_HEADER_PREFIX + 'version-id',
+            STORAGE_CLASS_HEADER_KEY: AWS_HEADER_PREFIX + 'storage-class',
+            MFA_HEADER_KEY: AWS_HEADER_PREFIX + 'mfa',
         },
-        'google' : {
-            HEADER_PREFIX_KEY : GOOG_HEADER_PREFIX,
-            METADATA_PREFIX_KEY : GOOG_HEADER_PREFIX + 'meta-',
-            ACL_HEADER_KEY : GOOG_HEADER_PREFIX + 'acl',
-            AUTH_HEADER_KEY : 'GOOG1',
-            COPY_SOURCE_HEADER_KEY : GOOG_HEADER_PREFIX + 'copy-source',
-            COPY_SOURCE_VERSION_ID_HEADER_KEY : GOOG_HEADER_PREFIX +
+        'google': {
+            HEADER_PREFIX_KEY: GOOG_HEADER_PREFIX,
+            METADATA_PREFIX_KEY: GOOG_HEADER_PREFIX + 'meta-',
+            ACL_HEADER_KEY: GOOG_HEADER_PREFIX + 'acl',
+            AUTH_HEADER_KEY: 'GOOG1',
+            COPY_SOURCE_HEADER_KEY: GOOG_HEADER_PREFIX + 'copy-source',
+            COPY_SOURCE_VERSION_ID_HEADER_KEY: GOOG_HEADER_PREFIX +
                                                 'copy-source-version-id',
-            COPY_SOURCE_RANGE_HEADER_KEY : None,
-            DATE_HEADER_KEY : GOOG_HEADER_PREFIX + 'date',
-            DELETE_MARKER_HEADER_KEY : GOOG_HEADER_PREFIX + 'delete-marker',
-            METADATA_DIRECTIVE_HEADER_KEY : GOOG_HEADER_PREFIX  +
+            COPY_SOURCE_RANGE_HEADER_KEY: None,
+            DATE_HEADER_KEY: GOOG_HEADER_PREFIX + 'date',
+            DELETE_MARKER_HEADER_KEY: GOOG_HEADER_PREFIX + 'delete-marker',
+            METADATA_DIRECTIVE_HEADER_KEY: GOOG_HEADER_PREFIX  +
                                             'metadata-directive',
-            RESUMABLE_UPLOAD_HEADER_KEY : GOOG_HEADER_PREFIX + 'resumable',
-            SECURITY_TOKEN_HEADER_KEY : GOOG_HEADER_PREFIX + 'security-token',
-            SERVER_SIDE_ENCRYPTION_KEY : None,
+            RESUMABLE_UPLOAD_HEADER_KEY: GOOG_HEADER_PREFIX + 'resumable',
+            SECURITY_TOKEN_HEADER_KEY: GOOG_HEADER_PREFIX + 'security-token',
+            SERVER_SIDE_ENCRYPTION_KEY: None,
             # Note that this version header is not to be confused with
             # the Google Cloud Storage 'x-goog-api-version' header.
-            VERSION_ID_HEADER_KEY : GOOG_HEADER_PREFIX + 'version-id',
-            STORAGE_CLASS_HEADER_KEY : None,
-            MFA_HEADER_KEY : None,
+            VERSION_ID_HEADER_KEY: GOOG_HEADER_PREFIX + 'version-id',
+            STORAGE_CLASS_HEADER_KEY: None,
+            MFA_HEADER_KEY: None,
         }
     }
 
     ErrorMap = {
-        'aws' : {
-            STORAGE_COPY_ERROR : boto.exception.S3CopyError,
-            STORAGE_CREATE_ERROR : boto.exception.S3CreateError,
-            STORAGE_DATA_ERROR : boto.exception.S3DataError,
-            STORAGE_PERMISSIONS_ERROR : boto.exception.S3PermissionsError,
-            STORAGE_RESPONSE_ERROR : boto.exception.S3ResponseError,
+        'aws': {
+            STORAGE_COPY_ERROR: boto.exception.S3CopyError,
+            STORAGE_CREATE_ERROR: boto.exception.S3CreateError,
+            STORAGE_DATA_ERROR: boto.exception.S3DataError,
+            STORAGE_PERMISSIONS_ERROR: boto.exception.S3PermissionsError,
+            STORAGE_RESPONSE_ERROR: boto.exception.S3ResponseError,
         },
-        'google' : {
-            STORAGE_COPY_ERROR : boto.exception.GSCopyError,
-            STORAGE_CREATE_ERROR : boto.exception.GSCreateError,
-            STORAGE_DATA_ERROR : boto.exception.GSDataError,
-            STORAGE_PERMISSIONS_ERROR : boto.exception.GSPermissionsError,
-            STORAGE_RESPONSE_ERROR : boto.exception.GSResponseError,
+        'google': {
+            STORAGE_COPY_ERROR: boto.exception.GSCopyError,
+            STORAGE_CREATE_ERROR: boto.exception.GSCreateError,
+            STORAGE_DATA_ERROR: boto.exception.GSDataError,
+            STORAGE_PERMISSIONS_ERROR: boto.exception.GSPermissionsError,
+            STORAGE_RESPONSE_ERROR: boto.exception.GSResponseError,
         }
     }
 

--- a/boto/roboto/awsqueryrequest.py
+++ b/boto/roboto/awsqueryrequest.py
@@ -230,7 +230,7 @@ class AWSQueryRequest(object):
                 self.request_params['Filter.%d.Name' % (i+1)] = name
                 for j, value in enumerate(boto.utils.mklist(filters[name])):
                     Encoder.encode(filter, self.request_params, value,
-                                   'Filter.%d.Value.%d' % (i+1,j+1))
+                                   'Filter.%d.Value.%d' % (i+1, j+1))
 
     def process_args(self, **args):
         """

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -164,7 +164,7 @@ class Bucket(object):
         if version_id:
             query_args.append('versionId=%s' % version_id)
         if response_headers:
-            for rk,rv in response_headers.iteritems():
+            for rk, rv in response_headers.iteritems():
                 query_args.append('%s=%s' % (rk, urllib.quote(rv)))
         if query_args:
             query_args = '&'.join(query_args)

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -171,7 +171,7 @@ class Key(object):
             response_headers = self.resp.msg
             self.metadata = boto.utils.get_aws_metadata(response_headers,
                                                         provider)
-            for name,value in response_headers.items():
+            for name, value in response_headers.items():
                 # To get correct size for Range GETs, use Content-Range
                 # header if one was returned. If not, use Content-Length
                 # header.

--- a/boto/sdb/db/manager/sdbmanager.py
+++ b/boto/sdb/db/manager/sdbmanager.py
@@ -49,15 +49,15 @@ class SDBConverter(object):
     """
     def __init__(self, manager):
         self.manager = manager
-        self.type_map = { bool : (self.encode_bool, self.decode_bool),
-                          int : (self.encode_int, self.decode_int),
-                          long : (self.encode_long, self.decode_long),
-                          float : (self.encode_float, self.decode_float),
-                          Model : (self.encode_reference, self.decode_reference),
-                          Key : (self.encode_reference, self.decode_reference),
-                          datetime : (self.encode_datetime, self.decode_datetime),
-                          date : (self.encode_date, self.decode_date),
-                          time : (self.encode_time, self.decode_time),
+        self.type_map = { bool: (self.encode_bool, self.decode_bool),
+                          int: (self.encode_int, self.decode_int),
+                          long: (self.encode_long, self.decode_long),
+                          float: (self.encode_float, self.decode_float),
+                          Model: (self.encode_reference, self.decode_reference),
+                          Key: (self.encode_reference, self.decode_reference),
+                          datetime: (self.encode_datetime, self.decode_datetime),
+                          date: (self.encode_date, self.decode_date),
+                          time: (self.encode_time, self.decode_time),
                           Blob: (self.encode_blob, self.decode_blob),
                           str: (self.encode_string, self.decode_string),
                       }
@@ -92,7 +92,7 @@ class SDBConverter(object):
         # We support lists up to 1,000 attributes, since
         # SDB technically only supports 1024 attributes anyway
         values = {}
-        for k,v in enumerate(value):
+        for k, v in enumerate(value):
             values["%03d" % k] = v
         return self.encode_map(prop, values)
 
@@ -128,7 +128,7 @@ class SDBConverter(object):
             dec_val = {}
             for val in value:
                 if val != None:
-                    k,v = self.decode_map_element(item_type, val)
+                    k, v = self.decode_map_element(item_type, val)
                     try:
                         k = int(k)
                     except:
@@ -143,7 +143,7 @@ class SDBConverter(object):
         ret_value = {}
         item_type = getattr(prop, "item_type")
         for val in value:
-            k,v = self.decode_map_element(item_type, val)
+            k, v = self.decode_map_element(item_type, val)
             ret_value[k] = v
         return ret_value
 
@@ -152,7 +152,7 @@ class SDBConverter(object):
         import urllib
         key = value
         if ":" in value:
-            key, value = value.split(':',1)
+            key, value = value.split(':', 1)
             key = urllib.unquote(key)
         if Model in item_type.mro():
             value = item_type(id=value)
@@ -470,7 +470,7 @@ class SDBManager(object):
             
     def load_object(self, obj):
         if not obj._loaded:
-            a = self.domain.get_attributes(obj.id,consistent_read=self.consistent)
+            a = self.domain.get_attributes(obj.id, consistent_read=self.consistent)
             if a.has_key('__type__'):
                 for prop in obj.properties(hidden=False):
                     if a.has_key(prop.name):
@@ -485,7 +485,7 @@ class SDBManager(object):
     def get_object(self, cls, id, a=None):
         obj = None
         if not a:
-            a = self.domain.get_attributes(id,consistent_read=self.consistent)
+            a = self.domain.get_attributes(id, consistent_read=self.consistent)
         if a.has_key('__type__'):
             if not cls or a['__type__'] != cls.__name__:
                 cls = find_class(a['__module__'], a['__type__'])
@@ -534,7 +534,7 @@ class SDBManager(object):
         if name != "itemName()":
             name = '`%s`' % name
         if val == None:
-            if op in ('is','='):
+            if op in ('is', '='):
                 return "%(name)s is null" % {"name": name}
             elif op in ('is not', '!='):
                 return "%s is not null" % name
@@ -698,7 +698,7 @@ class SDBManager(object):
         self.domain.put_attributes(obj.id, {name : value}, replace=True)
 
     def get_property(self, prop, obj, name):
-        a = self.domain.get_attributes(obj.id,consistent_read=self.consistent)
+        a = self.domain.get_attributes(obj.id, consistent_read=self.consistent)
 
         # try to get the attribute value from SDB
         if name in a:
@@ -715,7 +715,7 @@ class SDBManager(object):
         self.domain.delete_attributes(obj.id, name)
 
     def get_key_value(self, obj, name):
-        a = self.domain.get_attributes(obj.id, name,consistent_read=self.consistent)
+        a = self.domain.get_attributes(obj.id, name, consistent_read=self.consistent)
         if a.has_key(name):
             return a[name]
         else:

--- a/boto/sdb/db/property.py
+++ b/boto/sdb/db/property.py
@@ -488,7 +488,7 @@ class ReferenceProperty(Property):
         This causes bad things to happen"""
         if value != None and (obj.id == value or (hasattr(value, "id") and obj.id == value.id)):
             raise ValueError, "Can not associate an object with itself!"
-        return super(ReferenceProperty, self).__set__(obj,value)
+        return super(ReferenceProperty, self).__set__(obj, value)
 
     def __property_config__(self, model_class, property_name):
         Property.__property_config__(self, model_class, property_name)
@@ -643,7 +643,7 @@ class ListProperty(Property):
             value = [value]
         elif value == None: # Override to allow them to set this to "None" to remove everything
             value = []
-        return super(ListProperty, self).__set__(obj,value)
+        return super(ListProperty, self).__set__(obj, value)
 
 
 class MapProperty(Property):

--- a/boto/sdb/db/test_db.py
+++ b/boto/sdb/db/test_db.py
@@ -153,7 +153,7 @@ def test_list():
     t = TestList()
     _objects['test_list_t'] = t
     t.name = 'a list of ints'
-    t.nums = [1,2,3,4,5]
+    t.nums = [1, 2, 3, 4, 5]
     t.put()
     tt = TestList.get_by_id(t.id)
     _objects['test_list_tt'] = tt

--- a/boto/swf/layer1.py
+++ b/boto/swf/layer1.py
@@ -62,7 +62,7 @@ class Layer1(AWSAuthConnection):
         'com.amazonaws.swf.base.model#OperationNotPermittedFault':
             swf_exceptions.SWFOperationNotPermittedError,
         'com.amazonaws.swf.base.model#TypeAlreadyExistsFault':
-            swf_exceptions.SWFTypeAlreadyExistsError ,
+            swf_exceptions.SWFTypeAlreadyExistsError,
     }
 
     ResponseError = SWFResponseError

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -133,7 +133,7 @@ def canonical_string(method, path, headers, expires=None,
         qsa = [ a.split('=', 1) for a in qsa]
         qsa = [ unquote_v(a) for a in qsa if a[0] in qsa_of_interest ]
         if len(qsa) > 0:
-            qsa.sort(cmp=lambda x,y:cmp(x[0], y[0]))
+            qsa.sort(cmp=lambda x, y:cmp(x[0], y[0]))
             qsa = [ '='.join(a) for a in qsa ]
             buf += '?'
             buf += '&'.join(qsa)
@@ -225,7 +225,7 @@ def get_instance_metadata(version='latest', url='http://169.254.169.254'):
 
 def get_instance_userdata(version='latest', sep=None,
                           url='http://169.254.169.254'):
-    ud_url = '%s/%s/user-data' % (url,version)
+    ud_url = '%s/%s/user-data' % (url, version)
     user_data = retry_url(ud_url, retry_on_404=False)
     if user_data:
         if sep:
@@ -651,7 +651,7 @@ def write_mime_multipart(content, compress=False, deftype='text/plain', delimite
     :rtype: str:
     """
     wrapper = MIMEMultipart()
-    for name,con in content:
+    for name, con in content:
         definite_type = guess_mime_type(con, deftype)
         maintype, subtype = definite_type.split('/', 1)
         if maintype == 'text':
@@ -697,7 +697,7 @@ def guess_mime_type(content, deftype):
         '#cloud-boothook' : 'text/cloud-boothook'
     }
     rtype = deftype
-    for possible_type,mimetype in starts_with_mappings.items():
+    for possible_type, mimetype in starts_with_mappings.items():
         if content.startswith(possible_type):
             rtype = mimetype
             break

--- a/tests/db/test_lists.py
+++ b/tests/db/test_lists.py
@@ -46,13 +46,13 @@ class TestLists(object):
     def test_list_order(self):
         """Testing the order of lists"""
         t = SimpleListModel()
-        t.nums = [5,4,1,3,2]
+        t.nums = [5, 4, 1, 3, 2]
         t.strs = ["B", "C", "A", "D", "Foo"]
         t.put()
         self.objs.append(t)
         time.sleep(3)
         t = SimpleListModel.get_by_id(t.id)
-        assert(t.nums == [5,4,1,3,2])
+        assert(t.nums == [5, 4, 1, 3, 2])
         assert(t.strs == ["B", "C", "A", "D", "Foo"])
 
     def test_old_compat(self):
@@ -82,7 +82,7 @@ class TestLists(object):
         time.sleep(3)
         assert(SimpleListModel.find(strs="Bizzle").count() == 1)
         assert(SimpleListModel.find(strs="Bar").count() == 1)
-        assert(SimpleListModel.find(strs=["Bar","Bizzle"]).count() == 1)
+        assert(SimpleListModel.find(strs=["Bar", "Bizzle"]).count() == 1)
 
     def test_query_not_equals(self):
         """Test a not equal filter"""

--- a/tests/db/test_password.py
+++ b/tests/db/test_password.py
@@ -81,7 +81,7 @@ class PasswordPropertyTest(unittest.TestCase):
         id= obj.id
         time.sleep(5)
         obj = MyModel.get_by_id(id)
-        self.assertEquals(obj.password,'bar')
+        self.assertEquals(obj.password, 'bar')
         self.assertEquals(str(obj.password), expected)
                           #hmac.new('mysecret','bar').hexdigest())
  
@@ -98,7 +98,7 @@ class PasswordPropertyTest(unittest.TestCase):
 
     def test_password_constructor_hashfunc(self):
         import hmac
-        myhashfunc=lambda msg: hmac.new('mysecret',msg)
+        myhashfunc=lambda msg: hmac.new('mysecret', msg)
         cls = self.test_model(hashfunc=myhashfunc)
         obj = cls()
         obj.password='hello'

--- a/tests/db/test_sequence.py
+++ b/tests/db/test_sequence.py
@@ -69,7 +69,7 @@ class TestDBHandler(object):
         assert(s2.val == 3)
 
     def test_sequence_simple_string(self):
-        from boto.sdb.db.sequence import Sequence,increment_string
+        from boto.sdb.db.sequence import Sequence, increment_string
         s = Sequence(fnc=increment_string)
         self.sequences.append(s)
         assert(s.val == "A")
@@ -80,26 +80,26 @@ class TestDBHandler(object):
         from boto.sdb.db.sequence import fib
         # Just check the first few numbers in the sequence
         lv = 0
-        for v in [1,2,3,5,8,13,21,34,55,89,144]:
-            assert(fib(v,lv) == lv+v)
-            lv = fib(v,lv)
+        for v in [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144]:
+            assert(fib(v, lv) == lv+v)
+            lv = fib(v, lv)
 
     def test_sequence_fib(self):
         """Test the fibonacci sequence"""
-        from boto.sdb.db.sequence import Sequence,fib
+        from boto.sdb.db.sequence import Sequence, fib
         s = Sequence(fnc=fib)
         s2 = Sequence(s.id)
         self.sequences.append(s)
         assert(s.val == 1)
         # Just check the first few numbers in the sequence
-        for v in [1,2,3,5,8,13,21,34,55,89,144]:
+        for v in [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144]:
             assert(s.next() == v)
             assert(s.val == v)
             assert(s2.val == v) # it shouldn't matter which reference we use since it's garunteed to be consistent
 
     def test_sequence_string(self):
         """Test the String incrementation sequence"""
-        from boto.sdb.db.sequence import Sequence,increment_string
+        from boto.sdb.db.sequence import Sequence, increment_string
         s = Sequence(fnc=increment_string)
         self.sequences.append(s)
         assert(s.val == "A")

--- a/tests/dynamodb/test_layer2.py
+++ b/tests/dynamodb/test_layer2.py
@@ -274,7 +274,7 @@ class DynamoDBLayer2Test (unittest.TestCase):
         item3['FalseBoolean'] = False
 
         # Test some set values
-        integer_set = set([1,2,3,4,5])
+        integer_set = set([1, 2, 3, 4, 5])
         float_set = set([1.1, 2.2, 3.3, 4.4, 5.5])
         mixed_set = set([1, 2, 3.3, 4, 5.555])
         str_set = set(['foo', 'bar', 'fie', 'baz'])

--- a/tests/mturk/create_hit_external.py
+++ b/tests/mturk/create_hit_external.py
@@ -10,7 +10,7 @@ class Test(unittest.TestCase):
 		q = ExternalQuestion(external_url=external_url, frame_height=800)
 		conn = SetHostMTurkConnection()
 		keywords=['boto', 'test', 'doctest']
-		create_hit_rs = conn.create_hit(question=q, lifetime=60*65,max_assignments=2,title="Boto External Question Test", keywords=keywords,reward = 0.05, duration=60*6,approval_delay=60*60, annotation='An annotation from boto external question test', response_groups=['Minimal','HITDetail','HITQuestion','HITAssignmentSummary',])
+		create_hit_rs = conn.create_hit(question=q, lifetime=60*65, max_assignments=2, title="Boto External Question Test", keywords=keywords, reward = 0.05, duration=60*6, approval_delay=60*60, annotation='An annotation from boto external question test', response_groups=['Minimal', 'HITDetail', 'HITQuestion', 'HITAssignmentSummary',])
 		assert(create_hit_rs.status == True)
 
 if __name__ == "__main__":

--- a/tests/mturk/create_hit_with_qualifications.py
+++ b/tests/mturk/create_hit_with_qualifications.py
@@ -8,7 +8,7 @@ def test():
     keywords=['boto', 'test', 'doctest']
     qualifications = Qualifications()
     qualifications.add(PercentAssignmentsApprovedRequirement(comparator="GreaterThan", integer_value="95"))
-    create_hit_rs = conn.create_hit(question=q, lifetime=60*65,max_assignments=2,title="Boto External Question Test", keywords=keywords,reward = 0.05, duration=60*6,approval_delay=60*60, annotation='An annotation from boto external question test', qualifications=qualifications)
+    create_hit_rs = conn.create_hit(question=q, lifetime=60*65, max_assignments=2, title="Boto External Question Test", keywords=keywords, reward = 0.05, duration=60*6, approval_delay=60*60, annotation='An annotation from boto external question test', qualifications=qualifications)
     assert(create_hit_rs.status == True)
     print create_hit_rs.HITTypeId
 

--- a/tests/mturk/support.py
+++ b/tests/mturk/support.py
@@ -1,8 +1,7 @@
-
 import sys
 
 # use unittest2 under Python 2.6 and earlier.
-if sys.version_info >= (2,7):
-	import unittest
+if sys.version_info >= (2, 7):
+    import unittest
 else:
-	import unittest2 as unittest
+    import unittest2 as unittest

--- a/tests/s3/test_gsconnection.py
+++ b/tests/s3/test_gsconnection.py
@@ -92,7 +92,7 @@ class GSConnectionTest (unittest.TestCase):
         fp = open('foobar1', 'wb')
         k.get_contents_to_file(fp)
         fp.close()
-        fp2.seek(0,0)
+        fp2.seek(0, 0)
         fp = open('foobar1', 'rb')
         assert (fp2.read() == fp.read()), 'Chunked Transfer corrupted the Data'
         fp.close()

--- a/tests/s3/test_key.py
+++ b/tests/s3/test_key.py
@@ -136,7 +136,7 @@ class S3KeyTest (unittest.TestCase):
         # let's try a wrong md5 by just altering it.
         k = self.bucket.new_key("k")
         sfp.seek(0)
-        hexdig,base64 = k.compute_md5(sfp)
+        hexdig, base64 = k.compute_md5(sfp)
         bad_md5 = (hexdig, base64[3:])
         try:
             k.set_contents_from_file(sfp, md5=bad_md5)

--- a/tests/s3/test_mfa.py
+++ b/tests/s3/test_mfa.py
@@ -51,7 +51,7 @@ class S3MFATest (unittest.TestCase):
 
         # Check enabling mfa worked.
         i = 0
-        for i in range(1,8):
+        for i in range(1, 8):
             time.sleep(2**i)
             d = self.bucket.get_versioning_status()
             if d['Versioning'] == 'Enabled' and d['MfaDelete'] == 'Enabled':
@@ -82,7 +82,7 @@ class S3MFATest (unittest.TestCase):
 
         # Lastly, check disabling mfa worked.
         i = 0
-        for i in range(1,8):
+        for i in range(1, 8):
             time.sleep(2**i)
             d = self.bucket.get_versioning_status()
             if d['Versioning'] == 'Suspended' and d['MfaDelete'] != 'Enabled':

--- a/tests/s3/test_multidelete.py
+++ b/tests/s3/test_multidelete.py
@@ -150,7 +150,7 @@ class S3MultiDeleteTest (unittest.TestCase):
         nkeys = 100
         
         # create a bunch of keynames
-        key_names = ['key-%03d' % i for i in range(0,nkeys)]
+        key_names = ['key-%03d' % i for i in range(0, nkeys)]
 
         # create the corresponding keys
         for key_name in key_names:

--- a/tests/utils/test_password.py
+++ b/tests/utils/test_password.py
@@ -28,23 +28,23 @@ log = logging.getLogger(__file__)
 class TestPassword(unittest.TestCase):
     """Test basic password functionality"""
     
-    def clstest(self,cls):
+    def clstest(self, cls):
 
         """Insure that password.__eq__ hashes test value before compare"""
 
         password=cls('foo')
         log.debug( "Password %s" % password )
-        self.assertNotEquals(password , 'foo')
+        self.assertNotEquals(password, 'foo')
 
         password.set('foo')
         hashed = str(password)
-        self.assertEquals(password , 'foo')
+        self.assertEquals(password, 'foo')
         self.assertEquals(password.str, hashed)
 
         password = cls(hashed)
-        self.assertNotEquals(password.str , 'foo')
-        self.assertEquals(password , 'foo')
-        self.assertEquals(password.str , hashed)
+        self.assertNotEquals(password.str, 'foo')
+        self.assertEquals(password, 'foo')
+        self.assertEquals(password.str, hashed)
 
  
     def test_aaa_version_1_9_default_behavior(self):
@@ -67,7 +67,7 @@ class TestPassword(unittest.TestCase):
         from boto.utils import Password
         import hmac
 
-        def hmac_hashfunc(cls,msg):
+        def hmac_hashfunc(cls, msg):
             log.debug("\n%s %s" % (cls.__class__, cls) )
             return hmac.new('mysecretkey', msg)
 
@@ -78,7 +78,7 @@ class TestPassword(unittest.TestCase):
         password=HMACPassword()
         password.set('foo')
   
-        self.assertEquals(str(password), hmac.new('mysecretkey','foo').hexdigest())
+        self.assertEquals(str(password), hmac.new('mysecretkey', 'foo').hexdigest())
 
     def test_constructor(self):
         from boto.utils import Password
@@ -88,7 +88,7 @@ class TestPassword(unittest.TestCase):
 
         password = Password(hashfunc=hmac_hashfunc)
         password.set('foo')
-        self.assertEquals(password.str, hmac.new('mysecretkey','foo').hexdigest())
+        self.assertEquals(password.str, hmac.new('mysecretkey', 'foo').hexdigest())
 
         
        


### PR DESCRIPTION
A bunch of code had too many or too few spaces in it to satisfy pep8.  This commit adds or removes enough of them to ensure that the correct number is there.
