### PR TITLE
Use fixed set of regions for ec2.connect_to_region

### DIFF
--- a/boto/ec2/__init__.py
+++ b/boto/ec2/__init__.py
@@ -24,6 +24,19 @@ This module provides an interface to the Elastic Compute Cloud (EC2)
 service from AWS.
 """
 from boto.ec2.connection import EC2Connection
+from boto.regioninfo import RegionInfo
+
+
+RegionData = {
+    'us-east-1': 'ec2.us-east-1.amazonaws.com',
+    'us-west-1': 'ec2.us-west-1.amazonaws.com',
+    'us-west-2': 'ec2.us-west-2.amazonaws.com',
+    'sa-east-1': 'ec2.sa-east-1.amazonaws.com',
+    'eu-west-1': 'ec2.eu-west-1.amazonaws.com',
+    'ap-northeast-1': 'ec2.ap-northeast-1.amazonaws.com',
+    'ap-southeast-1': 'ec2.ap-southeast-1.amazonaws.com',
+    'ap-southeast-2': 'ec2.ap-southeast-2.amazonaws.com',
+}
 
 
 def regions(**kw_params):
@@ -36,8 +49,13 @@ def regions(**kw_params):
     :rtype: list
     :return: A list of :class:`boto.ec2.regioninfo.RegionInfo`
     """
-    c = EC2Connection(**kw_params)
-    return c.get_all_regions()
+    regions = []
+    for region_name in RegionData:
+        region = RegionInfo(name=region_name,
+                            endpoint=RegionData[region_name],
+                            connection_cls=EC2Connection)
+        regions.append(region)
+    return regions
 
 
 def connect_to_region(region_name, **kw_params):

--- a/tests/integration/ec2/test_cert_verification.py
+++ b/tests/integration/ec2/test_cert_verification.py
@@ -26,7 +26,7 @@ Check that all of the certs on all service endpoints validate.
 """
 
 import unittest
-import boto.rds
+import boto.ec2
 
 
 class CertVerificationTest(unittest.TestCase):
@@ -35,6 +35,6 @@ class CertVerificationTest(unittest.TestCase):
     ssl = True
 
     def test_certs(self):
-        for region in boto.rds.regions():
+        for region in boto.ec2.regions():
             c = region.connect()
-            c.get_all_dbinstances()
+            c.get_all_instances()


### PR DESCRIPTION
The `boto.ec2.connect_to_region` function is implemented by calling `get_all_regions`.  This has a number of benefits, primarily that the list of ec2 regions is always up to date.  There are a number of downsides with this approach as well, two main ones being that every `connect_to_region` call makes a `get_all_regions` call and a dependency on us-east-1 (or the DefaultRegionName) even when connecting to other regions.

Also, switching to a fixed set of regions would make ec2 consistent with other boto modules connect_to_region implementations.
