### PR TITLE
Fix reserved instance missing 'start' attribute.

### DIFF
--- a/boto/ec2/reservedinstance.py
+++ b/boto/ec2/reservedinstance.py
@@ -128,6 +128,7 @@ class ReservedInstance(ReservedInstancesOffering):
                                            usage_price, description)
         self.instance_count = instance_count
         self.state = state
+        self.start = None
 
     def __repr__(self):
         return 'ReservedInstance:%s' % self.id
@@ -139,6 +140,8 @@ class ReservedInstance(ReservedInstancesOffering):
             self.instance_count = int(value)
         elif name == 'state':
             self.state = value
+        elif name == 'start':
+            self.start = value
         else:
             ReservedInstancesOffering.endElement(self, name, value, connection)
 


### PR DESCRIPTION
Bug introduced with e2a38bd985c13160.  start field was lost with
the removal of the blanket setattr in the parent object
(ReservedInstancesOffering)
