### PR TITLE
Allow upload_archive to accept file like objects

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -350,6 +350,12 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         return http_request.path
 
     def payload(self, http_request):
+        body = http_request.body
+        # If the body is a file like object, we can use
+        # boto.utils.compute_hash, which will avoid reading
+        # the entire body into memory.
+        if hasattr(body, 'seek') and hasattr(body, 'read'):
+            return boto.utils.compute_hash(body, hash_algorithm=sha256)[0]
         return sha256(http_request.body).hexdigest()
 
     def canonical_request(self, http_request):

--- a/boto/glacier/vault.py
+++ b/boto/glacier/vault.py
@@ -22,7 +22,8 @@
 #
 
 from .job import Job
-from .writer import Writer, bytes_to_hex, chunk_hashes, tree_hash
+from .writer import Writer, bytes_to_hex, chunk_hashes, tree_hash, \
+        compute_hashes_from_fileobj
 import hashlib
 import os.path
 
@@ -86,13 +87,10 @@ class Vault(object):
         :rtype: str
         :return: The archive id of the newly created archive
         """
-        archive = ''
-        with open(filename, 'rb') as fd:
-            archive = fd.read()
-        linear_hash = hashlib.sha256(archive).hexdigest()
-        hex_tree_hash  = bytes_to_hex(tree_hash(chunk_hashes(archive)))
-        response = self.layer1.upload_archive(self.name, archive, linear_hash,
-                                              hex_tree_hash)
+        with open(filename, 'rb') as fileobj:
+            linear_hash, tree_hash = compute_hashes_from_fileobj(fileobj)
+        response = self.layer1.upload_archive(self.name, open(filename), linear_hash,
+                                              tree_hash)
         return response['ArchiveId']
 
     def create_archive_writer(self, part_size=DefaultPartSize,

--- a/boto/glacier/writer.py
+++ b/boto/glacier/writer.py
@@ -63,6 +63,33 @@ def tree_hash(fo):
     return hashes[0]
 
 
+def compute_hashes_from_fileobj(fileobj, chunk_size=1024 * 1024):
+    """Compute the linear and tree hash from a fileobj.
+
+    This function will compute the linear/tree hash of a fileobj
+    in a single pass through the fileobj.
+
+    :param fileobj: A file like object.
+
+    :param chunk_size: The size of the chunks to use for the tree
+        hash.  This is also the buffer size used to read from
+        `fileobj`.
+
+    :rtype: tuple
+    :return: A tuple of (linear_hash, tree_hash).  Both hashes
+        are returned in hex.
+
+    """
+    linear_hash = hashlib.sha256()
+    chunks = []
+    chunk = fileobj.read(chunk_size)
+    while chunk:
+        linear_hash.update(chunk)
+        chunks.append(hashlib.sha256(chunk).digest())
+        chunk = fileobj.read(chunk_size)
+    return linear_hash.hexdigest(), bytes_to_hex(tree_hash(chunks))
+
+
 def bytes_to_hex(str):
     return ''.join(["%02x" % ord(x) for x in str]).strip()
 

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -849,14 +849,18 @@ def compute_md5(fp, buf_size=8192, size=None):
              plain digest as the second element and the data size as
              the third element.
     """
-    m = md5()
+    return compute_hash(fp, buf_size, size, hash_algorithm=md5)
+
+
+def compute_hash(fp, buf_size=8192, size=None, hash_algorithm=md5):
+    hash_obj = hash_algorithm()
     spos = fp.tell()
     if size and size < buf_size:
         s = fp.read(size)
     else:
         s = fp.read(buf_size)
     while s:
-        m.update(s)
+        hash_obj.update(s)
         if size:
             size -= len(s)
             if size <= 0:
@@ -865,11 +869,11 @@ def compute_md5(fp, buf_size=8192, size=None):
             s = fp.read(size)
         else:
             s = fp.read(buf_size)
-    hex_md5 = m.hexdigest()
-    base64md5 = base64.encodestring(m.digest())
-    if base64md5[-1] == '\n':
-        base64md5 = base64md5[0:-1]
+    hex_digest = hash_obj.hexdigest()
+    base64_digest = base64.encodestring(hash_obj.digest())
+    if base64_digest[-1] == '\n':
+        base64_digest = base64_digest[0:-1]
     # data_size based on bytes read.
     data_size = fp.tell() - spos
     fp.seek(spos)
-    return (hex_md5, base64md5, data_size)
+    return (hex_digest, base64_digest, data_size)


### PR DESCRIPTION
The entire file is never read into memory, only single
chunks are read at a time.

This greatly reduces the memory usage, but it also appears to have sped
up performance for single operation uploads.  In testing various
archive sizes, I saw roughly 20% performance improvements.

A few notes about the changes:
- I changed `x-amz-content-length` to `Content-Length`.  From the
  docs: http://docs.amazonwebservices.com/amazonglacier/latest/dev/api-common-request-headers.html
  I couldn't find any info on this header, and if a Content-Length
  is not provided, boto.connection.HTTPRequest would try to
  `str(len(body))` to calculate this.
- Sigv4 assumes the body is a string.  I modified the payload method
  to support being passed file like objects and computing the hash
  by reading in configurable chunk sizes at a time.  This does
  mean that the sha256 of the body is being computed twice, once for the
  x-amz-content-sha256 header needed by glacier, and once for the
  signature.  We _could_ avoid doing this twice by checking if that header
  exists when we're signing the request, and to just use
  x-amz-content-sha256, but that seems like we're crossing abstraction
  boundaries.  However, if you guys want this, I can add it.
