### PR TITLE
Bugfix for missing 'time' import.

### DIFF
--- a/boto/cloudsearch/optionstatus.py
+++ b/boto/cloudsearch/optionstatus.py
@@ -22,6 +22,7 @@
 # IN THE SOFTWARE.
 #
 
+import time
 try:
     import simplejson as json
 except ImportError:


### PR DESCRIPTION
Line 123 invokes `time.sleep(5)`, but time is never imported.
No testing necessary.
