### PR TITLE
Correct layer1 scan documentation for limit param

### DIFF
--- a/boto/dynamodb/layer1.py
+++ b/boto/dynamodb/layer1.py
@@ -543,7 +543,7 @@ class Layer1(AWSAuthConnection):
             be returned.  Otherwise, all attributes will be returned.
 
         :type limit: int
-        :param limit: The maximum number of items to return.
+        :param limit: The maximum number of items to evaluate.
 
         :type count: bool
         :param count: If True, Amazon DynamoDB returns a total


### PR DESCRIPTION
"Limit - The maximum number of items to evaluate (not necessarily the
number of matching items). If Amazon DynamoDB processes the number of
items up to the limit while processing the results, it stops and returns
the matching values up to that point, and a LastEvaluatedKey to apply in
a subsequent operation to continue retrieving items. Also, if the
scanned data set size exceeds 1MB before Amazon DynamoDB reaches this
limit, it stops the scan and returns the matching values up to the
limit, and a LastEvaluatedKey to apply in a subsequent operation to
continue the scan."

http://docs.amazonwebservices.com/amazondynamodb/latest/developerguide/API_Scan.html
