### PR TITLE
Respecting the 'is_secure' constructor argument #1207

### DIFF
--- a/boto/glacier/layer1.py
+++ b/boto/glacier/layer1.py
@@ -23,7 +23,6 @@
 #
 
 import os
-import urllib
 
 import boto.glacier
 from boto.compat import json
@@ -56,7 +55,7 @@ class Layer1(AWSAuthConnection):
         self.account_id = account_id
         AWSAuthConnection.__init__(self, region.endpoint,
                                    aws_access_key_id, aws_secret_access_key,
-                                   True, port, proxy, proxy_port,
+                                   is_secure, port, proxy, proxy_port,
                                    proxy_user, proxy_pass, debug,
                                    https_connection_factory,
                                    path, provider, security_token,


### PR DESCRIPTION
At present, the boto.glacier.layer1.Layer1 ignores the user set keyword argument `is_secure` and passes always a value of `True` to the underlying object. 

Rationale: This is an undesired behavior because consumer's directive is not respected, regardless of whether this behaviour is supported by the service or not. Even if an insecure call wasn't supported, it's up to the service to complain about a 'bad request' and quote the reason.
