### PR TITLE
fix #869 in boto/boto for tab delimiter output in list_instances

### DIFF
--- a/bin/list_instances
+++ b/bin/list_instances
@@ -33,6 +33,7 @@ def main():
     parser = OptionParser()
     parser.add_option("-r", "--region", help="Region (default us-east-1)", dest="region", default="us-east-1")
     parser.add_option("-H", "--headers", help="Set headers (use 'T:tagname' for including tags)", default=None, action="store", dest="headers", metavar="ID,Zone,Groups,Hostname,State,T:Name")
+    parser.add_option("-t", "--tab", help="Tab delimited, skip header - useful in shell scripts", action="store_true", default=False)
     (options, args) = parser.parse_args()
 
     # Connect the region
@@ -61,13 +62,20 @@ def main():
 
 
     # List and print
-    print format_string % headers
-    print "-" * len(format_string % headers)
+
+    if not options.tab:
+        print format_string % headers
+        print "-" * len(format_string % headers)
+
     for r in ec2.get_all_instances():
         groups = [g.name for g in r.groups]
         for i in r.instances:
             i.groups = ','.join(groups)
-            print format_string % tuple(get_column(h, i) for h in headers)
+            if options.tab: 
+                print "\t".join(tuple(get_column(h, i) for h in headers))
+            else:
+                print format_string % tuple(get_column(h, i) for h in headers)
+ 
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Most sysadmins don't care about pretty printing list_instances but want to be able to parse it via awk grep etc.

Certain fixed width assumptions are wrong and not scalable as amazon adds new regions.
e.g. non parsable output for some regions

<pre>
$ list_instances -r ap-southeast-1
ID             Zone           Groups                        Hostname                                          
--------------------------------------------------------------------------------------------------------------
i-xxxxxxxx     ap-southeast-1bweb                           xyx
i-xxxxxxxx     ap-southeast-1aweb                           xyz
</pre>


So made a patch to print tab delimited  output
