### PR TITLE
Updating RDS API Version to 2012-09-17

### DIFF
--- a/boto/rds/__init__.py
+++ b/boto/rds/__init__.py
@@ -81,7 +81,7 @@ class RDSConnection(AWSQueryConnection):
 
     DefaultRegionName = 'us-east-1'
     DefaultRegionEndpoint = 'rds.us-east-1.amazonaws.com'
-    APIVersion = '2011-04-01'
+    APIVersion = '2012-09-17'
 
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,
@@ -162,7 +162,7 @@ class RDSConnection(AWSQueryConnection):
                           license_model = None,
                           option_group_name = None,
                           ):
-        # API version: 2012-04-23
+        # API version: 2012-09-17
         # Parameter notes:
         # =================
         # id should be db_instance_identifier according to API docs but has been left


### PR DESCRIPTION
The current API version didn't have support for launching RDS's into a VPC, even though the keyword options were there.  This pull request just updates it to the most recent version, 2012-09-17.  The old documentation had 2012-04-23, but the variable APIVersion was still 2011-04-01.  I'm cool with setting APIVersion = 2012-04-23, but I figure if I'm going to pull request an update, might as well use the latest documentation version.
