### PR TITLE
Add a command-line interface for MTurk

### DIFF
--- a/bin/mturk
+++ b/bin/mturk
@@ -146,7 +146,7 @@ def get_nickname(hitid):
 def display_datetime(dt):
     return dt.strftime('%e %b %Y, %l:%M %P')
 
-def display_hit(hit):
+def display_hit(hit, verbose = False):
     et = parse_timestamp(hit.Expiration)
     return '\n'.join([
         '{} - {} ({}, {}, {})'.format(
@@ -170,10 +170,13 @@ def display_hit(hit):
             int(hit.MaxAssignments) - (int(hit.NumberOfAssignmentsAvailable) + int(hit.NumberOfAssignmentsPending) + int(hit.NumberOfAssignmentsCompleted)),
             hit.NumberOfAssignmentsCompleted)
             if hasattr(hit, 'NumberOfAssignmentsAvailable')
-            else 'Assignments: {} total'.format(hit.MaxAssignments)
+            else 'Assignments: {} total'.format(hit.MaxAssignments),
             # For some reason, SearchHITs includes the
             # NumberOfAssignmentsFoobar fields but GetHIT doesn't.
-        ]) + '\n'
+        ] + ([] if not verbose else [
+            '\nDescription: ' + hit.Description,
+            '\nKeywords: ' + hit.Keywords
+        ])) + '\n'
 
 def digest_assignment(a):
     return dict(
@@ -191,7 +194,7 @@ def get_balance():
     return con.get_account_balance()
 
 def show_hit(hit):
-    return display_hit(con.get_hit(hit)[0])
+    return display_hit(con.get_hit(hit)[0], verbose = True)
 
 def list_hits():
     'Lists your 10 most recently created HITs, with the most recent last.'


### PR DESCRIPTION
I wrote this thing because the Amazon Mechanical Turk Command Line Tools are really old. They seem to require a deprecated version of Java, and they were never very convenient, anyway.

I've only tested my program in the MTurk sandbox so far. I'll probably start using it for real before 2013.

Several features, like non-external questions, aren't implemented merely because I don't use them.
