### PR TITLE
Add new S3 location: AP Southeast 2 (Sydney)

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -143,6 +143,7 @@ class Location:
     SAEast = 'sa-east-1'
     APNortheast = 'ap-northeast-1'
     APSoutheast = 'ap-southeast-1'
+    APSoutheast2 = 'ap-southeast-2'
 
 
 class S3Connection(AWSAuthConnection):


### PR DESCRIPTION
Amazon have added a new location: Asia-Pacific Southeast 2, in Sydney, Australia.  This change adds support for this location.
