### PR TITLE
Fix delete_key() so that it returns the key.

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -589,9 +589,10 @@ class Bucket(object):
             created or removed and what version_id the delete created
             or removed.
         """
-        self._delete_key_internal(key_name, headers=headers,
-                                  version_id=version_id, mfa_token=mfa_token,
-                                  query_args_l=None)
+        return self._delete_key_internal(key_name, headers=headers,
+                                         version_id=version_id,
+                                         mfa_token=mfa_token,
+                                         query_args_l=None)
 
     def _delete_key_internal(self, key_name, headers=None, version_id=None,
                              mfa_token=None, query_args_l=None):


### PR DESCRIPTION
The commit 1a0db44d broke the delete_key() method
which needs to return the key so that versioning
information is available should a delete marker
be created.
