### PR TITLE
Add __repr__ to GlacierResponse

### DIFF
--- a/boto/glacier/response.py
+++ b/boto/glacier/response.py
@@ -41,7 +41,10 @@ class GlacierResponse(dict):
         size = http_response.getheader('Content-Length', None)
         if size is not None:
             self.size = size
-        
+
+    def __repr__(self):
+        return "<GlacierResponse %s>" % self.get('RequestId')
+
     def read(self, amt=None):
         "Reads and returns the response body, or up to the next amt bytes."
         return self.http_response.read(amt)


### PR DESCRIPTION
Since GlacierResponse inherits from dict, it was not obvious at first that the object has other methods and attributes, which makes discovering how to read data back from Glacier non-obvious.
Hopefully this helps users with discoverability.
