### PR TITLE
connection: use right host for tunneled https connections

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -658,7 +658,7 @@ class AWSAuthConnection(object):
             return self.new_http_connection(host, is_secure)
 
     def new_http_connection(self, host, is_secure):
-        if self.use_proxy:
+        if self.use_proxy and not is_secure:
             host = '%s:%d' % (self.proxy, int(self.proxy_port))
         if host is None:
             host = self.server_name()
@@ -667,7 +667,7 @@ class AWSAuthConnection(object):
                     'establishing HTTPS connection: host=%s, kwargs=%s',
                     host, self.http_connection_kwargs)
             if self.use_proxy:
-                connection = self.proxy_ssl()
+                connection = self.proxy_ssl(host, is_secure and 443 or 80)
             elif self.https_connection_factory:
                 connection = self.https_connection_factory(host)
             elif self.https_validate_certificates and HAVE_HTTPS_CONNECTION:
@@ -703,8 +703,11 @@ class AWSAuthConnection(object):
     def put_http_connection(self, host, is_secure, connection):
         self._pool.put_http_connection(host, is_secure, connection)
 
-    def proxy_ssl(self):
-        host = '%s:%d' % (self.host, self.port)
+    def proxy_ssl(self, host=None, port=None):
+        if host and port:
+            host = '%s:%d' % (host, port)
+        else:
+            host = '%s:%d' % (self.host, self.port)
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             sock.connect((self.proxy, int(self.proxy_port)))


### PR DESCRIPTION
This should fix the use of boto under HTTP proxy.

It fixess the issue described in the following thread: https://forums.aws.amazon.com/message.jspa?messageID=326831.

Also fixes #926.
