### PR TITLE
Move gs parsing of generation and metageneration to handle_version_headers

### DIFF
--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -88,9 +88,6 @@ class Bucket(S3Bucket):
 
         key, resp = self._get_key_internal(key_name, headers,
                                            query_args_l=query_args_l)
-        if key:
-            key.meta_generation = resp.getheader('x-goog-metageneration')
-            key.generation = resp.getheader('x-goog-generation')
         return key
 
     def copy_key(self, new_key_name, src_bucket_name, src_key_name,

--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -55,6 +55,10 @@ class Key(S3Key):
         else:
             setattr(self, name, value)
 
+    def handle_version_headers(self, resp, force=False):
+        self.meta_generation = resp.getheader('x-goog-metageneration', None)
+        self.generation = resp.getheader('x-goog-generation', None)
+
     def get_file(self, fp, headers=None, cb=None, num_cb=10,
                  torrent=False, version_id=None, override_num_retries=None,
                  response_headers=None):

--- a/tests/integration/gs/test_versioning.py
+++ b/tests/integration/gs/test_versioning.py
@@ -196,3 +196,18 @@ class GSVersioningTest(unittest.TestCase):
         k2 = b2.get_key("foo2")
         s3 = k2.get_contents_as_string()
         self.assertEqual(s3, s1)
+
+    def testKeyGenerationUpdatesOnSet(self):
+        b = self._MakeVersionedBucket()
+        k = b.new_key("foo")
+        self.assertIsNone(k.generation)
+        k.set_contents_from_string("test1")
+        g1 = k.generation
+        self.assertRegexpMatches(g1, r'[0-9]+')
+        self.assertEqual(k.meta_generation, '1')
+        k.set_contents_from_string("test2")
+        g2 = k.generation
+        self.assertNotEqual(g1, g2)
+        self.assertRegexpMatches(g2, r'[0-9]+')
+        self.assertGreater(int(g2), int(g1))
+        self.assertEqual(k.meta_generation, '1')


### PR DESCRIPTION
Added test to make sure that the key's .generation and .meta_generation properties get updated when the contents are modified.
