### PR TITLE
Add Name field to `elbadmin get` output.

### DIFF
--- a/bin/elbadmin
+++ b/bin/elbadmin
@@ -109,9 +109,12 @@ def get(elb, name):
 
         # Make map of all instance Id's to Name tags
         ec2 = boto.connect_ec2()
-        names = {}
 
-        for r in ec2.get_all_instances():
+        instance_health = b.get_instance_health()
+        instances = [state.instance_id for state in instance_health]
+
+        names = {}
+        for r in ec2.get_all_instances(instances):
             for i in r.instances:
                 names[i.id] = i.tags.get('Name', '')
 
@@ -123,7 +126,7 @@ def get(elb, name):
                                        "STATE",
                                        name_column_width, "NAME",
                                        "DESCRIPTION")
-        for state in b.get_instance_health():
+        for state in instance_health:
             print "%-12s %-15s %-*s %s" % (state.instance_id,
                                            state.state,
                                            name_column_width, names[state.instance_id],


### PR DESCRIPTION
Contributing a change that has been very useful for my own daily use:

Meaningful Name fields are much easier to identify than instance id's.
