### PR TITLE
S3 get and set to filename methods file descriptor handling problem

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1153,10 +1153,13 @@ class Key(object):
             will be encrypted on the server-side by S3 and will be
             stored in an encrypted form while at rest in S3.
         """
-        with open(filename, 'rb') as fp:
+        fp = open(filename, 'rb')
+        try:
             self.set_contents_from_file(fp, headers, replace, cb, num_cb,
                                         policy, md5, reduced_redundancy,
                                         encrypt_key=encrypt_key)
+        finally:
+            fp.close()
 
     def set_contents_from_string(self, s, headers=None, replace=True,
                                  cb=None, num_cb=10, policy=None, md5=None,
@@ -1466,11 +1469,17 @@ class Key(object):
             with the stored object in the response.  See
             http://goo.gl/EWOPb for details.
         """
-        with open(filename, 'wb') as fp:
+        fp = open(filename, 'wb')
+        try:
             self.get_contents_to_file(fp, headers, cb, num_cb, torrent=torrent,
                                       version_id=version_id,
                                       res_download_handler=res_download_handler,
                                       response_headers=response_headers)
+        except Exception, e:
+            os.remove(filename)
+            raise
+        finally:
+            fp.close()
         # if last_modified date was sent from s3, try to set file's timestamp
         if self.last_modified != None:
             try:


### PR DESCRIPTION
Fix unreliable file closing in set_contents_from_filename and get_contents_to_filename methods of boto.s3.key.Key
