### PR TITLE
Fix for DynamoDB Rate Limited BotoServerError messages don't have any as...

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -889,7 +889,7 @@ class AWSAuthConnection(object):
         # use it to raise an exception.
         # Otherwise, raise the exception that must have already h#appened.
         if response:
-            raise BotoServerError(response.status, response.reason, body)
+            raise BotoServerError(response.status, response.reason, response.read())
         elif e:
             raise e
         else:

--- a/boto/exception.py
+++ b/boto/exception.py
@@ -29,6 +29,10 @@ import xml.sax
 from boto import handler
 from boto.resultset import ResultSet
 
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
 class BotoClientError(StandardError):
     """
@@ -91,6 +95,13 @@ class BotoServerError(StandardError):
                 # because occasionally we get error messages from Eucalyptus
                 # that are just text strings that we want to preserve.
                 self.error_message = self.body
+                self.body = None
+        # If the message isn't in XML, it might be JSON (for example, dynamodb responses)
+        if self.error_message:
+            try:
+                self.body = json.loads(self.error_message)
+                self.error_message = None
+            except (TypeError, json.JSONDecodeError), pe:
                 self.body = None
 
     def __getattr__(self, name):


### PR DESCRIPTION
Apologies in advance if I've done this wrong or if my fix is stupid - I'm new to both git and boto

This is intended as a patch for the fix described in Issue #1226 : DynamoDB Rate Limited BotoServerError messages don't have any associated data
