### PR TITLE
Fixed up some typos in s3put's help message

### DIFF
--- a/bin/s3put
+++ b/bin/s3put
@@ -53,7 +53,7 @@ SYNOPSIS
           [-d/--debug <debug_level>] [-i/--ignore <ignore_dirs>]
           [-n/--no_op] [-p/--prefix <prefix>] [-k/--key_prefix <key_prefix>]
           [-q/--quiet] [-g/--grant grant] [-w/--no_overwrite] [-r/--reduced]
-          [--header] """ + usage_string_multipart_capable + """ path [path...]
+          [--header] """ + usage_flag_multipart_capable + """ path [path...]
 
     Where
         access_key - Your AWS Access Key ID.  If not supplied, boto will
@@ -67,7 +67,7 @@ SYNOPSIS
         path - A path to a directory or file that represents the items
                to be uploaded.  If the path points to an individual file,
                that file will be uploaded to the specified bucket.  If the
-               path points to a directory, s3_it will recursively traverse
+               path points to a directory, it will recursively traverse
                the directory and upload all files to the specified bucket.
         debug_level - 0 means no debug output (default), 1 means normal
                       debug output from boto, and 2 means boto debug output
@@ -101,7 +101,7 @@ SYNOPSIS
                        sync, even if the file has been updated locally if
                        the key exists on s3 the file on s3 will not be
                        updated.
-        header - key=value paris of extra header(s) to pass along in the
+        header - key=value pairs of extra header(s) to pass along in the
                  request""" + usage_string_multipart_capable + """
 
 


### PR DESCRIPTION
This merge fixes a couple of typos I ran into in the s3put help which confused me a little when I started using it.
