### PR TITLE
Fixes vpn connection field name

### DIFF
--- a/boto/vpc/vpnconnection.py
+++ b/boto/vpc/vpnconnection.py
@@ -44,7 +44,7 @@ class VpnConnection(EC2Object):
             self.id = value
         elif name == 'state':
             self.state = value
-        elif name == 'CustomerGatewayConfiguration':
+        elif name == 'customerGatewayConfiguration':
             self.customer_gateway_configuration = value
         elif name == 'type':
             self.type = value


### PR DESCRIPTION
Second try. Fixes vpn connection class field name customer_gateway_configuration according to http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-ItemType-VpnConnectionType.html
