### PR TITLE
Add __future__ import of with_statement for < python2.5 compat

### DIFF
--- a/boto/glacier/job.py
+++ b/boto/glacier/job.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
+from __future__ import with_statement
 import math
 import socket
 

--- a/boto/glacier/vault.py
+++ b/boto/glacier/vault.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-
+from __future__ import with_statement
 from .job import Job
 from .writer import Writer, compute_hashes_from_fileobj
 from .concurrent import ConcurrentUploader


### PR DESCRIPTION
After looking through the source it looks like the only two places that use the 'with' statement without a "from **future** import with_statement" are in glacier. This should take care of those two cases making glacier work from Python2.5 or earlier, Jython, etc.
