### PR TITLE
group conditions correctly so that 'limit' won't be set to -1 for the qu...

### DIFF
--- a/boto/dynamodb/layer2.py
+++ b/boto/dynamodb/layer2.py
@@ -99,7 +99,7 @@ class TableGenerator:
         """
         # preserve any existing limit in case the user alters self.remaining
         limit = self.kwargs.get('limit')
-        if self.remaining > 0 and limit is None or limit > self.remaining:
+        if self.remaining > 0 and (limit is None or limit > self.remaining):
             self.kwargs['limit'] = self.remaining
         self._response = self.callable(**self.kwargs)
         self.kwargs['limit'] = limit


### PR DESCRIPTION
If 'max_results' is not specified, user will encounter an validation exception when making use of the query function.

<pre>
>> items = table.query(hash_key, request_limit=1)
>> for item in items:
         pass
>> DynamoDBValidationError: DynamoDBValidationError: 400 Bad Request
{'message': "1 validation error detected: Value '-1' at 'limit' failed to satisfy constraint: Member must have value greater than or equal to 1", '__type': 'com.amazon.coral.va
lidate#ValidationException'}
</pre>

This is caused by a wrong grouping of conditions which always set 'limit' to -1 when 'max_request' is None.
