### PR TITLE
Fixed DescribeDomains when domain_names is provided

### DIFF
--- a/boto/cloudsearch/layer1.py
+++ b/boto/cloudsearch/layer1.py
@@ -397,8 +397,8 @@ class Layer1(AWSQueryConnection):
                     'describe_domains_result',
                     'domain_status_list')
         params = {}
-        if domain_names:
-            params['DomainNames'] = domain_names
+        for i, domain in enumerate(domain_names, 1):
+            params['Domains.members.%d' % (i,)] = domain
         return self.get_response(doc_path, 'DescribeDomains',
                                  params, verb='POST',
                                  list_marker='DomainStatusList')


### PR DESCRIPTION
layer1.describe_domains() didn't convert the domain_names list into
the formatting that AWS seems to require as per the API
docs around DescribeDomains.
