### PR TITLE
Allow tags to be set at the time an AutoScaleGroup is created

### DIFF
--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -176,6 +176,9 @@ class AutoScaleConnection(AWSQueryConnection):
             if as_group.load_balancers:
                 self.build_list_params(params, as_group.load_balancers,
                                        'LoadBalancerNames')
+            if as_group.tags:
+                for i, tag in enumerate(as_group.tags):
+                    tag.build_params(params, i+1)
         return self.get_object(op, params, Request)
 
     def create_auto_scaling_group(self, as_group):

--- a/boto/ec2/autoscale/group.py
+++ b/boto/ec2/autoscale/group.py
@@ -86,7 +86,8 @@ class AutoScalingGroup(object):
                  load_balancers=None, default_cooldown=None,
                  health_check_type=None, health_check_period=None,
                  placement_group=None, vpc_zone_identifier=None,
-                 desired_capacity=None, min_size=None, max_size=None, **kwargs):
+                 desired_capacity=None, min_size=None, max_size=None, 
+                 tags=None, **kwargs):
         """
         Creates a new AutoScalingGroup with the specified name.
 
@@ -164,7 +165,7 @@ class AutoScalingGroup(object):
         self.autoscaling_group_arn = None
         self.vpc_zone_identifier = vpc_zone_identifier
         self.instances = None
-        self.tags = None
+        self.tags = tags or None
 
     # backwards compatible access to 'cooldown' param
     def _get_cooldown(self):


### PR DESCRIPTION
This patch will allow users to set the tags associated with an autoscale group at creation time in accordance with the API definition here:

http://docs.amazonwebservices.com/AutoScaling/latest/APIReference/API_CreateAutoScalingGroup.html
