### PR TITLE
header should be a dictionary by default

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1164,6 +1164,8 @@ class Key(object):
             with the stored object in the response.  See
             http://goo.gl/EWOPb for details.
         """
+        if header is None:
+            header = {}
         save_debug = self.bucket.connection.debug
         if self.bucket.connection.debug == 1:
             self.bucket.connection.debug = 0


### PR DESCRIPTION
Previous code assumes header is a dictionary, but it's default was `None`.

This explicitly sets header to an empty dictionary, if no default was specified.
