### PR TITLE
Close opened file in setup.py script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+from __future__ import with_statement
+
 try:
     from setuptools import setup
     extra = dict(test_suite="tests.test.suite", include_package_data=True)
@@ -39,10 +41,14 @@ if sys.version_info <= (2, 4):
     print >> sys.stderr, error
     sys.exit(1)
 
+def readme():
+    with open("README.rst") as f:
+        return f.read()
+
 setup(name = "boto",
       version = __version__,
       description = "Amazon Web Services Library",
-      long_description = open("README.rst").read(),
+      long_description = readme(),
       author = "Mitch Garnaat",
       author_email = "mitch@garnaat.com",
       scripts = ["bin/sdbadmin", "bin/elbadmin", "bin/cfadmin",


### PR DESCRIPTION
While `file.__del__()` closes itself in CPython, PyPy doesn’t use reference counting but garbage collection, so destructors aren’t automatically closed immediately.  Invoked time of `__del__` is not decidable in PyPy.

Ideally it must never cause any problem, but in real world we can’t assume setup.py script is immediately terminated.  Because in many cases users install boto using setuptools/`easy_install`. It might cause “too many open files” error.  In Windows opened files aren’t accessible by other process.  (setuptools tries copying files including `README.rst` while the file has been opened.)

So we should explicitly call `file.close()` in `try`–`finally` block or use `with` block.  This patch uses the latter way.
