### PR TITLE
fix for CW describe_alarms()

### DIFF
--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -390,8 +390,12 @@ class CloudWatchConnection(AWSQueryConnection):
             params['NextToken'] = next_token
         if state_value:
             params['StateValue'] = state_value
-        return self.get_list('DescribeAlarms', params,
-                             [('MetricAlarms', MetricAlarms)])[0]
+
+        result = self.get_list('DescribeAlarms', params,
+                               [('MetricAlarms', MetricAlarms)])
+        ret = result[0]
+        ret.next_token = result.next_token
+        return ret
 
     def describe_alarm_history(self, alarm_name=None,
                                start_date=None, end_date=None,

--- a/tests/integration/ec2/cloudwatch/test_connection.py
+++ b/tests/integration/ec2/cloudwatch/test_connection.py
@@ -34,6 +34,7 @@ from boto.ec2.cloudwatch.metric import Metric
 # HTTP response body for CloudWatchConnection.describe_alarms
 DESCRIBE_ALARMS_BODY = """<DescribeAlarmsResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">
   <DescribeAlarmsResult>
+    <NextToken>mynexttoken</NextToken>
     <MetricAlarms>
       <member>
         <StateUpdatedTimestamp>2011-11-18T23:43:59.111Z</StateUpdatedTimestamp>
@@ -264,6 +265,7 @@ class CloudWatchConnectionTest(unittest.TestCase):
 
         c.make_request = make_request
         alarms = c.describe_alarms()
+        self.assertEquals(alarms.next_token, 'mynexttoken')
         self.assertEquals(alarms[0].name, 'FancyAlarm')
         self.assertEquals(alarms[0].comparison, '<')
         self.assertEquals(alarms[0].dimensions, {u'Job': [u'ANiceCronJob']})


### PR DESCRIPTION
Carry over the next_token field from the ResultSet object to the return value.
