### PR TITLE
Fix #818: Decode unexpected octal asterisk in domain name

### DIFF
--- a/boto/route53/record.py
+++ b/boto/route53/record.py
@@ -284,7 +284,7 @@ class Record(object):
 
     def endElement(self, name, value, connection):
         if name == 'Name':
-            self.name = value
+            self.name = value.replace(r'\052', '*')
         elif name == 'Type':
             self.type = value
         elif name == 'TTL':


### PR DESCRIPTION
The Route 53 API returns asterisks as their escaped octal equivalent.
I wasn't sure why, so I asked for help at
https://forums.aws.amazon.com/thread.jspa?threadID=113183 .

This workaround is the approach taken in
https://github.com/fog/fog/issues/1093 and
https://github.com/pcorliss/ruby_route_53/issues/7 .
