### PR TITLE
Update SQS tutorial to use the recommended connect_to_region() method

### DIFF
--- a/docs/source/sqs_tut.rst
+++ b/docs/source/sqs_tut.rst
@@ -22,8 +22,8 @@ region-specific. In this example, the AWS access key and AWS secret key are
 passed in to the method explicitely. Alternatively, you can set the environment
 variables:
 
-AWS_ACCESS_KEY_ID - Your AWS Access Key ID
-AWS_SECRET_ACCESS_KEY - Your AWS Secret Access Key
+* `AWS_ACCESS_KEY_ID` - Your AWS Access Key ID
+* `AWS_SECRET_ACCESS_KEY` - Your AWS Secret Access Key
 
 and then simply call::
 


### PR DESCRIPTION
This updates the SQS tutorial to use the connect_to_region() method as suggested on the #boto freenode IRC channel instead of using the connector.
