### PR TITLE
Allow just html_body and text_body for send_email

### DIFF
--- a/boto/ses/connection.py
+++ b/boto/ses/connection.py
@@ -167,7 +167,7 @@ class SESConnection(AWSAuthConnection):
 
         raise ExceptionToRaise(response.status, exc_reason, body)
 
-    def send_email(self, source, subject, body, to_addresses,
+    def send_email(self, source, subject, body=None, to_addresses=None,
                    cc_addresses=None, bcc_addresses=None,
                    format='text', reply_addresses=None,
                    return_path=None, text_body=None, html_body=None):


### PR DESCRIPTION
A patch for i878 (https://github.com/boto/boto/issues/878)
