### PR TITLE
Add an __eq__ method for boto.s3.tagging.Tag

### DIFF
--- a/boto/s3/tagging.py
+++ b/boto/s3/tagging.py
@@ -20,6 +20,9 @@ class Tag(object):
         return '<Tag><Key>%s</Key><Value>%s</Value></Tag>' % (
             self.key, self.value)
 
+    def __eq__(self, other):
+        return (self.key == other.key and self.value == other.value)
+
 
 class TagSet(list):
     def startElement(self, name, attrs, connection):


### PR DESCRIPTION
Allows boto.s3.tagging.Tag objects to be compared especially when checking for existence within a TagSet
