### PR TITLE
Replacing print statements with logger calls to make test_db.py py3 compatible #1147 

### DIFF
--- a/boto/sdb/db/test_db.py
+++ b/boto/sdb/db/test_db.py
@@ -1,10 +1,16 @@
+import logging
+import time
+from datetime import datetime
+
 from boto.sdb.db.model import Model
 from boto.sdb.db.property import StringProperty, IntegerProperty, BooleanProperty
 from boto.sdb.db.property import DateTimeProperty, FloatProperty, ReferenceProperty
 from boto.sdb.db.property import PasswordProperty, ListProperty, MapProperty
-from datetime import datetime
-import time
 from boto.exception import SDBPersistenceError
+
+logging.basicConfig()
+log = logging.getLogger('test_db')
+log.setLevel(logging.DEBUG)
 
 _objects = {}
 
@@ -70,11 +76,11 @@ def test_basic():
     t.size = -42
     t.foo = True
     t.date = datetime.now()
-    print 'saving object'
+    log.debug('saving object')
     t.put()
     _objects['test_basic_t'] = t
     time.sleep(5)
-    print 'now try retrieving it'
+    log.debug('now try retrieving it')
     tt = TestBasic.get_by_id(t.id)
     _objects['test_basic_tt'] = tt
     assert tt.id == t.id
@@ -92,11 +98,11 @@ def test_float():
     t = TestFloat()
     t.name = 'float object'
     t.value = 98.6
-    print 'saving object'
+    log.debug('saving object')
     t.save()
     _objects['test_float_t'] = t
     time.sleep(5)
-    print 'now try retrieving it'
+    log.debug('now try retrieving it')
     tt = TestFloat.get_by_id(t.id)
     _objects['test_float_tt'] = tt
     assert tt.id == t.id
@@ -123,7 +129,7 @@ def test_reference(t=None):
     _objects['test_reference_tt'] = tt
     assert tt.ref.id == t.id
     for o in t.refs:
-        print o
+        log.debug(o)
 
 def test_subclass():
     global _objects
@@ -202,23 +208,23 @@ def test_datetime():
     assert tt.create_date.timetuple() == t.create_date.timetuple()
 
 def test():
-    print 'test_basic'
+    log.info('test_basic')
     t1 = test_basic()
-    print 'test_required'
+    log.info('test_required')
     test_required()
-    print 'test_reference'
+    log.info('test_reference')
     test_reference(t1)
-    print 'test_subclass'
+    log.info('test_subclass')
     test_subclass()
-    print 'test_password'
+    log.info('test_password')
     test_password()
-    print 'test_list'
+    log.info('test_list')
     test_list()
-    print 'test_list_reference'
+    log.info('test_list_reference')
     test_list_reference()
-    print "test_datetime"
+    log.info("test_datetime")
     test_datetime()
-    print 'test_unique'
+    log.info('test_unique')
     test_unique()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Print as a statement is not a valid py3 language construct. Using it as a statement results in a syntax error. Print statements are not ideal for use as a logger.
Logging module has the same semantics between py2 and 3, therefore change is compatible with both versions. This change may later be merged into the `neo` branch and #1147 may be then resolved.
