### PR TITLE
Various fixes in _mexe:

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -786,7 +786,10 @@ class AWSAuthConnection(object):
         """
         boto.log.debug('Method: %s' % request.method)
         boto.log.debug('Path: %s' % request.path)
-        boto.log.debug('Data: %s' % request.body)
+        if len(request.body) > 128:
+            boto.log.debug('Data (first 1024 of %s bytes): %s' % (len(request.body), request.body[0:1024]))
+        else:
+            boto.log.debug('Data: %s' % request.body)
         boto.log.debug('Headers: %s' % request.headers)
         boto.log.debug('Host: %s' % request.host)
         response = None
@@ -854,10 +857,12 @@ class AWSAuthConnection(object):
                     if isinstance(e, unretryable):
                         boto.log.debug(
                             'encountered unretryable %s exception, re-raising' %
-                            e.__class__.__name__)
+                            e)
                         raise e
                 boto.log.debug('encountered %s exception, reconnecting' % \
-                                  e.__class__.__name__)
+                                  e)
+                if hasattr(request.body, 'seek'):
+                    request.body.seek(0)
                 connection = self.new_http_connection(request.host,
                                                       self.is_secure)
             time.sleep(next_sleep)
@@ -952,7 +957,7 @@ class AWSQueryConnection(AWSAuthConnection):
         return self._mexe(http_request)
 
     def build_list_params(self, params, items, label):
-        if isinstance(items, str):
+        if isinstance(items, basestring):
             items = [items]
         for i in range(1, len(items) + 1):
             params['%s.%d' % (label, i)] = items[i - 1]


### PR DESCRIPTION
Logging the http request body: if the body is >1024 bytes, only the first 1024 bytes are logged, together with the total size of the body. This to prevent logging MB or even GB sized bodies like when uploading files. The first 1024 bytes should be enough to see whether the body is as expected.

Log e instead of e.**class**.**name** when an error is encountered, to have an actual error name (e.**class**.**name** results in 'error' which is not exactly useful).

If the request.body is a file-like object (e.g. an mmapped file), the seek pointer must be reset to 0 before retrying. Otherwise this gives problems calculating the hash for the authentication signature.
