### PR TITLE
Reset response to None when following a redirect.

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -782,6 +782,7 @@ class AWSAuthConnection(object):
                     boto.log.debug(msg)
                     connection = self.get_http_connection(request.host,
                                                           scheme == 'https')
+                    response = None
                     continue
             except self.http_exceptions, e:
                 for unretryable in self.http_unretryable_exceptions:


### PR DESCRIPTION
- if a request which follows a redirect throws a HTTPException
  and we're out of retries, the real exception is hidden because
  the response from the previous redirect is still set. Resetting
  the response to None, allows us to see any real exception.
