### PR TITLE
Update boto/emr/connection.py

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -461,9 +461,9 @@ class EmrConnection(AWSQueryConnection):
         properly prefixed, can be used for describing InstanceGroups in
         RunJobFlow or AddInstanceGroups requests.
         """
-        params = {'InstanceCount': instance_group.num_instances,
-                  'InstanceRole': instance_group.role,
-                  'InstanceType': instance_group.type,
+        params = {'InstanceCount': instance_group.instancerequestcount,
+                  'InstanceRole': instance_group.instancerole,
+                  'InstanceType': instance_group.instancetype,
                   'Name': instance_group.name,
                   'Market': instance_group.market}
         if instance_group.market == 'SPOT':


### PR DESCRIPTION
InstanceGroup defined at line 109 in following file
https://github.com/boto/boto/blob/develop/boto/emr/emrobject.py does not have num_instances, role, and type. Instead it has instancerequestcount, instancerole, and instancetype.  

The original code caused exception like "ttributeError: 'InstanceGroup' object has no attribute " and new code proposed fixes the problem.
