### PR TITLE
Fix short option parsing in bin/glacier and make help more helpful

### DIFF
--- a/bin/glacier
+++ b/bin/glacier
@@ -51,15 +51,15 @@ glacier <command> [args]
                     created
 
     Common args:
-        access_key - Your AWS Access Key ID.  If not supplied, boto will
-                     use the value of the environment variable
-                     AWS_ACCESS_KEY_ID
-        secret_key - Your AWS Secret Access Key.  If not supplied, boto
-                     will use the value of the environment variable
-                     AWS_SECRET_ACCESS_KEY
-        region     - AWS region to use. Possible vaules: us-east-1, us-west-1,
-                     us-west-2, ap-northeast-1, eu-west-1.
-                     Default: us-east-1
+        --access_key - Your AWS Access Key ID.  If not supplied, boto will
+                       use the value of the environment variable
+                       AWS_ACCESS_KEY_ID
+        --secret_key - Your AWS Secret Access Key.  If not supplied, boto
+                       will use the value of the environment variable
+                       AWS_SECRET_ACCESS_KEY
+        --region     - AWS region to use. Possible vaules: us-east-1, us-west-1,
+                       us-west-2, ap-northeast-1, eu-west-1.
+                       Default: us-east-1
 
     Vaults operations:
 
@@ -131,11 +131,11 @@ def main():
     access_key = secret_key = None
     region = 'us-east-1'
     for option, value in opts:
-        if option in ('a', '--access_key'):
+        if option in ('-a', '--access_key'):
             access_key = value
-        elif option in ('s', '--secret_key'):
+        elif option in ('-s', '--secret_key'):
             secret_key = value
-        elif option in ('r', '--region'):
+        elif option in ('-r', '--region'):
             region = value
     # handle each command
     if command == 'vaults':


### PR DESCRIPTION
Short options were ignored because of typo (missing - in option names). Usage help didn't include the -- in the beginning of long option names, making it difficult to understand.
