### PR TITLE
Changing configuration template to be able to source a parent template

### DIFF
--- a/boto/beanstalk/layer1.py
+++ b/boto/beanstalk/layer1.py
@@ -226,10 +226,9 @@ class Layer1(AWSQueryConnection):
         if solution_stack_name:
             params['SolutionStackName'] = solution_stack_name
         if source_configuration_application_name:
-            params['ApplicationName'] = source_configuration_application_name
+            params['SourceConfiguration.ApplicationName'] = source_configuration_application_name
         if source_configuration_template_name:
-            params['SourceConfiguration.ApplicationName'] = source_configuration_template_name[0]
-            params['SourceConfiguration.TemplateName'] = source_configuration_template_name[1]
+            params['SourceConfiguration.TemplateName'] = source_configuration_template_name
         if environment_id:
             params['EnvironmentId'] = environment_id
         if description:


### PR DESCRIPTION
The value was overwriting the desired template name, and according to the docs ( http://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_CreateConfigurationTemplate.html ) the SourceConfiguration needs to be of type SourceConfiguration ( http://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_SourceConfiguration.html ).
