### PR TITLE
Add debug logging for credential location

### DIFF
--- a/boto/provider.py
+++ b/boto/provider.py
@@ -230,22 +230,27 @@ class Provider(object):
             else:
                 return False
 
-
     def get_credentials(self, access_key=None, secret_key=None):
         access_key_name, secret_key_name = self.CredentialMap[self.name]
         if access_key is not None:
             self.access_key = access_key
+            boto.log.debug("Using access key provided by client.")
         elif access_key_name.upper() in os.environ:
             self.access_key = os.environ[access_key_name.upper()]
+            boto.log.debug("Using access key found in environment variable.")
         elif config.has_option('Credentials', access_key_name):
             self.access_key = config.get('Credentials', access_key_name)
+            boto.log.debug("Using access key found in config file.")
 
         if secret_key is not None:
             self.secret_key = secret_key
+            boto.log.debug("Using secret key provided by client.")
         elif secret_key_name.upper() in os.environ:
             self.secret_key = os.environ[secret_key_name.upper()]
+            boto.log.debug("Using secret key found in environment variable.")
         elif config.has_option('Credentials', secret_key_name):
             self.secret_key = config.get('Credentials', secret_key_name)
+            boto.log.debug("Using secret key found in config file.")
 
         if ((self._access_key is None or self._secret_key is None) and
                 self.MetadataServiceSupport[self.name]):


### PR DESCRIPTION
This makes it easier to troubleshoot any credential
issues.  Only the location of the credentials is logged,
not the actual credentials themselves.

Example:

```
>>> import os
>>> import boto
>>> boto.set_stream_logger('boto')
>>> c = boto.connect_s3()
2012-12-10 17:26:13,607 boto [DEBUG]:Using access key found in config file.
2012-12-10 17:26:13,607 boto [DEBUG]:Using secret key found in config file.

>>> c = boto.connect_s3('access_key', 'secret_key')
2012-12-10 17:26:23,071 boto [DEBUG]:Using access key provided by client.
2012-12-10 17:26:23,071 boto [DEBUG]:Using secret key provided by client.

>>> os.environ['AWS_ACCESS_KEY_ID'] = 'environ_access_key'
>>> os.environ['AWS_SECRET_ACCESS_KEY'] = 'environ_secret_key'
>>> c = boto.connect_s3()
2012-12-10 17:27:04,428 boto [DEBUG]:Using access key found in environment variable.
2012-12-10 17:27:04,429 boto [DEBUG]:Using secret key found in environment variable.
```

Would anyone else find this useful?
