### PR TITLE
Docs reflect current AssumeRole duration limits

### DIFF
--- a/boto/sts/connection.py
+++ b/boto/sts/connection.py
@@ -159,7 +159,7 @@ class STSConnection(AWSQueryConnection):
         Returns a set of temporary credentials that the caller can use to
         access resources that are allowed by the temporary credentials.  The
         credentials are valid for the duration that the caller specified, which
-        can be from 1 to 36 hours.
+        can be from 15 minutes (900 seconds) to 1 hour (3600 seconds)
 
         :type role_arn: str
         :param role_arn: The Amazon Resource Name (ARN) of the role that the
@@ -180,9 +180,8 @@ class STSConnection(AWSQueryConnection):
 
         :type duration_seconds: int
         :param duration_seconds: he duration, in seconds, of the role session.
-            The value can range from 3600 seconds (one hour) to 129600 seconds
-            (36 hours).  By default, the value is set to 43200 seconds (12
-            hours).
+            The value can range from 900 seconds (15 minutes) to 3600 seconds
+            (1 hour).  By default, the value is set to 3600 seconds.
 
         :type external_id: str
         :param external_id: A unique identifier that is used by


### PR DESCRIPTION
Limits on duration_seconds on assume role are really 900-3600 seconds as documented here http://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
