### PR TITLE
Fixing describe_alarms

### DIFF
--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -391,7 +391,7 @@ class CloudWatchConnection(AWSQueryConnection):
         if state_value:
             params['StateValue'] = state_value
         return self.get_list('DescribeAlarms', params,
-                             [('MetricAlarms', MetricAlarms)])[0]
+                             [('MetricAlarms', MetricAlarms)])
 
     def describe_alarm_history(self, alarm_name=None,
                                start_date=None, end_date=None,


### PR DESCRIPTION
As coded prior to my fix, describe_alarms returns the first element from the get_list() call; get_list returns a ResultSet which according to the API is what describe_alarms() is supposed to return, but by returning the first element, we actually return a MetricAlarms object.  Which also means we have no next_token element, and cannot retrieve alarms beyond the first set of alarms returned by the paginated AWS interface.  Returning the full result from get_list() gets us a ResultSet as the Boto documented API says we should get.
