### PR TITLE
Check type of raw_message before encoding

### DIFF
--- a/boto/ses/connection.py
+++ b/boto/ses/connection.py
@@ -294,8 +294,12 @@ class SESConnection(AWSAuthConnection):
         :param destinations: A list of destinations for the message.
 
         """
+
+        if isinstance(raw_message, unicode):
+            raw_message = raw_message.encode('utf-8')
+
         params = {
-            'RawMessage.Data': base64.b64encode(raw_message.encode('utf-8')),
+            'RawMessage.Data': base64.b64encode(raw_message),
         }
 
         if source:


### PR DESCRIPTION
The type of raw_message needs to be checked before encoding — it may already be a utf-8 encoded string.

Django, for example, will convert the message to a bytestring before passing it to the email backend.
