### PR TITLE
Added installation instructions to the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,7 @@ Install from source:
 ::
 
 	$ git clone git://github.com/boto/boto.git
+	$ cd boto
 	$ python setup.py install
 
 **********


### PR DESCRIPTION
Installation instructions are mysteriously missing from the readme and from the docs. For those of us new to python packages this information is not self-evident.
