### PR TITLE
support for tags in cloudformation

### DIFF
--- a/boto/cloudformation/connection.py
+++ b/boto/cloudformation/connection.py
@@ -73,7 +73,7 @@ class CloudFormationConnection(AWSQueryConnection):
     def _build_create_or_update_params(self, stack_name, template_body,
                                        template_url, parameters,
                                        notification_arns, disable_rollback,
-                                       timeout_in_minutes, capabilities):
+                                       timeout_in_minutes, capabilities, tags):
         """
         Helper that creates JSON parameters needed by a Stack Create or
         Stack Update call.
@@ -112,6 +112,10 @@ class CloudFormationConnection(AWSQueryConnection):
             the stack.  Currently, the only valid capability is
             'CAPABILITY_IAM'.
 
+        :type tags: list of tuples
+        :param tags: A list of (key, value) pairs of tags to associate with
+            this stack.
+
         :rtype: dict
         :return: JSON parameters represented as a Python dict.
         """
@@ -131,6 +135,10 @@ class CloudFormationConnection(AWSQueryConnection):
         if capabilities:
             for i, value in enumerate(capabilities):
                 params['Capabilities.member.%d' % (i+1)] = value
+        if tags:
+            for i, (key, value) in enumerate(tags):
+                params['Tags.member.%d.Key' % (i+1)] = key
+                params['Tags.member.%d.Value' % (i+1)] = value
         if len(notification_arns) > 0:
             self.build_list_params(params, notification_arns,
                                    "NotificationARNs.member")
@@ -140,7 +148,7 @@ class CloudFormationConnection(AWSQueryConnection):
 
     def create_stack(self, stack_name, template_body=None, template_url=None,
             parameters=[], notification_arns=[], disable_rollback=False,
-            timeout_in_minutes=None, capabilities=None):
+            timeout_in_minutes=None, capabilities=None, tags=None):
         """
         Creates a CloudFormation Stack as specified by the template.
 
@@ -178,12 +186,16 @@ class CloudFormationConnection(AWSQueryConnection):
             the stack.  Currently, the only valid capability is
             'CAPABILITY_IAM'.
 
+        :type tags: list of tuples
+        :param tags: A list of (key, value) pairs of tags to associate with
+            this stack.
+
         :rtype: string
         :return: The unique Stack ID.
         """
         params = self._build_create_or_update_params(stack_name,
             template_body, template_url, parameters, notification_arns,
-            disable_rollback, timeout_in_minutes, capabilities)
+            disable_rollback, timeout_in_minutes, capabilities, tags)
         response = self.make_request('CreateStack', params, '/', 'POST')
         body = response.read()
         if response.status == 200:
@@ -196,7 +208,7 @@ class CloudFormationConnection(AWSQueryConnection):
 
     def update_stack(self, stack_name, template_body=None, template_url=None,
             parameters=[], notification_arns=[], disable_rollback=False,
-            timeout_in_minutes=None, capabilities=None):
+            timeout_in_minutes=None, capabilities=None, tags=None):
         """
         Updates a CloudFormation Stack as specified by the template.
 
@@ -234,12 +246,16 @@ class CloudFormationConnection(AWSQueryConnection):
             the stack.  Currently, the only valid capability is
             'CAPABILITY_IAM'.
 
+        :type tags: list of tuples
+        :param tags: A list of (key, value) pairs of tags to associate with
+            this stack.
+
         :rtype: string
         :return: The unique Stack ID.
         """
         params = self._build_create_or_update_params(stack_name,
             template_body, template_url, parameters, notification_arns,
-            disable_rollback, timeout_in_minutes, capabilities)
+            disable_rollback, timeout_in_minutes, capabilities, tags)
         response = self.make_request('UpdateStack', params, '/', 'POST')
         body = response.read()
         if response.status == 200:

--- a/boto/cloudformation/stack.py
+++ b/boto/cloudformation/stack.py
@@ -12,6 +12,7 @@ class Stack:
         self.outputs = []
         self.parameters = []
         self.capabilities = []
+        self.tags = []
         self.stack_id = None
         self.stack_status = None
         self.stack_name = None
@@ -28,6 +29,9 @@ class Stack:
         elif name == "Capabilities":
             self.capabilities = ResultSet([('member', Capability)])
             return self.capabilities
+        elif name == "Tags":
+            self.tags = ResultSet([('member', Tag)])
+            return self.tags
         else:
             return None
 
@@ -182,6 +186,26 @@ class Capability:
 
     def __repr__(self):
         return "Capability:\"%s\"" % (self.value)
+
+class Tag:
+    def __init__(self, connection=None):
+        self.connection = None
+        self.key = None
+        self.value = None
+
+    def startElement(self, name, attrs, connection):
+        return None
+
+    def endElement(self, name, value, connection):
+        if name == "Key":
+            self.key = value
+        elif name == "Value":
+            self.value = value
+        else:
+            setattr(self, name, value)
+
+    def __repr__(self):
+        return "Tag:\"%s\"=\"%s\"" % (self.key, self.value)
 
 class StackResource:
     def __init__(self, connection=None):

--- a/tests/unit/cloudformation/test_connection.py
+++ b/tests/unit/cloudformation/test_connection.py
@@ -62,6 +62,7 @@ class TestCloudFormationCreateStack(CloudFormationConnectionBase):
             'stack_name', template_url='http://url',
             template_body=SAMPLE_TEMPLATE,
             parameters=[('KeyName', 'myKeyName')],
+            tags=[('TagKey', 'TagValue')],
             notification_arns=['arn:notify1', 'arn:notify2'],
             disable_rollback=True,
             timeout_in_minutes=20, capabilities=['CAPABILITY_IAM']
@@ -78,6 +79,8 @@ class TestCloudFormationCreateStack(CloudFormationConnectionBase):
             'NotificationARNs.member.2': 'arn:notify2',
             'Parameters.member.1.ParameterKey': 'KeyName',
             'Parameters.member.1.ParameterValue': 'myKeyName',
+            'Tags.member.1.Key': 'TagKey',
+            'Tags.member.1.Value': 'TagValue',
             'StackName': 'stack_name',
             'Version': '2010-05-15',
             'TimeoutInMinutes': 20,
@@ -125,6 +128,7 @@ class TestCloudFormationUpdateStack(CloudFormationConnectionBase):
             'stack_name', template_url='http://url',
             template_body=SAMPLE_TEMPLATE,
             parameters=[('KeyName', 'myKeyName')],
+            tags=[('TagKey', 'TagValue')],
             notification_arns=['arn:notify1', 'arn:notify2'],
             disable_rollback=True,
             timeout_in_minutes=20
@@ -137,6 +141,8 @@ class TestCloudFormationUpdateStack(CloudFormationConnectionBase):
             'NotificationARNs.member.2': 'arn:notify2',
             'Parameters.member.1.ParameterKey': 'KeyName',
             'Parameters.member.1.ParameterValue': 'myKeyName',
+            'Tags.member.1.Key': 'TagKey',
+            'Tags.member.1.Value': 'TagValue',
             'StackName': 'stack_name',
             'Version': '2010-05-15',
             'TimeoutInMinutes': 20,
@@ -387,6 +393,12 @@ class TestCloudFormationDescribeStacks(CloudFormationConnectionBase):
                       <OutputKey>ServerURL</OutputKey>
                     </member>
                   </Outputs>
+                  <Tags>
+                    <member>
+                      <Key>MyTagKey</Key>
+                      <Value>MyTagValue</Value>
+                    </member>
+                  </Tags>
                 </member>
               </Stacks>
             </DescribeStacksResult>
@@ -421,6 +433,10 @@ class TestCloudFormationDescribeStacks(CloudFormationConnectionBase):
 
         self.assertEqual(len(stack.capabilities), 1)
         self.assertEqual(stack.capabilities[0].value, 'CAPABILITY_IAM')
+
+        self.assertEqual(len(stack.tags), 1)
+        self.assertEqual(stack.tags[0].key, 'MyTagKey')
+        self.assertEqual(stack.tags[0].value, 'MyTagValue')
 
         self.assert_request_parameters({
             'Action': 'DescribeStacks',


### PR DESCRIPTION
Adds support for tags in CloudFormation Stacks with unit tests.

Documented as part of the Stack here:
- http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_Stack.html
- http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_Tag.html

Without this commit, describing stacks which contains tags breaks.
