### PR TITLE
Fix failing tests from pull request #825

### DIFF
--- a/tests/unit/cloudfront/test_signed_urls.py
+++ b/tests/unit/cloudfront/test_signed_urls.py
@@ -194,7 +194,8 @@ class CloudfrontSignedUrlsTest(unittest.TestCase):
         resource = statement["Resource"]
         self.assertEqual(url, resource)
         condition = statement["Condition"]
-        self.assertEqual(1, len(condition.keys()))
+        self.assertEqual(2, len(condition.keys()))
+        date_less_than = condition["DateLessThan"]
         date_greater_than = condition["DateGreaterThan"]
         self.assertEqual(1, len(date_greater_than.keys()))
         aws_epoch_time = date_greater_than["AWS:EpochTime"]
@@ -217,8 +218,9 @@ class CloudfrontSignedUrlsTest(unittest.TestCase):
         resource = statement["Resource"]
         self.assertEqual(url, resource)
         condition = statement["Condition"]
-        self.assertEqual(1, len(condition.keys()))
+        self.assertEqual(2, len(condition.keys()))
         ip_address = condition["IpAddress"]
+        self.assertTrue("DateLessThan" in condition)
         self.assertEqual(1, len(ip_address.keys()))
         source_ip = ip_address["AWS:SourceIp"]
         self.assertEqual("%s/32" % ip_range, source_ip)
@@ -240,7 +242,8 @@ class CloudfrontSignedUrlsTest(unittest.TestCase):
         resource = statement["Resource"]
         self.assertEqual(url, resource)
         condition = statement["Condition"]
-        self.assertEqual(1, len(condition.keys()))
+        self.assertEqual(2, len(condition.keys()))
+        self.assertTrue("DateLessThan" in condition)
         ip_address = condition["IpAddress"]
         self.assertEqual(1, len(ip_address.keys()))
         source_ip = ip_address["AWS:SourceIp"]


### PR DESCRIPTION
When I pulled in the latest changes today these tests started
failing for me:

```
======================================================================
FAIL: Test that a custom policy can be created with an IP address and
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jamessar/Source/boto/tests/unit/cloudfront/test_signed_urls.py", line 220, in test_custom_policy_ip_address
    self.assertEqual(1, len(condition.keys()))
AssertionError: 1 != 2

======================================================================
FAIL: Test that a custom policy can be created with an IP address and
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jamessar/Source/boto/tests/unit/cloudfront/test_signed_urls.py", line 243, in test_custom_policy_ip_range
    self.assertEqual(1, len(condition.keys()))
AssertionError: 1 != 2

======================================================================
FAIL: Test that a custom policy can be created with a valid-after time and
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jamessar/Source/boto/tests/unit/cloudfront/test_signed_urls.py", line 197, in test_custom_policy_valid_after
    self.assertEqual(1, len(condition.keys()))
AssertionError: 1 != 2

----------------------------------------------------------------------
Ran 14 tests in 0.057s

FAILED (failures=3)
```

I believe the tests just need to be udpated to account for the
new "DateLessThan" field added in commit
fcb68be57c735cd8281be4a5bc2d64053ac7090d.
