### PR TITLE
use ElementList instead of Element for boto.mws.response.GetReportReques...

### DIFF
--- a/boto/mws/response.py
+++ b/boto/mws/response.py
@@ -266,7 +266,7 @@ class RequestReportResult(ResponseElement):
 
 
 class GetReportRequestListResult(RequestReportResult):
-    ReportRequestInfo = Element()
+    ReportRequestInfo = ElementList()
 
 
 class GetReportRequestListByNextTokenResult(GetReportRequestListResult):


### PR DESCRIPTION
...tListResult.ReportRequestInfo

The GetReportRequestList response can contain multiple ReportRequestInfo elements, and using Element for these results in the loss of all but final element.
