### PR TITLE
Hotfix for issue #1051: Changed DSInstance.modify() to explicitly name arguments

### DIFF
--- a/boto/rds/dbinstance.py
+++ b/boto/rds/dbinstance.py
@@ -275,16 +275,17 @@ class DBInstance(object):
         :return: The modified db instance.
         """
         return self.connection.modify_dbinstance(self.id,
-                                                 param_group,
-                                                 security_groups,
-                                                 preferred_maintenance_window,
-                                                 master_password,
-                                                 allocated_storage,
-                                                 instance_class,
-                                                 backup_retention_period,
-                                                 preferred_backup_window,
-                                                 multi_az,
-                                                 apply_immediately)
+                                                 param_group=param_group,
+                                                 security_groups=security_groups,
+                                                 preferred_maintenance_window=preferred_maintenance_window,
+                                                 master_password=master_password,
+                                                 allocated_storage=allocated_storage,
+                                                 instance_class=instance_class,
+                                                 backup_retention_period=backup_retention_period,
+                                                 preferred_backup_window=preferred_backup_window,
+                                                 multi_az=multi_az,
+                                                 iops=iops,
+                                                 apply_immediately=apply_immediately)
 
 
 class PendingModifiedValues(dict):


### PR DESCRIPTION
This hotfix resolves issue #1051.

On the initial support for provisioned IOPS in RDS, the DBInstance.modify method used ordered arguments to call the RDSConnection.modify_dbinstance method. 

Adding the iops parameter swapped the iops & apply_immediately values when calling modify directly from the DBInstance.

This hotfix switches the DBInstance.modfy method to use explicitly named arguments.
