### PR TITLE
Fix signature generation when using a proxy server in boto/auth.py

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -264,7 +264,7 @@ class HmacAuthV3HTTPHandler(AuthHandler, HmacKeys):
         headers_to_sign = self.headers_to_sign(http_request)
         canonical_headers = self.canonical_headers(headers_to_sign)
         string_to_sign = '\n'.join([http_request.method,
-                                    http_request.path,
+                                    http_request.auth_path,
                                     '',
                                     canonical_headers,
                                     '',
@@ -363,7 +363,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         return ';'.join(l)
 
     def canonical_uri(self, http_request):
-        return http_request.path
+        return http_request.auth_path
 
     def payload(self, http_request):
         body = http_request.body


### PR DESCRIPTION
When using a proxy server AWSAuthConnection.build_base_http_request will modify the http_request.path to include the host header.  It caches the original path in the auth_path field so that the signature can be later correctly generated. 

Both the HMACAuthV3HTTPHandler and HMACAuthV4HTTPHandler signature generation methods in auth.py look at the path field and not the cached original auth_path which means boto will generate an incorrect signature when using a proxy server.

This patch updates those signature generation methods to use auth_path instead of path.
