### PR TITLE
Add a --filter option for list_instances

### DIFF
--- a/bin/list_instances
+++ b/bin/list_instances
@@ -35,7 +35,9 @@ def main():
     parser.add_option("-r", "--region", help="Region (default us-east-1)", dest="region", default="us-east-1")
     parser.add_option("-H", "--headers", help="Set headers (use 'T:tagname' for including tags)", default=None, action="store", dest="headers", metavar="ID,Zone,Groups,Hostname,State,T:Name")
     parser.add_option("-t", "--tab", help="Tab delimited, skip header - useful in shell scripts", action="store_true", default=False)
+    parser.add_option("-f", "--filter", help="Filter option sent to DescribeInstances API call, format is key1=value1,key2=value2,...", default=None)
     (options, args) = parser.parse_args()
+
 
     # Connect the region
     for r in regions():
@@ -62,13 +64,19 @@ def main():
             format_string += "%%-%ds" % HEADERS[h]['length']
 
 
+    # Parse filters (if any)
+    if options.filter:
+        filters = dict([entry.split('=') for entry in options.filter.split(',')])
+    else:
+        filters = {}
+
     # List and print
 
     if not options.tab:
         print format_string % headers
         print "-" * len(format_string % headers)
 
-    for r in ec2.get_all_instances():
+    for r in ec2.get_all_instances(filters=filters):
         groups = [g.name for g in r.groups]
         for i in r.instances:
             i.groups = ','.join(groups)


### PR DESCRIPTION
Add a --filter (abbreviated -f) option for bin/list_instances.

This allows to restrict instance list using EC2 API DescribeInstances defined filters. It allows to script actions based on list_instances easily.
