### PR TITLE
Changes to convert dynamoDb number type to a python decimal type, to pre...

### DIFF
--- a/boto/dynamodb/layer2.py
+++ b/boto/dynamodb/layer2.py
@@ -26,7 +26,8 @@ from boto.dynamodb.table import Table
 from boto.dynamodb.schema import Schema
 from boto.dynamodb.item import Item
 from boto.dynamodb.batch import BatchList, BatchWriteList
-from boto.dynamodb.types import get_dynamodb_type, dynamize_value, convert_num
+from boto.dynamodb.types import get_dynamodb_type, dynamize_value
+from decimal import Decimal
 
 
 def item_object_hook(dct):
@@ -40,11 +41,11 @@ def item_object_hook(dct):
     if 'S' in dct:
         return dct['S']
     if 'N' in dct:
-        return convert_num(dct['N'])
+        return Decimal(dct['N'])
     if 'SS' in dct:
         return set(dct['SS'])
     if 'NS' in dct:
-        return set(map(convert_num, dct['NS']))
+        return set(map(Decimal, dct['NS']))
     return dct
 
 def table_generator(tgen):

--- a/boto/dynamodb/types.py
+++ b/boto/dynamodb/types.py
@@ -24,23 +24,16 @@
 Some utility functions to deal with mapping Amazon DynamoDB types to
 Python types and vice-versa.
 """
+from decimal import Decimal
 
-
+#120717 elee, add Decimal to the list of types recognized as a number.
 def is_num(n):
-    types = (int, long, float, bool)
+    types = (int, long, float, bool, Decimal)
     return isinstance(n, types) or n in types
 
 
 def is_str(n):
     return isinstance(n, basestring) or (isinstance(n, type) and issubclass(n, basestring))
-
-
-def convert_num(s):
-    if '.' in s:
-        n = float(s)
-    else:
-        n = int(s)
-    return n
 
 
 def get_dynamodb_type(val):


### PR DESCRIPTION
...serve the 38 decimal digits that dynamoDb supports (after the decimal point).

This avoids converting the number to a float or int, which causes problems since the value no longer matches what is in dynamoDb.

See boot issue 873 for more details.
https://github.com/boto/boto/issues/873#issuecomment-7303664
