### PR TITLE
attempt to fix up confusing documentation in cloudwatch

### DIFF
--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -263,7 +263,7 @@ class CloudWatchConnection(AWSQueryConnection):
             retrieve the next page of metrics.
 
         :type dimension: dict
-        :param dimension_filters: A dictionary containing name/value
+        :param dimensions: A dictionary containing name/value
             pairs that will be used to filter the results.  The key in
             the dictionary is the name of a Dimension.  The value in
             the dictionary is either a scalar value of that Dimension


### PR DESCRIPTION
the args to list_metrics() contain 'dimensions' but no 'dimension_filters'.

this is probably just a copy/paste error, but I'm not %100 sure my fix is correct.
