### PR TITLE
Add proper to_print for LBR RRs in Route53

### DIFF
--- a/boto/route53/record.py
+++ b/boto/route53/record.py
@@ -264,6 +264,8 @@ class Record(object):
 
         if self.identifier != None and self.weight != None:
             rr += ' (WRR id=%s, w=%s)' % (self.identifier, self.weight)
+        elif self.identifier != None and self.region != None:
+            rr += ' (LBR id=%s, region=%s)' % (self.identifier, self.region)
 
         return rr
 


### PR DESCRIPTION
Discovered while working on https://github.com/boto/boto/pull/478
