### PR TITLE
Fix SNS add_permission parameter names

### DIFF
--- a/boto/sns/connection.py
+++ b/boto/sns/connection.py
@@ -155,8 +155,8 @@ class SNSConnection(AWSQueryConnection):
         params = {'ContentType' : 'JSON',
                   'TopicArn' : topic,
                   'Label' : label}
-        self.build_list_params(params, account_ids, 'AWSAccountId')
-        self.build_list_params(params, actions, 'ActionName')
+        self.build_list_params(params, account_ids, 'AWSAccountId.member')
+        self.build_list_params(params, actions, 'ActionName.member')
         response = self.make_request('AddPermission', params, '/', 'GET')
         body = response.read()
         if response.status == 200:


### PR DESCRIPTION
Calling add_permission will return a 400 error with the contents:

{"Error":{"Code":"MalformedInput","Message":"Top level element may not
be treated as a list","Type":"Sender"}}

Appending .member to the AWSAccountID and ActionName parameter names as
per the AWS docs
(http://docs.amazonwebservices.com/sns/latest/api/API_AddPermission.html
) solves the problem.
