### PR TITLE
Make boto.ec2 work with Python 3.2 and Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ python:
   - "2.6"
   - "2.7"
   - "3.2"
+  - "3.3"
 before_install:
   - sudo apt-get install swig
-install: if [ "$(python --version 2>&1)" == "Python 3.2.3" ]; then pip install -r requirements-py3.txt --use-mirrors; else pip install -r requirements.txt --use-mirrors; fi
-script: if [ "$(python --version 2>&1)" == "Python 3.2.3" ]; then nosetests -v tests/unit/ec2; else python tests/test.py unit; fi
+install: if [[ $(python --version 2>&1) == Python\ 3* ]]; then pip install -r requirements-py3.txt --use-mirrors; else pip install -r requirements.txt --use-mirrors; fi
+script: if [[ $(python --version 2>&1) == Python\ 3* ]]; then nosetests -v tests/unit/ec2; else python tests/test.py unit; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.2"
 before_install:
   - sudo apt-get install swig
-install: pip install --use-mirrors -r requirements.txt
-script: python tests/test.py unit
+install: if [ "$(python --version 2>&1)" == "Python 3.2.3" ]; then pip install -r requirements-py3.txt --use-mirrors; else pip install -r requirements.txt --use-mirrors; fi
+script: if [ "$(python --version 2>&1)" == "Python 3.2.3" ]; then nosetests -v tests/unit/ec2; else python tests/test.py unit; fi
+

--- a/boto/__init__.py
+++ b/boto/__init__.py
@@ -32,7 +32,7 @@ import re
 import sys
 import logging
 import logging.config
-import urlparse
+from boto.compat23 import urlparse
 from boto.exception import InvalidUriError
 
 __version__ = '2.6.0-dev'
@@ -449,7 +449,7 @@ def connect_ec2_endpoint(url, aws_access_key_id=None,
     """
     from boto.ec2.regioninfo import RegionInfo
 
-    purl = urlparse.urlparse(url)
+    purl = urlparse(url)
     kwargs['port'] = purl.port
     kwargs['host'] = purl.hostname
     kwargs['path'] = purl.path
@@ -673,7 +673,7 @@ def storage_uri(uri_str, default_scheme='file', debug=0, validate=True,
     The last example uses the default scheme ('file', unless overridden)
     """
 
-    # Manually parse URI components instead of using urlparse.urlparse because
+    # Manually parse URI components instead of using urlparse because
     # what we're calling URIs don't really fit the standard syntax for URIs
     # (the latter includes an optional host/net location part).
     end_scheme_idx = uri_str.find('://')

--- a/boto/auth_handler.py
+++ b/boto/auth_handler.py
@@ -23,7 +23,7 @@
 Defines an interface which all Auth handlers need to implement.
 """
 
-from plugin import Plugin
+from boto.plugin import Plugin
 
 class NotReadyToAuthenticate(Exception):
   pass

--- a/boto/compat23.py
+++ b/boto/compat23.py
@@ -35,7 +35,7 @@ except ImportError:
     from urllib.parse import urlparse
 
 def ensure_bytes(bytes_or_str):
-    if isinstance(bytes_or_str, bytes):
+    if isinstance(bytes_or_str, bytes) or bytes_or_str is None:
         return bytes_or_str
     else:
         return bytes_or_str.encode('latin-1')

--- a/boto/compat23.py
+++ b/boto/compat23.py
@@ -35,6 +35,8 @@ except ImportError:
     from urllib.parse import urlparse
 
 def ensure_bytes(bytes_or_str):
-    str_value = str(bytes_or_str)
-    return str_value.encode('ascii')
+    if isinstance(bytes_or_str, bytes):
+        return bytes_or_str
+    else:
+        return bytes_or_str.encode('latin-1')
 

--- a/boto/compat23.py
+++ b/boto/compat23.py
@@ -1,0 +1,40 @@
+import sys
+
+# True if we are running on Python 3.
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    integer_types = int,
+else:
+    integer_types = (int, long)
+
+try:
+    # Python 2
+    xrange = xrange
+except NameError:
+    xrange = range
+
+try:
+    # Python 2
+    basestring = basestring
+except NameError:
+    basestring = str
+
+try:
+    # Python 2
+    from urllib import quote, quote_plus
+except ImportError:
+    # Python 3
+    from urllib.parse import quote, quote_plus
+
+try:
+    # Python 2
+    from urlparse import urlparse
+except ImportError:
+    # Python 3
+    from urllib.parse import urlparse
+
+def ensure_bytes(bytes_or_str):
+    str_value = str(bytes_or_str)
+    return str_value.encode('ascii')
+

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -617,7 +617,7 @@ class AWSAuthConnection(object):
             # (and higher!)
             # it no longer does that.  Hence, this kludge.
             if ((ON_APP_ENGINE and sys.version[:3] == '2.5') or
-                    sys.version[:3] in ('2.6', '2.7')) and port == 443:
+                    sys.version[:3] in ('2.6', '2.7', '3.2', '3.3')) and port == 443:
                 signature_host = self.host
             else:
                 signature_host = '%s:%d' % (self.host, port)

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -88,7 +88,7 @@ from boto.resultset import ResultSet
 HAVE_HTTPS_CONNECTION = False
 try:
     import ssl
-    from boto import https_connection
+    import boto.https_connection as https_connection
     # Google App Engine runs on Python 2.5 so doesn't have ssl.SSLError.
     if hasattr(ssl, 'SSLError'):
         HAVE_HTTPS_CONNECTION = True

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -54,6 +54,13 @@ except ImportError:
     # Python 3
     from http.client import HTTPConnection, HTTPSConnection, HTTPResponse, HTTPException, BadStatusLine
 
+try:
+    # Python 2
+    long
+except NameError:
+    # Python 3
+    long = int
+
 import os
 import random
 import re

--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -45,6 +45,8 @@ from boto.ec2.autoscale.instance import Instance
 from boto.ec2.autoscale.scheduled import ScheduledUpdateGroupAction
 from boto.ec2.autoscale.tag import Tag
 
+from boto.compat23 import basestring, xrange
+
 RegionData = {
     'us-east-1': 'autoscaling.us-east-1.amazonaws.com',
     'us-west-1': 'autoscaling.us-west-1.amazonaws.com',

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -2096,7 +2096,7 @@ class EC2Connection(AWSQueryConnection):
         """
         try:
             return self.get_all_key_pairs(keynames=[keyname])[0]
-        except self.ResponseError, e:
+        except self.ResponseError as e:
             if e.code == 'InvalidKeyPair.NotFound':
                 return None
             else:

--- a/boto/ec2/keypair.py
+++ b/boto/ec2/keypair.py
@@ -83,7 +83,7 @@ class KeyPair(EC2Object):
             fp = open(file_path, 'wb')
             fp.write(self.material)
             fp.close()
-            os.chmod(file_path, 0600)
+            os.chmod(file_path, 0o600)
             return True
         else:
             raise BotoClientError('KeyPair contains no material')

--- a/boto/ec2/reservedinstance.py
+++ b/boto/ec2/reservedinstance.py
@@ -81,13 +81,13 @@ class ReservedInstancesOffering(EC2Object):
             self.marketplace = True if value == 'true' else False
 
     def describe(self):
-        print 'ID=%s' % self.id
-        print '\tInstance Type=%s' % self.instance_type
-        print '\tZone=%s' % self.availability_zone
-        print '\tDuration=%s' % self.duration
-        print '\tFixed Price=%s' % self.fixed_price
-        print '\tUsage Price=%s' % self.usage_price
-        print '\tDescription=%s' % self.description
+        print('ID=%s' % self.id)
+        print('\tInstance Type=%s' % self.instance_type)
+        print('\tZone=%s' % self.availability_zone)
+        print('\tDuration=%s' % self.duration)
+        print('\tFixed Price=%s' % self.fixed_price)
+        print('\tUsage Price=%s' % self.usage_price)
+        print('\tDescription=%s' % self.description)
 
     def purchase(self, instance_count=1):
         return self.connection.purchase_reserved_instance_offering(self.id, instance_count)

--- a/boto/exception.py
+++ b/boto/exception.py
@@ -106,7 +106,7 @@ class BotoServerError(Exception):
 
     def __str__(self):
         return '%s: %s %s\n%s' % (self.__class__.__name__,
-                                  self.status, self.reason, self.body)
+                                  self.status, self.reason, self.body.decode('utf-8'))
 
     def startElement(self, name, attrs, connection):
         pass

--- a/boto/exception.py
+++ b/boto/exception.py
@@ -30,13 +30,13 @@ from boto import handler
 from boto.resultset import ResultSet
 
 
-class BotoClientError(StandardError):
+class BotoClientError(Exception):
     """
     General Boto Client error (error accessing AWS)
     """
 
     def __init__(self, reason, *args):
-        StandardError.__init__(self, reason, *args)
+        Exception.__init__(self, reason, *args)
         self.reason = reason
 
     def __repr__(self):
@@ -45,7 +45,7 @@ class BotoClientError(StandardError):
     def __str__(self):
         return 'BotoClientError: %s' % self.reason
 
-class SDBPersistenceError(StandardError):
+class SDBPersistenceError(Exception):
 
     pass
 
@@ -67,10 +67,10 @@ class GSPermissionsError(StoragePermissionsError):
     """
     pass
 
-class BotoServerError(StandardError):
+class BotoServerError(Exception):
 
     def __init__(self, status, reason, body=None, *args):
-        StandardError.__init__(self, status, reason, body, *args)
+        Exception.__init__(self, status, reason, body, *args)
         self.status = status
         self.reason = reason
         self.body = body or ''
@@ -85,7 +85,7 @@ class BotoServerError(StandardError):
             try:
                 h = handler.XmlHandler(self, self)
                 xml.sax.parseString(self.body, h)
-            except (TypeError, xml.sax.SAXParseException), pe:
+            except (TypeError, xml.sax.SAXParseException) as pe:
                 # Remove unparsable message body so we don't include garbage
                 # in exception. But first, save self.body in self.error_message
                 # because occasionally we get error messages from Eucalyptus

--- a/boto/https_connection.py
+++ b/boto/https_connection.py
@@ -19,7 +19,13 @@
 
 """Extensions to allow HTTPS requests with SSL certificate validation."""
 
-import httplib
+try:
+    # Python 2
+    import httplib
+except ImportError:
+    # Python 3
+    import http.client as httplib
+
 import re
 import socket
 import ssl

--- a/boto/provider.py
+++ b/boto/provider.py
@@ -35,6 +35,7 @@ from boto.gs.acl import ACL
 from boto.gs.acl import CannedACLStrings as CannedGSACLStrings
 from boto.s3.acl import CannedACLStrings as CannedS3ACLStrings
 from boto.s3.acl import Policy
+from boto.compat23 import ensure_bytes
 
 
 HEADER_PREFIX_KEY = 'header_prefix'
@@ -272,11 +273,7 @@ class Provider(object):
                            self._credential_expiry_time - datetime.now(), expires_at)
 
     def _convert_key_to_str(self, key):
-        if isinstance(key, unicode):
-            # the secret key must be bytes and not unicode to work
-            #  properly with hmac.new (see http://bugs.python.org/issue5285)
-            return str(key)
-        return key
+        return ensure_bytes(key)
 
     def configure_headers(self):
         header_info_map = self.HeaderInfoMap[self.name]

--- a/boto/pyami/config.py
+++ b/boto/pyami/config.py
@@ -26,7 +26,7 @@ import warnings
 
 try:
     # Python 2
-    import StringIO
+    from StringIO import StringIO
 except ImportError:
     # Python 3
     from io import StringIO
@@ -91,7 +91,7 @@ class Config(SafeConfigParser):
 
     def load_credential_file(self, path):
         """Load a credential file as is setup like the Java utilities"""
-        c_data = StringIO.StringIO()
+        c_data = StringIO()
         c_data.write("[Credentials]\n")
         for line in open(path, "r").readlines():
             c_data.write(line.replace("AWSAccessKeyId", "aws_access_key_id").replace("AWSSecretKey", "aws_secret_access_key"))
@@ -195,13 +195,13 @@ class Config(SafeConfigParser):
             self.set(section, name, 'false')
     
     def dump(self):
-        s = StringIO.StringIO()
+        s = StringIO()
         self.write(s)
         print(s.getvalue())
 
     def dump_safe(self, fp=None):
         if not fp:
-            fp = StringIO.StringIO()
+            fp = StringIO()
         for section in self.sections():
             fp.write('[%s]\n' % section)
             for option in self.options(section):

--- a/boto/pyami/config.py
+++ b/boto/pyami/config.py
@@ -20,9 +20,24 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-import StringIO, os, re
+
+import os, re
 import warnings
-import ConfigParser
+
+try:
+    # Python 2
+    import StringIO
+except ImportError:
+    # Python 3
+    from io import StringIO
+
+try:
+    # Python 2
+    from ConfigParser import SafeConfigParser
+except ImportError:
+    # Python 3
+    from configparser import SafeConfigParser
+
 import boto
 
 # If running in Google App Engine there is no "user" and
@@ -55,10 +70,10 @@ elif 'BOTO_PATH' in os.environ:
         BotoConfigLocations.append(expanduser(path))
 
 
-class Config(ConfigParser.SafeConfigParser):
+class Config(SafeConfigParser):
 
     def __init__(self, path=None, fp=None, do_load=True):
-        ConfigParser.SafeConfigParser.__init__(self, {'working_dir' : '/mnt/pyami',
+        SafeConfigParser.__init__(self, {'working_dir' : '/mnt/pyami',
                                                       'debug' : '0'})
         if do_load:
             if path:
@@ -99,7 +114,7 @@ class Config(ConfigParser.SafeConfigParser):
         Replace any previous value.  If the path doesn't exist, create it.
         Also add the option the the in-memory config.
         """
-        config = ConfigParser.SafeConfigParser()
+        config = SafeConfigParser()
         config.read(path)
         if not config.has_section(section):
             config.add_section(section)
@@ -143,21 +158,21 @@ class Config(ConfigParser.SafeConfigParser):
 
     def get(self, section, name, default=None):
         try:
-            val = ConfigParser.SafeConfigParser.get(self, section, name)
+            val = SafeConfigParser.get(self, section, name)
         except:
             val = default
         return val
     
     def getint(self, section, name, default=0):
         try:
-            val = ConfigParser.SafeConfigParser.getint(self, section, name)
+            val = SafeConfigParser.getint(self, section, name)
         except:
             val = int(default)
         return val
     
     def getfloat(self, section, name, default=0.0):
         try:
-            val = ConfigParser.SafeConfigParser.getfloat(self, section, name)
+            val = SafeConfigParser.getfloat(self, section, name)
         except:
             val = float(default)
         return val
@@ -182,7 +197,7 @@ class Config(ConfigParser.SafeConfigParser):
     def dump(self):
         s = StringIO.StringIO()
         self.write(s)
-        print s.getvalue()
+        print(s.getvalue())
 
     def dump_safe(self, fp=None):
         if not fp:

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -745,11 +745,12 @@ def notify(subject, body=None, html_body=None, to_string=None, attachments=None,
             boto.log.exception('notify failed')
 
 def get_utf8_value(value):
-    if not isinstance(value, str) and not isinstance(value, unicode):
+    if not hasattr(value, 'startswith'):
         value = str(value)
-    if isinstance(value, unicode):
+
+    try:
         return value.encode('utf-8')
-    else:
+    except AttributeError:
         return value
 
 def mklist(value):

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -1,0 +1,7 @@
+mock==0.8.0
+nose==1.1.2
+M2Crypto==0.21.1
+requests==0.13.1
+tox==1.4
+Sphinx==1.1.3
+argparse==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ M2Crypto==0.21.1
 requests==0.13.1
 tox==1.4
 Sphinx==1.1.3
-simplejson==2.5.2
 argparse==1.2.1
 unittest2==0.5.1

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -2,7 +2,13 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-import httplib
+
+try:
+    # Python 2
+    from httplib import HTTPSConnection, HTTPResponse
+except ImportError:
+    # Python 3
+    from http.client import HTTPSConnection, HTTPResponse
 
 from mock import Mock
 
@@ -15,7 +21,7 @@ class AWSMockServiceTestCase(unittest.TestCase):
     connection_class = None
 
     def setUp(self):
-        self.https_connection = Mock(spec=httplib.HTTPSConnection)
+        self.https_connection = Mock(spec=HTTPSConnection)
         self.https_connection_factory = (
             Mock(return_value=self.https_connection), ())
         self.service_connection = self.create_service_connection(
@@ -39,7 +45,7 @@ class AWSMockServiceTestCase(unittest.TestCase):
     def create_response(self, status_code, reason='', header=[], body=None):
         if body is None:
             body = self.default_body()
-        response = Mock(spec=httplib.HTTPResponse)
+        response = Mock(spec=HTTPResponse)
         response.status = status_code
         response.read.return_value = body
         response.reason = reason

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -53,7 +53,7 @@ class AWSMockServiceTestCase(unittest.TestCase):
         response.getheaders.return_value = header
         def overwrite_header(arg, default=None):
             header_dict = dict(header)
-            if header_dict.has_key(arg):
+            if arg in header_dict:
                 return header_dict[arg]
             else:
                 return default

--- a/tox.ini
+++ b/tox.ini
@@ -5,13 +5,13 @@ envlist = py26,py27,py32_ec2,py33_ec2
 [testenv]
 commands =
     pip install -qr requirements.txt
-    nosetests -v -w /tmp boto.tests.test boto.tests.unit
+    nosetests -v tests/test.py tests/unit
 
 [testenv:py27_ec2]
 basepython = python2.7
 commands =
     python --version
-    nosetests -v -w /tmp boto.tests.unit.ec2
+    nosetests -v tests/unit/ec2
 deps =
     mock==0.8.0
     nose==1.1.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,35 @@
 [tox]
-envlist = py26,py27
+envlist = py26,py27,py32_ec2,py33_ec2
 
 
 [testenv]
 commands =
     pip install -qr requirements.txt
-    python tests/test.py tests/unit
+    nosetests -v -w /tmp boto.tests.test boto.tests.unit
+
+[testenv:py27_ec2]
+basepython = python2.7
+commands =
+    python --version
+    nosetests -v -w /tmp boto.tests.unit.ec2
+deps =
+    mock==0.8.0
+    nose==1.1.2
+
+[testenv:py32_ec2]
+basepython = python3.2
+commands =
+    python --version
+    nosetests -v tests/unit/ec2
+deps =
+    mock==0.8.0
+    nose==1.1.2
+
+[testenv:py33_ec2]
+basepython = python3.3
+commands =
+    python --version
+    nosetests -v tests/unit/ec2
+deps =
+    mock==0.8.0
+    nose==1.1.2

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,17 @@ envlist = py26,py27,py32_ec2,py33_ec2
 [testenv]
 commands =
     pip install -qr requirements.txt
-    nosetests -v tests/test.py tests/unit
+    # nosetests -v tests/test.py tests/unit
+    python tests/test.py tests/unit
+
+[testenv:py26_ec2]
+basepython = python2.6
+commands =
+    python --version
+    nosetests -v tests/unit/ec2
+deps =
+    mock==0.8.0
+    nose==1.1.2
 
 [testenv:py27_ec2]
 basepython = python2.7


### PR DESCRIPTION
A bunch of changes to make `boto.ec2` tests pass on Python 3.2 and Python 3.3 while all boto tests continue to pass on Python 2. There has been some manual testing as well to verify that basic functionality works (e.g.: printing all available images) when connecting to Eucalyptus Community Cloud (see [here](https://github.com/boto/boto/pull/1156#issuecomment-13978916)) and EC2 (see [here](https://github.com/boto/boto/pull/1156#issuecomment-14049058)).

Passing Travis CI build: https://travis-ci.org/msabramo/boto/builds/3465072

This is the work that I alluded to in #1127.