### PR TITLE
Enable use of https_connection_factory for non-secure connections also.

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -625,7 +625,13 @@ class AWSAuthConnection(object):
         else:
             boto.log.debug('establishing HTTP connection: kwargs=%s' %
                     self.http_connection_kwargs)
-            connection = httplib.HTTPConnection(host,
+            if self.https_connection_factory:
+                # even though the factory says https, this is too handy
+                # to not be able to allow overriding for http also.
+                connection = self.https_connection_factory(host,
+                    **self.http_connection_kwargs)
+            else:
+                connection = httplib.HTTPConnection(host,
                     **self.http_connection_kwargs)
         if self.debug > 1:
             connection.set_debuglevel(self.debug)


### PR DESCRIPTION
- It's extremely nice to be able to overload the http connection object
  and since this  parameter already exists for https, its nice to be
  able to reuse it without adding yet another parameter. Can't rename
  it more generally though as there are probably many users.
