### PR TITLE
utils.py: Add guard for blank responses to get-instance-metadata

### DIFF
--- a/boto/utils.py
+++ b/boto/utils.py
@@ -251,7 +251,7 @@ class LazyLoadMetadata(dict):
             val = boto.utils.retry_url(self._url + urllib.quote(resource,
                                                                 safe="/:"),
                                        num_retries=self._num_retries)
-            if val[0] == '{':
+            if val and val[0] == '{':
                 val = json.loads(val)
             else:
                 p = val.find('\n')


### PR DESCRIPTION
Blank responses or '404' returns from retry_url - all of which return an empty string cause an 'Index out of range' Exception in get-instance-metadata causing the entire tree to fail.

Just need to add a guard before the val[0] check.
