### PR TITLE
create_bucket kwarg location type

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -428,7 +428,7 @@ class S3Connection(AWSAuthConnection):
         :type headers: dict
         :param headers: Additional headers to pass along with the request to AWS.
 
-        :type location: :class:`boto.s3.connection.Location`
+        :type location: string
         :param location: The location of the new bucket
 
         :type policy: :class:`boto.s3.acl.CannedACLStrings`


### PR DESCRIPTION
The value of `location` kwarg is a member of `boto.s3.connection.Location` not an instance of it.
