### PR TITLE
Add support for the Reserved Instance Marketplace

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -47,6 +47,7 @@ from boto.ec2.regioninfo import RegionInfo
 from boto.ec2.instanceinfo import InstanceInfo
 from boto.ec2.reservedinstance import ReservedInstancesOffering
 from boto.ec2.reservedinstance import ReservedInstance
+from boto.ec2.reservedinstance import ReservedInstanceListing
 from boto.ec2.spotinstancerequest import SpotInstanceRequest
 from boto.ec2.spotpricehistory import SpotPriceHistory
 from boto.ec2.spotdatafeedsubscription import SpotDatafeedSubscription
@@ -63,7 +64,7 @@ from boto.exception import EC2ResponseError
 
 class EC2Connection(AWSQueryConnection):
 
-    APIVersion = boto.config.get('Boto', 'ec2_version', '2012-07-20')
+    APIVersion = boto.config.get('Boto', 'ec2_version', '2012-08-15')
     DefaultRegionName = boto.config.get('Boto', 'ec2_region_name', 'us-east-1')
     DefaultRegionEndpoint = boto.config.get('Boto', 'ec2_region_endpoint',
                                             'ec2.us-east-1.amazonaws.com')
@@ -2661,17 +2662,26 @@ class EC2Connection(AWSQueryConnection):
     # Reservation methods
     #
 
-    def get_all_reserved_instances_offerings(self, reserved_instances_id=None,
+    def get_all_reserved_instances_offerings(self,
+                                             reserved_instances_offering_ids=None,
                                              instance_type=None,
                                              availability_zone=None,
                                              product_description=None,
-                                             filters=None):
+                                             filters=None,
+                                             instance_tenancy=None,
+                                             offering_type=None,
+                                             include_marketplace=None,
+                                             min_duration=None,
+                                             max_duration=None,
+                                             max_instance_count=None,
+                                             next_token=None,
+                                             max_results=None):
         """
         Describes Reserved Instance offerings that are available for purchase.
 
-        :type reserved_instances_id: str
-        :param reserved_instances_id: Displays Reserved Instances with the
-                                      specified offering IDs.
+        :type reserved_instances_offering_ids: list
+        :param reserved_instances_id: One or more Reserved Instances
+            offering IDs.
 
         :type instance_type: str
         :param instance_type: Displays Reserved Instances of the specified
@@ -2695,12 +2705,49 @@ class EC2Connection(AWSQueryConnection):
                         being performed.  Check the EC2 API guide
                         for details.
 
+        :type instance_tenancy: string
+        :param instance_tenancy: The tenancy of the Reserved Instance offering.
+            A Reserved Instance with tenancy of dedicated will run on
+            single-tenant hardware and can only be launched within a VPC.
+
+        :type offering_type: string
+        :param offering_type: The Reserved Instance offering type.
+            Valid Values:
+                * Heavy Utilization
+                * Medium Utilization
+                * Light Utilization
+
+        :type include_marketplace: bool
+        :param include_marketplace: Include Marketplace offerings in the
+            response.
+
+        :type min_duration: int :param min_duration: Minimum duration (in
+            seconds) to filter when searching for offerings.
+
+        :type max_duration: int
+        :param max_duration: Maximum duration (in seconds) to filter when
+            searching for offerings.
+
+        :type max_instance_count: int
+        :param max_instance_count: Maximum number of instances to filter when
+            searching for offerings.
+
+        :type next_token: string
+        :param next_token: Token to use when requesting the next paginated set
+            of offerings.
+
+        :type max_results: int
+        :param max_results: Maximum number of offerings to return per call.
+
         :rtype: list
-        :return: A list of :class:`boto.ec2.reservedinstance.ReservedInstancesOffering`
+        :return: A list of
+            :class:`boto.ec2.reservedinstance.ReservedInstancesOffering`.
+
         """
         params = {}
-        if reserved_instances_id:
-            params['ReservedInstancesId'] = reserved_instances_id
+        if reserved_instances_offering_ids is not None:
+            self.build_list_params(params, reserved_instances_offering_ids,
+                                   'ReservedInstancesOfferingId')
         if instance_type:
             params['InstanceType'] = instance_type
         if availability_zone:
@@ -2709,6 +2756,25 @@ class EC2Connection(AWSQueryConnection):
             params['ProductDescription'] = product_description
         if filters:
             self.build_filter_params(params, filters)
+        if instance_tenancy is not None:
+            params['InstanceTenancy'] = instance_tenancy
+        if offering_type is not None:
+            params['OfferingType'] = offering_type
+        if include_marketplace is not None:
+            if include_marketplace:
+                params['IncludeMarketplace'] = 'true'
+            else:
+                params['IncludeMarketplace'] = 'false'
+        if min_duration is not None:
+            params['MinDuration'] = str(min_duration)
+        if max_duration is not None:
+            params['MaxDuration'] = str(max_duration)
+        if max_instance_count is not None:
+            params['MaxInstanceCount'] = str(max_instance_count)
+        if next_token is not None:
+            params['NextToken'] = next_token
+        if max_results is not None:
+            params['MaxResults'] = str(max_results)
 
         return self.get_list('DescribeReservedInstancesOfferings',
                              params, [('item', ReservedInstancesOffering)],
@@ -2748,7 +2814,7 @@ class EC2Connection(AWSQueryConnection):
 
     def purchase_reserved_instance_offering(self,
                                             reserved_instances_offering_id,
-                                            instance_count=1):
+                                            instance_count=1, limit_price=None):
         """
         Purchase a Reserved Instance for use with your account.
         ** CAUTION **
@@ -2763,14 +2829,106 @@ class EC2Connection(AWSQueryConnection):
         :param instance_count: The number of Reserved Instances to purchase.
                                Default value is 1.
 
+        :type limit_price: tuple
+        :param instance_count: Limit the price on the total order.
+                               Must be a tuple of (amount, currency_code), for example:
+                                   (100.0, 'USD').
+
         :rtype: :class:`boto.ec2.reservedinstance.ReservedInstance`
         :return: The newly created Reserved Instance
         """
         params = {
             'ReservedInstancesOfferingId': reserved_instances_offering_id,
             'InstanceCount': instance_count}
+        if limit_price is not None:
+            params['LimitPrice.Amount'] = str(limit_price[0])
+            params['LimitPrice.CurrencyCode'] = str(limit_price[1])
         return self.get_object('PurchaseReservedInstancesOffering', params,
                                ReservedInstance, verb='POST')
+
+    def create_reserved_instances_listing(self, reserved_instances_id, instance_count,
+                                          price_schedules, client_token):
+        """Creates a new listing for Reserved Instances.
+
+        Creates a new listing for Amazon EC2 Reserved Instances that will be
+        sold in the Reserved Instance Marketplace. You can submit one Reserved
+        Instance listing at a time.
+
+        The Reserved Instance Marketplace matches sellers who want to resell
+        Reserved Instance capacity that they no longer need with buyers who
+        want to purchase additional capacity. Reserved Instances bought and
+        sold through the Reserved Instance Marketplace work like any other
+        Reserved Instances.
+
+        If you want to sell your Reserved Instances, you must first register as
+        a Seller in the Reserved Instance Marketplace. After completing the
+        registration process, you can create a Reserved Instance Marketplace
+        listing of some or all of your Reserved Instances, and specify the
+        upfront price you want to receive for them. Your Reserved Instance
+        listings then become available for purchase.
+
+        :type reserved_instances_id: string
+        :param reserved_instances_id: The ID of the Reserved Instance that
+            will be listed.
+
+        :type instance_count: int
+        :param instance_count: The number of instances that are a part of a
+            Reserved Instance account that will be listed in the Reserved
+            Instance Marketplace. This number should be less than or equal to
+            the instance count associated with the Reserved Instance ID
+            specified in this call.
+
+        :type price_schedules: List of tuples
+        :param price_schedules: A list specifying the price of the Reserved
+            Instance for each month remaining in the Reserved Instance term.
+            Each tuple contains two elements, the price and the term.  For
+            example, for an instance that 11 months remaining in its term,
+            we can have a price schedule with an upfront price of $2.50.
+            At 8 months remaining we can drop the price down to $2.00.
+            This would be expressed as::
+
+                price_schedules=[('2.50', 11), ('2.00', 8)]
+
+        :type client_token: string
+        :param client_token: Unique, case-sensitive identifier you provide
+            to ensure idempotency of the request.  Maximum 64 ASCII characters.
+
+        :rtype: list
+        :return: A list of
+            :class:`boto.ec2.reservedinstance.ReservedInstanceListing`
+
+        """
+        params = {
+            'ReservedInstancesId': reserved_instances_id,
+            'InstanceCount': str(instance_count),
+            'ClientToken': client_token,
+        }
+        for i, schedule in enumerate(price_schedules):
+            price, term = schedule
+            params['PriceSchedules.%s.Price' % i] = str(price)
+            params['PriceSchedules.%s.Term' % i] = str(term)
+        return self.get_list('CreateReservedInstancesListing',
+                             params, [('item', ReservedInstanceListing)], verb='POST')
+
+    def cancel_reserved_instances_listing(
+            self, reserved_instances_listing_ids=None):
+        """Cancels the specified Reserved Instance listing.
+
+        :type reserved_instances_listing_ids: List of strings
+        :param reserved_instances_listing_ids: The ID of the
+            Reserved Instance listing to be cancelled.
+
+        :rtype: list
+        :return: A list of
+            :class:`boto.ec2.reservedinstance.ReservedInstanceListing`
+
+        """
+        params = {}
+        if reserved_instances_listing_ids is not None:
+            self.build_list_params(params, reserved_instances_listing_ids,
+                                   'ReservedInstancesListingId')
+        return self.get_list('CancelReservedInstancesListing',
+                             params, [('item', ReservedInstanceListing)], verb='POST')
 
     #
     # Monitoring

--- a/boto/ec2/reservedinstance.py
+++ b/boto/ec2/reservedinstance.py
@@ -14,18 +14,22 @@
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
 # ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+from boto.resultset import ResultSet
 from boto.ec2.ec2object import EC2Object
 
+
 class ReservedInstancesOffering(EC2Object):
-    
+
     def __init__(self, connection=None, id=None, instance_type=None,
                  availability_zone=None, duration=None, fixed_price=None,
-                 usage_price=None, description=None):
+                 usage_price=None, description=None, instance_tenancy=None,
+                 currency_code=None, offering_type=None,
+                 recurring_charges=None, pricing_details=None):
         EC2Object.__init__(self, connection)
         self.id = id
         self.instance_type = instance_type
@@ -34,11 +38,22 @@ class ReservedInstancesOffering(EC2Object):
         self.fixed_price = fixed_price
         self.usage_price = usage_price
         self.description = description
+        self.instance_tenancy = instance_tenancy
+        self.currency_code = currency_code
+        self.offering_type = offering_type
+        self.recurring_charges = recurring_charges
+        self.pricing_details = pricing_details
 
     def __repr__(self):
         return 'ReservedInstanceOffering:%s' % self.id
 
     def startElement(self, name, attrs, connection):
+        if name == 'recurringCharges':
+            self.recurring_charges = ResultSet([('item', RecurringCharge)])
+            return self.recurring_charges
+        elif name == 'pricingDetailsSet':
+            self.pricing_details = ResultSet([('item', PricingDetail)])
+            return self.pricing_details
         return None
 
     def endElement(self, name, value, connection):
@@ -49,15 +64,21 @@ class ReservedInstancesOffering(EC2Object):
         elif name == 'availabilityZone':
             self.availability_zone = value
         elif name == 'duration':
-            self.duration = value
+            self.duration = int(value)
         elif name == 'fixedPrice':
             self.fixed_price = value
         elif name == 'usagePrice':
             self.usage_price = value
         elif name == 'productDescription':
             self.description = value
-        else:
-            setattr(self, name, value)
+        elif name == 'instanceTenancy':
+            self.instance_tenancy = value
+        elif name == 'currencyCode':
+            self.currency_code = value
+        elif name == 'offeringType':
+            self.offering_type = value
+        elif name == 'marketplace':
+            self.marketplace = True if value == 'true' else False
 
     def describe(self):
         print 'ID=%s' % self.id
@@ -70,6 +91,31 @@ class ReservedInstancesOffering(EC2Object):
 
     def purchase(self, instance_count=1):
         return self.connection.purchase_reserved_instance_offering(self.id, instance_count)
+
+
+class RecurringCharge(object):
+    def __init__(self, connection=None, frequency=None, amount=None):
+        self.frequency = frequency
+        self.amount = amount
+
+    def startElement(self, name, attrs, connection):
+        return None
+
+    def endElement(self, name, value, connection):
+        setattr(self, name, value)
+
+
+class PricingDetail(object):
+    def __init__(self, connection=None, price=None, count=None):
+        self.price = price
+        self.count = count
+
+    def startElement(self, name, attrs, connection):
+        return None
+
+    def endElement(self, name, value, connection):
+        setattr(self, name, value)
+
 
 class ReservedInstance(ReservedInstancesOffering):
 
@@ -95,3 +141,84 @@ class ReservedInstance(ReservedInstancesOffering):
             self.state = value
         else:
             ReservedInstancesOffering.endElement(self, name, value, connection)
+
+
+class ReservedInstanceListing(EC2Object):
+    def __init__(self, connection=None, listing_id=None, id=None,
+                 create_date=None, update_date=None,
+                 status=None, status_message=None, client_token=None):
+        self.connection = connection
+        self.listing_id = listing_id
+        self.id = id
+        self.create_date = create_date
+        self.update_date = update_date
+        self.status = status
+        self.status_message = status_message
+        self.client_token = client_token
+
+    def startElement(self, name, attrs, connection):
+        if name == 'instanceCounts':
+            self.instance_counts = ResultSet([('item', InstanceCount)])
+            return self.instance_counts
+        elif name == 'priceSchedules':
+            self.price_schedules = ResultSet([('item', PriceSchedule)])
+            return self.price_schedules
+        return None
+
+    def endElement(self, name, value, connection):
+        if name == 'reservedInstancesListingId':
+            self.listing_id = value
+        elif name == 'reservedInstancesId':
+            self.id = value
+        elif name == 'createDate':
+            self.create_date = value
+        elif name == 'updateDate':
+            self.update_date = value
+        elif name == 'status':
+            self.status = value
+        elif name == 'statusMessage':
+            self.status_message = value
+        else:
+            setattr(self, name, value)
+
+
+class InstanceCount(object):
+    def __init__(self, connection=None, state=None, instance_count=None):
+        self.state = state
+        self.instance_count = instance_count
+
+    def startElement(self, name, attrs, connection):
+        return None
+
+    def endElement(self, name, value, connection):
+        if name == 'state':
+            self.state = value
+        elif name == 'instanceCount':
+            self.instance_count = int(value)
+        else:
+            setattr(self, name, value)
+
+
+class PriceSchedule(object):
+    def __init__(self, connection=None, term=None, price=None,
+                 currency_code=None, active=None):
+        self.connection = connection
+        self.term = term
+        self.price = price
+        self.currency_code = currency_code
+        self.active = active
+
+    def startElement(self, name, attrs, connection):
+        return None
+
+    def endElement(self, name, value, connection):
+        if name == 'term':
+            self.term = int(value)
+        elif name == 'price':
+            self.price = value
+        elif name == 'currencyCode':
+            self.currency_code = value
+        elif name == 'active':
+            self.active = True if value == 'true' else False
+        else:
+            setattr(self, name, value)

--- a/tests/unit/ec2/test_connection.py
+++ b/tests/unit/ec2/test_connection.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python
+from tests.unit import unittest
+from tests.unit import AWSMockServiceTestCase
+
+from boto.ec2.connection import EC2Connection
+
+
+class TestEC2ConnectionBase(AWSMockServiceTestCase):
+    connection_class = EC2Connection
+
+    def setUp(self):
+        super(TestEC2ConnectionBase, self).setUp()
+        self.ec2 = self.service_connection
+
+
+class TestReservedInstanceOfferings(TestEC2ConnectionBase):
+
+    def default_body(self):
+        return """
+            <DescribeReservedInstancesOfferingsResponse>
+                <requestId>d3253568-edcf-4897-9a3d-fb28e0b3fa38</requestId>
+                    <reservedInstancesOfferingsSet>
+                    <item>
+                        <reservedInstancesOfferingId>2964d1bf71d8</reservedInstancesOfferingId>
+                        <instanceType>c1.medium</instanceType>
+                        <availabilityZone>us-east-1c</availabilityZone>
+                        <duration>94608000</duration>
+                        <fixedPrice>775.0</fixedPrice>
+                        <usagePrice>0.0</usagePrice>
+                        <productDescription>product description</productDescription>
+                        <instanceTenancy>default</instanceTenancy>
+                        <currencyCode>USD</currencyCode>
+                        <offeringType>Heavy Utilization</offeringType>
+                        <recurringCharges>
+                            <item>
+                                <frequency>Hourly</frequency>
+                                <amount>0.095</amount>
+                            </item>
+                        </recurringCharges>
+                        <marketplace>false</marketplace>
+                        <pricingDetailsSet>
+                            <item>
+                                <price>0.045</price>
+                                <count>1</count>
+                            </item>
+                        </pricingDetailsSet>
+                    </item>
+                    <item>
+                        <reservedInstancesOfferingId>2dce26e46889</reservedInstancesOfferingId>
+                        <instanceType>c1.medium</instanceType>
+                        <availabilityZone>us-east-1c</availabilityZone>
+                        <duration>94608000</duration>
+                        <fixedPrice>775.0</fixedPrice>
+                        <usagePrice>0.0</usagePrice>
+                        <productDescription>Linux/UNIX</productDescription>
+                        <instanceTenancy>default</instanceTenancy>
+                        <currencyCode>USD</currencyCode>
+                        <offeringType>Heavy Utilization</offeringType>
+                        <recurringCharges>
+                            <item>
+                                <frequency>Hourly</frequency>
+                                <amount>0.035</amount>
+                            </item>
+                        </recurringCharges>
+                        <marketplace>false</marketplace>
+                        <pricingDetailsSet/>
+                    </item>
+                </reservedInstancesOfferingsSet>
+                <nextToken>next_token</nextToken>
+            </DescribeReservedInstancesOfferingsResponse>
+        """
+
+    def test_get_reserved_instance_offerings(self):
+        self.set_http_response(status_code=200)
+        response = self.ec2.get_all_reserved_instances_offerings()
+        self.assertEqual(len(response), 2)
+        instance = response[0]
+        self.assertEqual(instance.id, '2964d1bf71d8')
+        self.assertEqual(instance.instance_type, 'c1.medium')
+        self.assertEqual(instance.availability_zone, 'us-east-1c')
+        self.assertEqual(instance.duration, 94608000)
+        self.assertEqual(instance.fixed_price, '775.0')
+        self.assertEqual(instance.usage_price, '0.0')
+        self.assertEqual(instance.description, 'product description')
+        self.assertEqual(instance.instance_tenancy, 'default')
+        self.assertEqual(instance.currency_code, 'USD')
+        self.assertEqual(instance.offering_type, 'Heavy Utilization')
+        self.assertEqual(len(instance.recurring_charges), 1)
+        self.assertEqual(instance.recurring_charges[0].frequency, 'Hourly')
+        self.assertEqual(instance.recurring_charges[0].amount, '0.095')
+        self.assertEqual(len(instance.pricing_details), 1)
+        self.assertEqual(instance.pricing_details[0].price, '0.045')
+        self.assertEqual(instance.pricing_details[0].count, '1')
+
+    def test_get_reserved_instance_offerings_params(self):
+        self.set_http_response(status_code=200)
+        self.ec2.get_all_reserved_instances_offerings(
+            reserved_instances_offering_ids=['id1','id2'],
+            instance_type='t1.micro',
+            availability_zone='us-east-1',
+            product_description='description',
+            instance_tenancy='dedicated',
+            offering_type='offering_type',
+            include_marketplace=False,
+            min_duration=100,
+            max_duration=1000,
+            max_instance_count=1,
+            next_token='next_token',
+            max_results=10
+        )
+        self.assert_request_parameters({
+            'Action': 'DescribeReservedInstancesOfferings',
+            'ReservedInstancesOfferingId.1': 'id1',
+            'ReservedInstancesOfferingId.2': 'id2',
+            'InstanceType': 't1.micro',
+            'AvailabilityZone': 'us-east-1',
+            'ProductDescription': 'description',
+            'InstanceTenancy': 'dedicated',
+            'OfferingType': 'offering_type',
+            'IncludeMarketplace': 'false',
+            'MinDuration': '100',
+            'MaxDuration': '1000',
+            'MaxInstanceCount': '1',
+            'NextToken': 'next_token',
+            'MaxResults': '10',
+            'Version': '2012-08-15'},
+             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
+                                   'SignatureVersion', 'Timestamp'])
+
+
+class TestPurchaseReservedInstanceOffering(TestEC2ConnectionBase):
+    def default_body(self):
+        return """<PurchaseReservedInstancesOffering />"""
+
+    def test_serialized_api_args(self):
+        self.set_http_response(status_code=200)
+        response = self.ec2.purchase_reserved_instance_offering(
+                'offering_id', 1, (100.0, 'USD'))
+        self.assert_request_parameters({
+            'Action': 'PurchaseReservedInstancesOffering',
+            'InstanceCount': 1,
+            'ReservedInstancesOfferingId': 'offering_id',
+            'LimitPrice.Amount': '100.0',
+            'LimitPrice.CurrencyCode': 'USD',
+            'Version': '2012-08-15'},
+             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
+                                   'SignatureVersion', 'Timestamp'])
+
+
+class TestCancelReservedInstancesListing(TestEC2ConnectionBase):
+    def default_body(self):
+        return """
+            <CancelReservedInstancesListingResponse>
+                <requestId>request_id</requestId>
+                <reservedInstancesListingsSet>
+                    <item>
+                        <reservedInstancesListingId>listing_id</reservedInstancesListingId>
+                        <reservedInstancesId>instance_id</reservedInstancesId>
+                        <createDate>2012-07-12T16:55:28.000Z</createDate>
+                        <updateDate>2012-07-12T16:55:28.000Z</updateDate>
+                        <status>cancelled</status>
+                        <statusMessage>CANCELLED</statusMessage>
+                        <instanceCounts>
+                            <item>
+                                <state>Available</state>
+                                <instanceCount>0</instanceCount>
+                            </item>
+                            <item>
+                                <state>Sold</state>
+                                <instanceCount>0</instanceCount>
+                            </item>
+                            <item>
+                                <state>Cancelled</state>
+                                <instanceCount>1</instanceCount>
+                            </item>
+                            <item>
+                                <state>Pending</state>
+                                <instanceCount>0</instanceCount>
+                            </item>
+                        </instanceCounts>
+                        <priceSchedules>
+                            <item>
+                                <term>5</term>
+                                <price>166.64</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>false</active>
+                            </item>
+                            <item>
+                                <term>4</term>
+                                <price>133.32</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>false</active>
+                            </item>
+                            <item>
+                                <term>3</term>
+                                <price>99.99</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>false</active>
+                            </item>
+                            <item>
+                                <term>2</term>
+                                <price>66.66</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>false</active>
+                            </item>
+                            <item>
+                                <term>1</term>
+                                <price>33.33</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>false</active>
+                            </item>
+                        </priceSchedules>
+                        <tagSet/>
+                        <clientToken>XqJIt1342112125076</clientToken>
+                    </item>
+                </reservedInstancesListingsSet>
+            </CancelReservedInstancesListingResponse>
+        """
+
+    def test_reserved_instances_listing(self):
+        self.set_http_response(status_code=200)
+        response = self.ec2.cancel_reserved_instances_listing()
+        self.assertEqual(len(response), 1)
+        cancellation = response[0]
+        self.assertEqual(cancellation.status, 'cancelled')
+        self.assertEqual(cancellation.status_message, 'CANCELLED')
+        self.assertEqual(len(cancellation.instance_counts), 4)
+        first = cancellation.instance_counts[0]
+        self.assertEqual(first.state, 'Available')
+        self.assertEqual(first.instance_count, 0)
+        self.assertEqual(len(cancellation.price_schedules), 5)
+        schedule = cancellation.price_schedules[0]
+        self.assertEqual(schedule.term, 5)
+        self.assertEqual(schedule.price, '166.64')
+        self.assertEqual(schedule.currency_code, 'USD')
+        self.assertEqual(schedule.active, False)
+
+
+class TestCreateReservedInstancesListing(TestEC2ConnectionBase):
+    def default_body(self):
+        return """
+            <CreateReservedInstancesListingResponse>
+                <requestId>request_id</requestId>
+                <reservedInstancesListingsSet>
+                    <item>
+                        <reservedInstancesListingId>listing_id</reservedInstancesListingId>
+                        <reservedInstancesId>instance_id</reservedInstancesId>
+                        <createDate>2012-07-17T17:11:09.449Z</createDate>
+                        <updateDate>2012-07-17T17:11:09.468Z</updateDate>
+                        <status>active</status>
+                        <statusMessage>ACTIVE</statusMessage>
+                        <instanceCounts>
+                            <item>
+                                <state>Available</state>
+                                <instanceCount>1</instanceCount>
+                            </item>
+                            <item>
+                                <state>Sold</state>
+                                <instanceCount>0</instanceCount>
+                            </item>
+                            <item>
+                                <state>Cancelled</state>
+                                <instanceCount>0</instanceCount>
+                            </item>
+                            <item>
+                                <state>Pending</state>
+                                <instanceCount>0</instanceCount>
+                            </item>
+                        </instanceCounts>
+                        <priceSchedules>
+                            <item>
+                                <term>11</term>
+                                <price>2.5</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>true</active>
+                            </item>
+                            <item>
+                                <term>10</term>
+                                <price>2.5</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>false</active>
+                            </item>
+                            <item>
+                                <term>9</term>
+                                <price>2.5</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>false</active>
+                            </item>
+                            <item>
+                                <term>8</term>
+                                <price>2.0</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>false</active>
+                            </item>
+                            <item>
+                                <term>7</term>
+                                <price>2.0</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>false</active>
+                            </item>
+                            <item>
+                                <term>6</term>
+                                <price>2.0</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>false</active>
+                            </item>
+                            <item>
+                                <term>5</term>
+                                <price>1.5</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>false</active>
+                            </item>
+                            <item>
+                                <term>4</term>
+                                <price>1.5</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>false</active>
+                            </item>
+                            <item>
+                                <term>3</term>
+                                <price>0.7</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>false</active>
+                            </item>
+                            <item>
+                                <term>2</term>
+                                <price>0.7</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>false</active>
+                            </item>
+                            <item>
+                                <term>1</term>
+                                <price>0.1</price>
+                                <currencyCode>USD</currencyCode>
+                                <active>false</active>
+                            </item>
+                        </priceSchedules>
+                        <tagSet/>
+                        <clientToken>myIdempToken1</clientToken>
+                    </item>
+                </reservedInstancesListingsSet>
+            </CreateReservedInstancesListingResponse>
+        """
+
+    def test_create_reserved_instances_listing(self):
+        self.set_http_response(status_code=200)
+        response = self.ec2.create_reserved_instances_listing(
+            'instance_id', 1, [('2.5', 11), ('2.0', 8)], 'client_token')
+        self.assertEqual(len(response), 1)
+        cancellation = response[0]
+        self.assertEqual(cancellation.status, 'active')
+        self.assertEqual(cancellation.status_message, 'ACTIVE')
+        self.assertEqual(len(cancellation.instance_counts), 4)
+        first = cancellation.instance_counts[0]
+        self.assertEqual(first.state, 'Available')
+        self.assertEqual(first.instance_count, 1)
+        self.assertEqual(len(cancellation.price_schedules), 11)
+        schedule = cancellation.price_schedules[0]
+        self.assertEqual(schedule.term, 11)
+        self.assertEqual(schedule.price, '2.5')
+        self.assertEqual(schedule.currency_code, 'USD')
+        self.assertEqual(schedule.active, True)
+
+        self.assert_request_parameters({
+            'Action': 'CreateReservedInstancesListing',
+            'ReservedInstancesId': 'instance_id',
+            'InstanceCount': '1',
+            'ClientToken': 'client_token',
+            'PriceSchedules.0.Price': '2.5',
+            'PriceSchedules.0.Term': '11',
+            'PriceSchedules.1.Price': '2.0',
+            'PriceSchedules.1.Term': '8',
+            'Version': '2012-08-15'},
+             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
+                                   'SignatureVersion', 'Timestamp'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This includes adding new parameters for two
existing API calls:
- get_all_reserved_instances_offerings
- purchase_reserved_instance_offering

And adds two new API calls:
- create_reserved_instances_listing
- cancel_reserved_instances_listing
