### PR TITLE
S3: cleanup if key.get_contents_to_filename fails

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1468,11 +1468,16 @@ class Key(object):
             http://goo.gl/EWOPb for details.
         """
         fp = open(filename, 'wb')
-        self.get_contents_to_file(fp, headers, cb, num_cb, torrent=torrent,
-                                  version_id=version_id,
-                                  res_download_handler=res_download_handler,
-                                  response_headers=response_headers)
-        fp.close()
+        try:
+            self.get_contents_to_file(fp, headers, cb, num_cb, torrent=torrent,
+                                      version_id=version_id,
+                                      res_download_handler=res_download_handler,
+                                      response_headers=response_headers)
+        except Exception:
+            os.remove(filename)
+            raise
+        finally:
+            fp.close()
         # if last_modified date was sent from s3, try to set file's timestamp
         if self.last_modified != None:
             try:


### PR DESCRIPTION
if key.get_contents_to_filename fails, it leaves an empty file and open file descriptor behind.  Instead, remove the file (since we created it, or at least truncated it to 0 length) and close the file descriptor.
