### PR TITLE
Glacier: Raise exception on empty archive upload attempt

### DIFF
--- a/boto/glacier/exceptions.py
+++ b/boto/glacier/exceptions.py
@@ -44,3 +44,6 @@ class UnexpectedHTTPResponseError(Exception):
 
 class UploadArchiveError(Exception):
     pass
+
+class EmptyArchiveError(UploadArchiveError):
+    pass


### PR DESCRIPTION
Currently you get a weird failure in tree_hash() instead:

```
Traceback (most recent call last):
  <snip>
  File "/home/pete/src/glacier-cli/boto/glacier/writer.py", line 65, in tree_hash
    return hashes[0]
IndexError: list index out of range
```

Amazon does not allow empty archives to be uploaded, so raising an exception specific to this error is correct.

FWIW I've also written a (much uglier) patch for glacier-cli to allow you to fake uploads of empty archives so git-annex works.
