### PR TITLE
S3Connection.build_post_form_args(): omit 'content-length-range' from fields list

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -278,8 +278,6 @@ class S3Connection(AWSAuthConnection):
             fields.append({"name": "success_action_redirect", "value": success_action_redirect})
         if max_content_length:
             conditions.append('["content-length-range", 0, %i]' % max_content_length)
-            fields.append({"name": 'content-length-range',
-                           "value": "0,%i" % max_content_length})
 
         if self.provider.security_token:
             fields.append({'name': 'x-amz-security-token',


### PR DESCRIPTION
It appears that `content-length-range` is not a part of [POST form fields spec](http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTObjectPOST.html), and S3 actually complains if it is present in request. Putting it to `conditions` is enough.
