### PR TITLE
Launch config name is not required for update

### DIFF
--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -156,12 +156,13 @@ class AutoScaleConnection(AWSQueryConnection):
 
     def _update_group(self, op, as_group):
         params = {'AutoScalingGroupName': as_group.name,
-                  'LaunchConfigurationName': as_group.launch_config_name,
                   'MinSize': as_group.min_size,
                   'MaxSize': as_group.max_size}
         # get availability zone information (required param)
         zones = as_group.availability_zones
         self.build_list_params(params, zones, 'AvailabilityZones')
+        if as_group.launch_config_name:
+            params['LaunchConfigurationName'] = as_group.launch_config_name
         if as_group.desired_capacity:
             params['DesiredCapacity'] = as_group.desired_capacity
         if as_group.vpc_zone_identifier:


### PR DESCRIPTION
UpdateAutoScalingGroup doesn't require LaunchConfigurationName parameter to be sent.
See http://docs.aws.amazon.com/AutoScaling/2011-01-01/APIReference/API_UpdateAutoScalingGroup.html

In cases where you want to update a group (for example change min size) it is unnecessary and cumbersome to look up the LaunchConfigurationName each time.
