### PR TITLE
DynamoDB: Passing custom retries exceeded handler

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -796,7 +796,7 @@ class AWSAuthConnection(object):
         return {'Proxy-Authorization': 'Basic %s' % auth}
 
     def _mexe(self, request, sender=None, override_num_retries=None,
-              retry_handler=None):
+              retry_handler=None, retry_exhausted_handler=None):
         """
         mexe - Multi-execute inside a loop, retrying multiple times to handle
                transient Internet errors by simply trying again.
@@ -889,7 +889,10 @@ class AWSAuthConnection(object):
         # use it to raise an exception.
         # Otherwise, raise the exception that must have already h#appened.
         if response:
-            raise BotoServerError(response.status, response.reason, body)
+            if callable(retry_exhausted_handler):
+                retry_exhausted_handler(response)
+            else:
+                raise BotoServerError(response.status, response.reason, body)
         elif e:
             raise e
         else:

--- a/boto/dynamodb/exceptions.py
+++ b/boto/dynamodb/exceptions.py
@@ -45,3 +45,11 @@ class DynamoDBValidationError(DynamoDBResponseError):
     has exceeded the 64Kb size limit.
     """
     pass
+
+
+class DynamoDBThroughputExceededError(BotoServerError):
+    """
+    Raised when a ProvisionedThroughputExceededException response is receive.
+    This happens after retries have been exceeded.
+    """
+    pass


### PR DESCRIPTION
Passing custom retries exceeded handler to _mexe method in DynamoDB. This method will handle retries exceeded to raise a throughput exceeded error from amazon rather than raising a generic BotoServerError.
