### PR TITLE
s3: allow empty metadata dict in bucket.copy_key()

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -692,7 +692,7 @@ class Bucket(object):
         # make sure storage_class_header key exists before accessing it
         if provider.storage_class_header and storage_class:
             headers[provider.storage_class_header] = storage_class
-        if metadata:
+        if metadata is not None:
             headers[provider.metadata_directive_header] = 'REPLACE'
             headers = boto.utils.merge_meta(headers, metadata, provider)
         elif not query_args: # Can't use this header with multi-part copy.


### PR DESCRIPTION
Previously the metadata would only be REPLACE'd if metadata was not None
AND not empty. Updated the code to only require that metadata is not
None in order to REPLACE the metadata. This allows an empty dictionary
to be used which will completely clear the metadata on the new key.

Before this change an empty metadata dict resulted in the new key's
metadata being completely copied from the original as if no metadata was
specified.
