### PR TITLE
CloudSearch - Fix Describe* MalformedInput Error

### DIFF
--- a/boto/cloudsearch/layer1.py
+++ b/boto/cloudsearch/layer1.py
@@ -397,8 +397,9 @@ class Layer1(AWSQueryConnection):
                     'describe_domains_result',
                     'domain_status_list')
         params = {}
-        if domain_names:
-            params['DomainNames'] = domain_names
+        if domain_names is not None:
+            for i, domain_name in enumerate(domain_names, 1):
+                params['DomainNames.members.%d' % (i,)] = domain_name
         return self.get_response(doc_path, 'DescribeDomains',
                                  params, verb='POST',
                                  list_marker='DomainStatusList')
@@ -426,8 +427,9 @@ class Layer1(AWSQueryConnection):
                     'describe_index_fields_result',
                     'index_fields')
         params = {'DomainName': domain_name}
-        if field_names:
-            params['FieldNames'] = field_names
+        if field_names is not None:
+            for i, field_name in enumerate(field_names, 1):
+                params['FieldNames.members.%d' % (i,)] = field_name
         return self.get_response(doc_path, 'DescribeIndexFields',
                                  params, verb='POST',
                                  list_marker='IndexFields')
@@ -455,8 +457,9 @@ class Layer1(AWSQueryConnection):
                     'describe_rank_expressions_result',
                     'rank_expressions')
         params = {'DomainName': domain_name}
-        if rank_names:
-            params['RankNames'] = rank_names
+        if rank_names is not None:
+            for i, rank_name in enumerate(rank_names, 1):
+                params['RankNames.members.%d' % (i,)] = rank_name
         return self.get_response(doc_path, 'DescribeRankExpressions',
                                  params, verb='POST',
                                  list_marker='RankExpressions')


### PR DESCRIPTION
The following functions all use "member lists":

layer1.describe_domains()
layer1.describe_index_fields()
layer1.describe_rank_expressions()

and as such will give you this when their optional
list specifying one or more individuals is attempted:

  <Error>
    <Type>Sender</Type>
    <Code>MalformedInput</Code>
    <Message>Unexpected list element termination</Message>
  </Error>

They were converted to send FOO.members.N and now
work as expected from the amazon cloudsearch api docs.
