### PR TITLE
Updated SNS implementation to be more consistent with other implementati...

### DIFF
--- a/boto/sns/attributes.py
+++ b/boto/sns/attributes.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2012 Derek McGowan
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+"""
+Represents an SNS Attribute Name/Value set
+"""
+
+class Attributes(dict):
+    
+    def __init__(self, parent):
+        self.parent = parent
+        self.current_key = None
+        self.current_value = None
+
+    def startElement(self, name, attrs, connection):
+        pass
+
+    def endElement(self, name, value, connection):
+        if name == 'entry':
+            self[self.current_key] = self.current_value
+        elif name == 'key':
+            self.current_key = value
+        elif name == 'value':
+            self.current_value = value
+        else:
+            setattr(self, name, value)
+
+        

--- a/boto/sns/result.py
+++ b/boto/sns/result.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2012 Derek McGowan
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+"""
+Represents the result from an SNS publish
+"""
+
+class PublishResult(dict):
+    def __init__(self, connection):
+        self.connection = connection
+    
+    def startElement(self, name, attrs, connection):
+        return None
+
+    def endElement(self, name, value, connection):
+        if name == 'MessageId':
+            self['message_id'] = value
+    
+    def __repr__(self):
+        return 'PublishResult(%s)' % self['message_id']

--- a/boto/sns/subscription.py
+++ b/boto/sns/subscription.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2012 Derek McGowan
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+"""
+An SNS subscription
+"""
+
+from topic import Topic
+
+class Subscription:
+    def __init__(self, connection = None, arn = None):
+        self.connection = connection
+        self.arn = arn
+    
+    def startElement(self, name, attrs, connection):
+        return None
+
+    def endElement(self, name, value, connection):
+        if name == 'SubscriptionArn':
+            self.arn = value
+        elif name == 'TopicArn':
+            self.topic = Topic(arn=value)
+        elif name == 'Protocol':
+            self.protocol = value
+        elif name == 'Endpoint':
+            self.endpoint = value
+        elif name == 'Owner':
+            self.owner = value
+        else:
+            setattr(self, name, value)
+            
+    def __repr__(self):
+        return 'Subscription(%s)' % self.arn
+    
+    def unsubscribe(self):
+        """
+        Unsubscribe this subscription
+        """
+        self.connection.unsubscribe(self)
+        

--- a/boto/sns/topic.py
+++ b/boto/sns/topic.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2012 Derek McGowan
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+"""
+Represents an SQS Topic
+"""
+
+class Topic:
+  
+    def __init__(self, connection=None, arn=None):
+        self.connection = connection
+        self.arn = arn
+        
+    
+    def __repr__(self):
+        return 'Topic(%s)' % self.arn
+    
+    def startElement(self, name, attrs, connection):
+        return None
+
+    def endElement(self, name, value, connection):
+        if name == 'TopicArn':
+            self.arn = value
+        else:
+            setattr(self, name, value)
+            
+    def get_attributes(self):
+        """
+        Retrieves attributes about this topic
+        """
+        return self.connection.get_topic_attributes(self)
+    
+    def set_attribute(self, attribute, value):
+        """
+        Set a new value for an attribute of the Topic.
+        
+        :type topic: string
+        :param topic: The ARN of the topic.
+
+        :type attr_name: string
+        :param attr_name: The name of the attribute you want to set.
+                          Only a subset of the topic's attributes are mutable.
+                          Valid values: Policy | DisplayName
+
+        :type attr_value: string
+        :param attr_value: The new value for the attribute.
+        """
+        return self.connection.set_topic_attributes(self, attribute, value)
+    
+    def delete(self):
+        """
+        Delete the topic.
+        """
+        return self.connection.delete_topic(self)
+    
+    def subscribe(self, protocol, endpoint):
+        """
+        Subscribes endpoint to the topic
+        """
+        return self.connection.subscribe(self, protocol, endpoint)
+    
+    def subscribe_sqs_queue(self, queue):
+        """
+        Subscribes sqs queue to the topic
+        """
+        return self.connection.subscribe_sqs_queue(self, queue)
+    
+    def publish(self, message, subject=None):
+        """
+        Publishes message to topic
+        """
+        return self.connection.publish(self, message, subject)
+    
+    def add_permission(self, label, account_ids, actions):
+        """
+        Adds a statement to a topic's access control policy, granting
+        access for the specified AWS accounts to the specified actions.
+        
+        :type label: string
+        :param label: A unique identifier for the new policy statement.
+
+        :type account_ids: list of strings
+        :param account_ids: The AWS account ids of the users who will be
+                            give access to the specified actions.
+
+        :type actions: list of strings
+        :param actions: The actions you want to allow for each of the
+                        specified principal(s).
+        """
+        self.connection.add_permission(self, label, account_ids, actions)
+        
+    def remove_permission(self, label):
+        """
+        Removes a statement from a topic's access control policy.
+
+        :type label: string
+        :param label: A unique identifier for the policy statement
+                      to be removed.
+        """
+        self.connection.remove_permission(self, label)
+        

--- a/boto/sqs/connection.py
+++ b/boto/sqs/connection.py
@@ -64,8 +64,7 @@ class SQSConnection(AWSQueryConnection):
         if response.status != 401:
             return False
         try:
-            for event, node in ElementTree.iterparse(response,
-                                                     events=['start']):
+            for _, node in ElementTree.iterparse(response, events=['start']):
                 if node.tag.endswith('Code'):
                     if node.text == 'InvalidAccessKeyId':
                         return True
@@ -123,14 +122,14 @@ class SQSConnection(AWSQueryConnection):
         """
         return self.get_status('DeleteQueue', None, queue.id)
 
-    def get_queue_attributes(self, queue, attribute='All'):
+    def get_queue_attributes(self, queue, attributes='All'):
         """
         Gets one or all attributes of a Queue
 
         :type queue: A Queue object
         :param queue: The SQS queue to be deleted
 
-        :type attribute: str
+        :type attribute: str or list
         :type attribute: The specific attribute requested.  If not
             supplied, the default is to return all attributes.  Valid
             attributes are:
@@ -145,7 +144,14 @@ class SQSConnection(AWSQueryConnection):
         :rtype: :class:`boto.sqs.attributes.Attributes`
         :return: An Attributes object containing request value(s).
         """
-        params = {'AttributeName' : attribute}
+        if isinstance(attributes, list):
+            params = {}
+            i = 1
+            for attribute in attributes:
+                params['AttributeName.'+str(i)] = attribute 
+                i = i+1
+        else:
+            params = {'AttributeName.1' : attributes}
         return self.get_object('GetQueueAttributes', params,
                                Attributes, queue.id)
 


### PR DESCRIPTION
I updated the SNS implementation to not use ContentType=JSON and instead use separate objects representing the return data types (such as how SQS is implemented).  I was running into issues when using boto with a mock SNS service which we setup to return XML as defined in the AWS documentation.  I could not find any place in the AWS documention that mentioned support for ContentType.  Subsequently I will update the SNS documentation to include a tutorial similar to SQS's which specifies which objects can be returned and how to use them.
