### PR TITLE
Remove hack used in describe_alarms parsing 

### DIFF
--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -387,11 +387,8 @@ class CloudWatchConnection(AWSQueryConnection):
         if state_value:
             params['StateValue'] = state_value
 
-        result = self.get_list('DescribeAlarms', params,
-                               [('MetricAlarms', MetricAlarms)])
-        ret = result[0]
-        ret.next_token = result.next_token
-        return ret
+        return self.get_list('DescribeAlarms', params,
+                             [('member', MetricAlarm)])
 
     def describe_alarm_history(self, alarm_name=None,
                                start_date=None, end_date=None,


### PR DESCRIPTION
This hack isn't needed.  The MetricAlarm data is already present in the 'member' field so we can parse it directly instead of splicing out the first 'MetricAlarms' object and manually copying next_token.

The DescribeAlarmsForMetric response looks almost the same and is already being parsed in this way.
