### PR TITLE
str() http params in sigv4 implementation

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -315,7 +315,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         parameter_names = sorted(http_request.params.keys())
         pairs = []
         for pname in parameter_names:
-            pval = http_request.params[pname].encode('utf-8')
+            pval = str(http_request.params[pname]).encode('utf-8')
             pairs.append(urllib.quote(pname, safe='') + '=' +
                          urllib.quote(pval, safe='-_~'))
         return '&'.join(pairs)
@@ -323,7 +323,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
     def canonical_query_string(self, http_request):
         l = []
         for param in http_request.params:
-            value = http_request.params[param]
+            value = str(http_request.params[param])
             l.append('%s=%s' % (urllib.quote(param, safe='/~'),
                                 urllib.quote(value, safe='/~')))
         l = sorted(l)


### PR DESCRIPTION
This accommodates any non str params for sigv4. The particular issue I was
running into was cloudformation support for sigv4 where the TimeoutInMinutes
param was causing this code to raise an exception.

Unittests pass, and I ran the ec2/dynamodb tests as well:

```
$ python test.py -t dynamodb
nose command: test.py -a !notdefault,dynamodb
..
----------------------------------------------------------------------
Ran 2 tests in 201.559s

OK
```

```
$ python test.py -t ec2
nose command: test.py -a !notdefault,ec2
..................
----------------------------------------------------------------------
Ran 18 tests in 244.276s

OK
```
