### PR TITLE
Sort by param keys only for sigv4

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -342,11 +342,10 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         if http_request.method == 'POST':
             return ""
         l = []
-        for param in http_request.params:
+        for param in sorted(http_request.params):
             value = str(http_request.params[param])
             l.append('%s=%s' % (urllib.quote(param, safe='-_.~'),
                                 urllib.quote(value, safe='-_.~')))
-        l = sorted(l)
         return '&'.join(l)
 
     def canonical_headers(self, headers_to_sign):

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -49,3 +49,15 @@ class TestSigV4Handler(unittest.TestCase):
                          'host:glacier.us-east-1.amazonaws.com\n'
                          'x-amz-archive-description:two spaces\n'
                          'x-amz-glacier-version:2012-06-01')
+
+    def test_canonical_query_string(self):
+        auth = HmacAuthV4Handler('glacier.us-east-1.amazonaws.com',
+                                 Mock(), self.provider)
+        request = HTTPRequest(
+            'GET', 'https', 'glacier.us-east-1.amazonaws.com', 443,
+            '/-/vaults/foo/archives', None, {},
+            {'x-amz-glacier-version': '2012-06-01'}, '')
+        request.params['Foo.1'] = 'aaa'
+        request.params['Foo.10'] = 'zzz'
+        query_string = auth.canonical_query_string(request)
+        self.assertEqual(query_string, 'Foo.1=aaa&Foo.10=zzz')


### PR DESCRIPTION
The sigv4 spec states that the canonical_query_string should be sorted by the
param keys only.  Boto was previously using 'key=value' as the sort key.
This will cause auth errors when serializing items with 10 or more items
(the included test shows an example of this).
