### PR TITLE
Fixed region support copy&paste comment vestiges.

### DIFF
--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -43,7 +43,7 @@ RegionData = {
 
 def regions():
     """
-    Get all available regions for the SDB service.
+    Get all available regions for the ELB service.
 
     :rtype: list
     :return: A list of :class:`boto.RegionInfo` instances

--- a/boto/rds/__init__.py
+++ b/boto/rds/__init__.py
@@ -58,14 +58,14 @@ def regions():
 def connect_to_region(region_name, **kw_params):
     """
     Given a valid region name, return a
-    :class:`boto.ec2.connection.EC2Connection`.
+    :class:`boto.rds.RDSConnection`.
     Any additional parameters after the region_name are passed on to
     the connect method of the region object.
 
     :type: str
     :param region_name: The name of the region to connect to.
 
-    :rtype: :class:`boto.ec2.connection.EC2Connection` or ``None``
+    :rtype: :class:`boto.rds.RDSConnection` or ``None``
     :return: A connection to the given region, or None if an invalid region
              name is given
     """

--- a/boto/sqs/__init__.py
+++ b/boto/sqs/__init__.py
@@ -27,7 +27,7 @@ def regions():
     Get all available regions for the SQS service.
         
     :rtype: list
-    :return: A list of :class:`boto.ec2.regioninfo.RegionInfo`
+    :return: A list of :class:`boto.sqs.regioninfo.RegionInfo`
     """
     return [SQSRegionInfo(name='us-east-1',
                           endpoint='sqs.us-east-1.amazonaws.com'),


### PR DESCRIPTION
This has been discovered in the context of #891: Region support has apparently been copied from existing services usually (and so did I) - while there are two different implementation patterns for region support in place (might be subject of another issue later on), at least the respective comment/documentation vestiges can get fixed already.
