### PR TITLE
Support timestamps without microseconds in Cloudwatch alarms.

### DIFF
--- a/boto/ec2/cloudwatch/alarm.py
+++ b/boto/ec2/cloudwatch/alarm.py
@@ -308,5 +308,9 @@ class AlarmHistoryItem(object):
         elif name == 'HistorySummary':
             self.summary = value
         elif name == 'Timestamp':
-            self.timestamp = datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%fZ')
+            try:
+                self.timestamp = datetime.strptime(value,
+                                                   '%Y-%m-%dT%H:%M:%S.%fZ')
+            except ValueError:
+                self.timestamp = datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
 


### PR DESCRIPTION
Some of the older CloudWatch alarms are failing in the `strptime` call because the timestamp doesn't match the format given in boto:

```
  File "workspace/boto/boto/ec2/cloudwatch/__init__.py", line 448, in describe_alarm_history
    [('member', AlarmHistoryItem)])
  File "workspace/boto/boto/connection.py", line 1037, in get_list
    xml.sax.parseString(body, h)
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/xml/sax/__init__.py", line 49, in parseString
    parser.parse(inpsrc)
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/xml/sax/expatreader.py", line 107, in parse
    xmlreader.IncrementalParser.parse(self, source)
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/xml/sax/xmlreader.py", line 123, in parse
    self.feed(buffer)
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/xml/sax/expatreader.py", line 207, in feed
    self._parser.Parse(data, isFinal)
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/xml/sax/expatreader.py", line 304, in end_element
    self._cont_handler.endElement(name)
  File "workspace/boto/boto/handler.py", line 38, in endElement
    self.nodes[-1][1].endElement(name, self.current_text, self.connection)
  File "workspace/boto/boto/ec2/cloudwatch/alarm.py", line 313, in endElement
    '%Y-%m-%dT%H:%M:%S.%fZ')
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/_strptime.py", line 325, in _strptime
    (data_string, format))
ValueError: time data '2013-01-14T11:28:03Z' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'
```

This fix will try the non-microsecond timestamp format if the initial format fails.
