### PR TITLE
Allow non-numerics in a RegExConstraint's attributes. Fixes issue #941.

### DIFF
--- a/boto/mturk/question.py
+++ b/boto/mturk/question.py
@@ -250,7 +250,7 @@ class Constraint(object):
     def get_attributes(self):
         pairs = zip(self.attribute_names, self.attribute_values)
         attrs = ' '.join(
-            '%s="%s"' % (name, value)
+            '%s="%d"' % (name, value)
             for (name, value) in pairs
             if value is not None
             )
@@ -280,6 +280,15 @@ class RegExConstraint(Constraint):
 
     def __init__(self, pattern, error_text=None, flags=None):
         self.attribute_values = pattern, error_text, flags
+
+    def get_attributes(self):
+        pairs = zip(self.attribute_names, self.attribute_values)
+        attrs = ' '.join(
+            '%s="%s"' % (name, value)
+            for (name, value) in pairs
+            if value is not None
+            )
+        return attrs
 
 class NumberOfLinesSuggestion(object):
     template = '<NumberOfLinesSuggestion>%(num_lines)s</NumberOfLinesSuggestion>'


### PR DESCRIPTION
https://github.com/boto/boto/issues/941

One cannot create RegExConstraints (with non-numeric regex strings) with the current scheme, as described in the issue. I've overridden the behavior in only RegExConstraints, as I believe all other constraints do take numeric attributes.
