### PR TITLE
Support for per directory .boto config files

### DIFF
--- a/boto/pyami/config.py
+++ b/boto/pyami/config.py
@@ -35,12 +35,15 @@ except (AttributeError, ImportError):
   # This is probably running on App Engine.
   expanduser = (lambda x: x)
 
-# By default we use two locations for the boto configurations,
+# By default we use three locations for the boto configurations,
 # /etc/boto.cfg and ~/.boto (which works on Windows and Unix).
+# os.getcwd() was added so users could have multiple config files
+# without using environment variables
 BotoConfigPath = '/etc/boto.cfg'
 BotoConfigLocations = [BotoConfigPath]
 UserConfigPath = os.path.join(expanduser('~'), '.boto')
 BotoConfigLocations.append(UserConfigPath)
+BotoConfigLocations.append( os.getcwd() + "/.boto" )
 
 # If there's a BOTO_CONFIG variable set, we load ONLY 
 # that variable


### PR DESCRIPTION
A one liner change boto/pyami/config.py allows users to have .boto config files in their working directory. Which allows for easy switching between projects/contexts without playing around with environment variables.

I preferred spending a few minutes on this once instead of wasting a few seconds with env vars every time I change projects.

Maybe this has been discussed and shot down before, in which case, I apologize for not finding out; but I think many users will be happy with this relatively sane new default.

Thanks
