### PR TITLE
Add support for website bucket redirect rules

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -40,6 +40,7 @@ from boto.s3.lifecycle import Lifecycle
 from boto.s3.tagging import Tags
 from boto.s3.cors import CORSConfiguration
 from boto.s3.bucketlogging import BucketLogging
+from boto.s3 import website
 import boto.jsonresponse
 import boto.utils
 import xml.sax
@@ -1215,7 +1216,10 @@ class Bucket(object):
             raise self.connection.provider.storage_response_error(
                 response.status, response.reason, body)
 
-    def configure_website(self, suffix, error_key='', headers=None):
+    def configure_website(self, suffix=None, error_key=None,
+                          redirect_all_requests_to=None,
+                          routing_rules=None,
+                          headers=None):
         """
         Configure this bucket to act as a website
 
@@ -1231,12 +1235,22 @@ class Bucket(object):
         :param error_key: The object key name to use when a 4XX class
             error occurs.  This is optional.
 
+        :type redirect_all_requests_to: :class:`boto.s3.website.RedirectLocation`
+        :param redirect_all_requests_to: Describes the redirect behavior for
+            every request to this bucket's website endpoint. If this value is
+            non None, no other values are considered when configuring the
+            website configuration for the bucket. This is an instance of
+            ``RedirectLocation``.
+
+        :type routing_rules: :class:`boto.s3.website.RoutingRules`
+        :param routing_rules: Object which specifies conditions
+            and redirects that apply when the conditions are met.
+
         """
-        if error_key:
-            error_frag = self.WebsiteErrorFragment % error_key
-        else:
-            error_frag = ''
-        body = self.WebsiteBody % (suffix, error_frag)
+        config = website.WebsiteConfiguration(
+                suffix, error_key, redirect_all_requests_to,
+                routing_rules)
+        body = config.to_xml()
         response = self.connection.make_request('PUT', self.name, data=body,
                                                 query_args='website',
                                                 headers=headers)
@@ -1275,7 +1289,7 @@ class Bucket(object):
         :rtype: 2-Tuple
         :returns: 2-tuple containing:
         1) A dictionary containing a Python representation
-                  of the XML response from GCS. The overall structure is:
+                  of the XML response. The overall structure is:
           * WebsiteConfiguration
             * IndexDocument
               * Suffix : suffix that is appended to request that

--- a/boto/s3/website.py
+++ b/boto/s3/website.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2013 Amazon.com, Inc. or its affiliates.  All Rights Reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+
+def tag(key, value):
+    start = '<%s>' % key
+    end = '</%s>' % key
+    return '%s%s%s' % (start, value, end)
+
+
+class WebsiteConfiguration(object):
+    """
+    Website configuration for a bucket.
+
+    :ivar suffix: Suffix that is appended to a request that is for a
+        "directory" on the website endpoint (e.g. if the suffix is
+        index.html and you make a request to samplebucket/images/
+        the data that is returned will be for the object with the
+        key name images/index.html).  The suffix must not be empty
+        and must not include a slash character.
+
+    :ivar error_key: The object key name to use when a 4xx class error
+        occurs.  This key identifies the page that is returned when
+        such an error occurs.
+
+    :ivar redirect_all_requests_to: Describes the redirect behavior for every
+        request to this bucket's website endpoint. If this value is non None,
+        no other values are considered when configuring the website
+        configuration for the bucket. This is an instance of
+        ``RedirectLocation``.
+
+    :ivar routing_rules: ``RoutingRules`` object which specifies conditions
+        and redirects that apply when the conditions are met.
+
+    """
+    WEBSITE_SKELETON = """<?xml version="1.0" encoding="UTF-8"?>
+      <WebsiteConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+      %(body)s
+      </WebsiteConfiguration>"""
+
+
+    def __init__(self, suffix=None, error_key=None,
+                 redirect_all_requests_to=None, routing_rules=None):
+        self.suffix = suffix
+        self.error_key = error_key
+        self.redirect_all_requests_to = redirect_all_requests_to
+        self.routing_rules = routing_rules
+
+    def to_xml(self):
+        body_parts = []
+        if self.suffix is not None:
+            body_parts.append(tag('IndexDocument', tag('Suffix', self.suffix)))
+        if self.error_key is not None:
+            body_parts.append(tag('ErrorDocument', tag('Key', self.error_key)))
+        if self.redirect_all_requests_to is not None:
+            body_parts.append(self.redirect_all_requests_to.to_xml())
+        if self.routing_rules is not None:
+            body_parts.append(self.routing_rules.to_xml())
+        body = '\n'.join(body_parts)
+        return self.WEBSITE_SKELETON % {'body': body}
+
+
+class RedirectLocation(object):
+    """Specify redirect behavior for every request to a bucket's endpoint.
+
+    :ivar hostname: Name of the host where requests will be redirected.
+
+    :ivar protocol: Protocol to use (http, https) when redirecting requests.
+        The default is the protocol that is used in the original request.
+
+    """
+
+    def __init__(self, hostname, protocol=None):
+        self.hostname = hostname
+        self.protocol = protocol
+
+    def to_xml(self):
+        inner_text = []
+        if self.hostname is not None:
+            inner_text.append(tag('HostName', self.hostname))
+        if self.protocol is not None:
+            inner_text.append(tag('Protocol', self.protocol))
+        return tag('RedirectAllRequestsTo', '\n'.join(inner_text))
+
+
+class RoutingRules(object):
+    def __init__(self):
+        self._rules = []
+
+    def add_rule(self, rule):
+        """
+
+        :type rule: :class:`boto.s3.website.RoutingRule`
+        :param rule: A routing rule.
+
+        :return: This ``RoutingRules`` object is returned,
+            so that it can chain subsequent calls.
+
+        """
+        self._rules.append(rule)
+        return self
+
+    def to_xml(self):
+        inner_text = []
+        for rule in self._rules:
+            inner_text.append(rule.to_xml())
+        return tag('RoutingRules', '\n'.join(inner_text))
+
+
+class RoutingRule(object):
+    """Represents a single routing rule.
+
+    There are convenience methods to making creating rules
+    more concise::
+
+        rule = RoutingRule.when(key_prefix='foo/').then_redirect('example.com')
+
+    :ivar condition: Describes condition that must be met for the
+        specified redirect to apply.
+
+    :ivar redirect: Specifies redirect behavior.  You can redirect requests to
+        another host, to another page, or with another protocol. In the event
+        of an error, you can can specify a different error code to return.
+
+    """
+    def __init__(self, condition, redirect):
+        self.condition = condition
+        self.redirect = redirect
+
+    def to_xml(self):
+        return tag('RoutingRule',
+                   self.condition.to_xml() + self.redirect.to_xml())
+
+    @classmethod
+    def when(cls, key_prefix=None, http_error_code=None):
+        return cls(Condition(key_prefix=key_prefix,
+                             http_error_code=http_error_code), None)
+
+    def then_redirect(self, hostname=None, protocol=None, replace_key=None,
+                      replace_key_prefix=None, http_redirect_code=None):
+        self.redirect = Redirect(
+                hostname=hostname, protocol=protocol,
+                replace_key=replace_key,
+                replace_key_prefix=replace_key_prefix,
+                http_redirect_code=http_redirect_code)
+        return self
+
+
+class Condition(object):
+    """
+
+    :ivar key_prefix: The object key name prefix when the redirect is applied.
+        For example, to redirect requests for ExamplePage.html, the key prefix
+        will be ExamplePage.html. To redirect request for all pages with the
+        prefix docs/, the key prefix will be /docs, which identifies all
+        objects in the docs/ folder.
+
+    :ivar http_error_code: The HTTP error code when the redirect is applied. In
+        the event of an error, if the error code equals this value, then the
+        specified redirect is applied.
+
+    """
+    def __init__(self, key_prefix=None, http_error_code=None):
+        self.key_prefix = key_prefix
+        self.http_error_code = http_error_code
+
+    def to_xml(self):
+        inner_text = []
+        if self.key_prefix is not None:
+            inner_text.append(tag('KeyPrefixEquals', self.key_prefix))
+        if self.http_error_code is not None:
+            inner_text.append(
+                tag('HttpErrorCodeReturnedEquals',
+                self.http_error_code))
+        return tag('Condition', '\n'.join(inner_text))
+
+
+class Redirect(object):
+    """
+
+    :ivar hostname: The host name to use in the redirect request.
+
+    :ivar protocol: The protocol to use in the redirect request.  Can be either
+    'http' or 'https'.
+
+    :ivar replace_key: The specific object key to use in the redirect request.
+        For example, redirect request to error.html.
+
+    :ivar replace_key_prefix: The object key prefix to use in the redirect
+        request. For example, to redirect requests for all pages with prefix
+        docs/ (objects in the docs/ folder) to documents/, you can set a
+        condition block with KeyPrefixEquals set to docs/ and in the Redirect
+        set ReplaceKeyPrefixWith to /documents.
+
+    :ivar http_redirect_code: The HTTP redirect code to use on the response.
+
+    """
+    def __init__(self, hostname=None, protocol=None, replace_key=None,
+                 replace_key_prefix=None, http_redirect_code=None):
+        self.hostname = hostname
+        self.protocol = protocol
+        self.replace_key = replace_key
+        self.replace_key_prefix = replace_key_prefix
+        self.http_redirect_code = http_redirect_code
+
+    def to_xml(self):
+        inner_text = []
+        if self.hostname is not None:
+            inner_text.append(tag('HostName', self.hostname))
+        if self.protocol is not None:
+            inner_text.append(tag('Protocol', self.protocol))
+        if self.replace_key is not None:
+            inner_text.append(tag('ReplaceKey', self.replace_key))
+        if self.replace_key_prefix is not None:
+            inner_text.append(tag('ReplaceKeyPrefixWith',
+                                  self.replace_key_prefix))
+        if self.http_redirect_code is not None:
+            inner_text.append(tag('HttpRedirectCode', self.http_redirect_code))
+        return tag('Redirect', '\n'.join(inner_text))

--- a/tests/integration/s3/test_bucket.py
+++ b/tests/integration/s3/test_bucket.py
@@ -38,6 +38,7 @@ from boto.s3.lifecycle import Rule
 from boto.s3.acl import Grant
 from boto.s3.tagging import Tags, TagSet
 from boto.s3.lifecycle import Lifecycle, Expiration, Transition
+from boto.s3.website import RedirectLocation
 
 
 class S3BucketTest (unittest.TestCase):
@@ -162,6 +163,26 @@ class S3BucketTest (unittest.TestCase):
         config2, xml = self.bucket.get_website_configuration_with_xml()
         self.assertEqual(config, config2)
         self.assertTrue('<Suffix>index.html</Suffix>' in xml, xml)
+
+    def test_website_redirect_all_requests(self):
+        response = self.bucket.configure_website(
+            redirect_all_requests_to=RedirectLocation('example.com'))
+        config = self.bucket.get_website_configuration()
+        self.assertEqual(config, {
+            'WebsiteConfiguration': {
+                'RedirectAllRequestsTo': {
+                    'HostName': 'example.com'}}})
+
+        # Can configure the protocol as well.
+        response = self.bucket.configure_website(
+            redirect_all_requests_to=RedirectLocation('example.com', 'https'))
+        config = self.bucket.get_website_configuration()
+        self.assertEqual(config, {
+            'WebsiteConfiguration': {'RedirectAllRequestsTo': {
+                'HostName': 'example.com',
+                'Protocol': 'https',
+            }}}
+        )
 
     def test_lifecycle(self):
         lifecycle = Lifecycle()

--- a/tests/unit/s3/test_website.py
+++ b/tests/unit/s3/test_website.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2013 Amazon.com, Inc. or its affiliates.  All Rights Reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+
+from tests.unit import unittest
+import xml.dom.minidom
+
+from boto.s3.website import WebsiteConfiguration
+from boto.s3.website import RedirectLocation
+from boto.s3.website import RoutingRules
+from boto.s3.website import Condition
+from boto.s3.website import RoutingRules
+from boto.s3.website import RoutingRule
+from boto.s3.website import Redirect
+
+
+def pretty_print_xml(text):
+    text = ''.join(t.strip() for t in text.splitlines())
+    x = xml.dom.minidom.parseString(text)
+    return x.toprettyxml()
+
+
+class TestS3WebsiteConfiguration(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_suffix_only(self):
+        config = WebsiteConfiguration(suffix='index.html')
+        xml = config.to_xml()
+        self.assertIn(
+            '<IndexDocument><Suffix>index.html</Suffix></IndexDocument>', xml)
+
+    def test_suffix_and_error(self):
+        config = WebsiteConfiguration(suffix='index.html',
+                                      error_key='error.html')
+        xml = config.to_xml()
+        self.assertIn(
+            '<ErrorDocument><Key>error.html</Key></ErrorDocument>', xml)
+
+    def test_redirect_all_request_to_with_just_host(self):
+        location = RedirectLocation(hostname='example.com')
+        config = WebsiteConfiguration(redirect_all_requests_to=location)
+        xml = config.to_xml()
+        self.assertIn(
+            ('<RedirectAllRequestsTo><HostName>'
+             'example.com</HostName></RedirectAllRequestsTo>'), xml)
+
+    def test_redirect_all_requests_with_protocol(self):
+        location = RedirectLocation(hostname='example.com', protocol='https')
+        config = WebsiteConfiguration(redirect_all_requests_to=location)
+        xml = config.to_xml()
+        self.assertIn(
+            ('<RedirectAllRequestsTo><HostName>'
+             'example.com</HostName>\n<Protocol>https</Protocol>'
+             '</RedirectAllRequestsTo>'), xml)
+
+    def test_routing_rules_key_prefix(self):
+        x = pretty_print_xml
+        # This rule redirects requests for docs/* to documentation/*
+        rules = RoutingRules()
+        condition = Condition(key_prefix='docs/')
+        redirect = Redirect(replace_key_prefix='documents/')
+        rules.add_rule(RoutingRule(condition, redirect))
+        config = WebsiteConfiguration(suffix='index.html', routing_rules=rules)
+        xml = config.to_xml()
+
+        expected_xml = """<?xml version="1.0" encoding="UTF-8"?>
+            <WebsiteConfiguration xmlns='http://s3.amazonaws.com/doc/2006-03-01/'>
+              <IndexDocument>
+                <Suffix>index.html</Suffix>
+              </IndexDocument>
+              <RoutingRules>
+                <RoutingRule>
+                <Condition>
+                  <KeyPrefixEquals>docs/</KeyPrefixEquals>
+                </Condition>
+                <Redirect>
+                  <ReplaceKeyPrefixWith>documents/</ReplaceKeyPrefixWith>
+                </Redirect>
+                </RoutingRule>
+              </RoutingRules>
+            </WebsiteConfiguration>
+        """
+        self.assertEqual(x(expected_xml), x(xml))
+
+    def test_routing_rules_to_host_on_404(self):
+        x = pretty_print_xml
+        # Another example from the docs:
+        # Redirect requests to a specific host in the event of a 404.
+        # Also, the redirect inserts a report-404/.  For example,
+        # if you request a page ExamplePage.html and it results
+        # in a 404, the request is routed to a page report-404/ExamplePage.html
+        rules = RoutingRules()
+        condition = Condition(http_error_code=404)
+        redirect = Redirect(hostname='example.com',
+                            replace_key_prefix='report-404/')
+        rules.add_rule(RoutingRule(condition, redirect))
+        config = WebsiteConfiguration(suffix='index.html', routing_rules=rules)
+        xml = config.to_xml()
+
+        expected_xml = """<?xml version="1.0" encoding="UTF-8"?>
+            <WebsiteConfiguration xmlns='http://s3.amazonaws.com/doc/2006-03-01/'>
+              <IndexDocument>
+                <Suffix>index.html</Suffix>
+              </IndexDocument>
+              <RoutingRules>
+                <RoutingRule>
+                <Condition>
+                  <HttpErrorCodeReturnedEquals>404</HttpErrorCodeReturnedEquals>
+                </Condition>
+                <Redirect>
+                  <HostName>example.com</HostName>
+                  <ReplaceKeyPrefixWith>report-404/</ReplaceKeyPrefixWith>
+                </Redirect>
+                </RoutingRule>
+              </RoutingRules>
+            </WebsiteConfiguration>
+        """
+        self.assertEqual(x(expected_xml), x(xml))
+
+    def test_builders(self):
+        x = pretty_print_xml
+        # This is a more declarative way to create rules.
+        # First the long way.
+        rules = RoutingRules()
+        condition = Condition(http_error_code=404)
+        redirect = Redirect(hostname='example.com',
+                            replace_key_prefix='report-404/')
+        rules.add_rule(RoutingRule(condition, redirect))
+        xml = rules.to_xml()
+
+        # Then the more concise way.
+        rules2 = RoutingRules().add_rule(
+            RoutingRule.when(http_error_code=404).then_redirect(
+                hostname='example.com', replace_key_prefix='report-404/'))
+        xml2 = rules2.to_xml()
+        self.assertEqual(x(xml), x(xml2))


### PR DESCRIPTION
This is a backwards compatible change that updates the
`configure_website` method on the `Bucket` class with
extra parameters.

I've extracted the website configuration into it's own class,
similar to the CORS and Lifecycle configurations, but only
used it internally for the implementation of configure_website.
We could also add a method on Bucket that takes a WebsiteConfiguration
object directly, but I've not added that.

This is a direct mapping to the API as specified in:
http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTwebsite.html

I've added unittests and integration tests for these changes,
and the existing integration test for website configuration still
passes.
