### PR TITLE
Use simplejson when json module not available

### DIFF
--- a/boto/iam/connection.py
+++ b/boto/iam/connection.py
@@ -19,7 +19,10 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-import json
+try:
+    import json
+except ImportError:
+    import simplejson as json
 
 import boto
 import boto.jsonresponse


### PR DESCRIPTION
If python < 2.6 is used (including Jython), the json module isn't yet available in the standard library. 
Using simplejson as a fallback, if available, would be nice.
