### PR TITLE
_get_instance_metadata: quote components in url requests

### DIFF
--- a/boto/utils.py
+++ b/boto/utils.py
@@ -238,7 +238,8 @@ def _get_instance_metadata(url, num_retries):
                     resource = field[0:p] + '/openssh-key'
                 else:
                     key = resource = field
-                val = retry_url(url + resource, num_retries=num_retries)
+                val = retry_url(url + urllib.quote(resource, safe="/:"),
+                                num_retries=num_retries)
                 if val[0] == '{':
                     val = json.loads(val)
                 else:


### PR DESCRIPTION
This addresses Issue 659 by having urllib.quote escape each component of the
metadata in a url before making the request.

This issue was seen in a openstack metadata where some user supplied strings
(specifically, 'keyname') contained spaces and were presented as a key in
the metadata service.  That caused boto to make invalid requests to the server
when trying to crawl those fields.

Some things to note about this change:
- '/' and ':' are explicitly not escaped.  The mac addresses presented
  in 'macs' field will have a : in them, so that is ignored.
- only portions of the metadata service returned are escaped.  The initial
  url passed in will not be modified.
- At this point I'm not aware of any actual content in the EC2 metadata
  service that would need escaping.
