### PR TITLE
Convert binary value back to Binary type

### DIFF
--- a/boto/dynamodb/layer2.py
+++ b/boto/dynamodb/layer2.py
@@ -28,7 +28,7 @@ from boto.dynamodb.schema import Schema
 from boto.dynamodb.item import Item
 from boto.dynamodb.batch import BatchList, BatchWriteList
 from boto.dynamodb.types import get_dynamodb_type, dynamize_value, \
-        convert_num, convert_binary, Binary
+        convert_num, convert_binary
 
 
 def item_object_hook(dct):
@@ -48,7 +48,7 @@ def item_object_hook(dct):
     if 'NS' in dct:
         return set(map(convert_num, dct['NS']))
     if 'B' in dct:
-        return Binary(base64.b64decode(dct['B']))
+        return convert_binary(dct['B'])
     if 'BS' in dct:
         return set(map(convert_binary, dct['BS']))
     return dct


### PR DESCRIPTION
After retrieving an item which has a binary field, it would fail to be saved unless all binary fields were mapped back to Binary. This commit solves that problem by automatically mapping binary fields to Binary when an item is retrieved from dynamoDB.
