### PR TITLE
Fix a bug in set_contents_from_file where it wasn't setting md5 properly

### DIFF
--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -277,12 +277,12 @@ class Key(S3Key):
                 fp.seek(spos)
                 size = self.size
 
-            if self.name == None:
-                if md5 == None:
-                  md5 = self.compute_md5(fp, size)
-                  self.md5 = md5[0]
-                  self.base64md5 = md5[1]
+            if md5 == None:
+                md5 = self.compute_md5(fp, size)
+            self.md5 = md5[0]
+            self.base64md5 = md5[1]
 
+            if self.name == None:
                 self.name = self.md5
             if not replace:
                 if self.bucket.lookup(self.name):

--- a/tests/integration/gs/test_connection.py
+++ b/tests/integration/gs/test_connection.py
@@ -28,15 +28,17 @@
 Some unit tests for the GSConnection
 """
 
-import boto
-import time
 import os
 import re
+import StringIO
+import time
 import xml
-from boto.gs.connection import GSConnection
-from boto.gs.cors import Cors
+
+import boto
 from boto import handler
 from boto import storage_uri
+from boto.gs.connection import GSConnection
+from boto.gs.cors import Cors
 from tests.integration.gs.util import has_google_credentials
 from tests.unit import unittest
 
@@ -70,6 +72,11 @@ class GSConnectionTest(unittest.TestCase):
         # check to make sure content read from s3 is identical to original
         assert s1 == fp.read(), 'corrupted file'
         fp.close()
+        # check to make sure set_contents_from_file is working
+        sfp = StringIO.StringIO("foo")
+        k.set_contents_from_file(sfp)
+        sfp2 = StringIO.StringIO("foo2")
+        k.set_contents_from_file(sfp2)
         bucket.delete_key(k)
         # test a few variations on get_all_keys - first load some data
         # for the first one, let's override the content type


### PR DESCRIPTION
If you called set_contents_from_file twice on the same Key object with different contents, the md5 value was not being recomputed, causing the server to reject the PUT request.
