### PR TITLE
glacier: fix Vault.retrieve_archive result type

### DIFF
--- a/boto/glacier/vault.py
+++ b/boto/glacier/vault.py
@@ -170,7 +170,7 @@ class Vault(object):
             job_data['Description'] = description
 
         response = self.layer1.initiate_job(self.name, job_data)
-        return response['JobId']
+        return self.get_job(response['JobId'])
         
     def retrieve_inventory(self, sns_topic=None,
                          description=None):


### PR DESCRIPTION
retrieve_archive is documented to return a Job object, but currently it
returns a job id string. As this is layer 2, it would make more sense to
return a full Job object, so do this instead.
