### PR TITLE
get_metric_statistics should pass 'Unit' parameter.

### DIFF
--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -223,6 +223,8 @@ class CloudWatchConnection(AWSQueryConnection):
         self.build_list_params(params, statistics, 'Statistics.member.%d')
         if dimensions:
             self.build_dimension_param(dimensions, params)
+        if unit:
+            params['Unit'] = unit
         return self.get_list('GetMetricStatistics', params,
                              [('member', Datapoint)])
 


### PR DESCRIPTION
Currently, get_metric_statistics request does not pass 'Unit' parameter while it is specified in CloudWatch API reference.
