### PR TITLE
Py26 compat for ec2.test_volume

### DIFF
--- a/tests/unit/ec2/test_volume.py
+++ b/tests/unit/ec2/test_volume.py
@@ -1,5 +1,5 @@
 import mock
-import unittest
+from tests.unit import unittest
 
 from boto.ec2.snapshot import Snapshot
 from boto.ec2.tag import Tag, TagSet


### PR DESCRIPTION
These tests are great, they just need a small tweak so that they can run with
python 2.6 and 2.7.  The python2.6 unittest does not have
assertRaisesRegexp, so it needs to use unittest2, which
tests.unit.unittest will refer to if available.

```
======================================================================
ERROR: test_update_with_validate_true_raises_value_error (tests.unit.ec2.test_volume.VolumeTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jamessar/Source/boto/tests/unit/ec2/test_volume.py", line 111, in test_update_with_validate_true_raises_value_error
    with self.assertRaisesRegexp(ValueError, "^1 is not a valid Volume ID$"):
AttributeError: 'VolumeTests' object has no attribute 'assertRaisesRegexp'

----------------------------------------------------------------------
Ran 91 tests in 0.196s

FAILED (errors=1)
```
