### PR TITLE
Added two new exceptions for CloudSearch's document service

### DIFF
--- a/boto/cloudsearch/document.py
+++ b/boto/cloudsearch/document.py
@@ -34,6 +34,24 @@ class SearchServiceException(Exception):
 class CommitMismatchError(Exception):
     pass
 
+class EncodingError(Exception):
+    """
+    Content sent for Cloud Search indexing was incorrectly encoded.
+
+    This usually happens when a document is marked as unicode but non-unicode
+    characters are present.
+    """
+    pass
+
+class ContentTooLongError(Exception):
+    """
+    Content sent for Cloud Search indexing was too long
+
+    This will usually happen when documents queued for indexing add up to more
+    than the limit allowed per upload batch (5MB)
+
+    """
+    pass
 
 class DocumentServiceConnection(object):
 
@@ -119,6 +137,11 @@ class CommitResponse(object):
         if self.status == 'error':
             self.errors = [e.get('message') for e in self.content.get('errors',
                 [])]
+            for e in self.errors:
+                if "Illegal Unicode character" in e:
+                    raise EncodingError("Illegal Unicode character in document")
+                elif e == "The Content-Length is too long":
+                    raise ContentTooLongError("Content was too long")
         else:
             self.errors = []
 


### PR DESCRIPTION
Currently, when the `commit()` method gets called on the document service it is hard to tell what's going based on the error that gets thrown. 

At the moment `CommitResponse` correctly looks up the results of the API call, but never actually returns the error to the user. Instead, right at the end of `CommitResponse`'s `__init__()` function, a check is done to ensure that the number of add/delete operations matches what was expected. This results in a `CommitMismatchError` getting thrown which doesn't contain the actual error that caused the mismatch in the first place.

This patch makes the error message available to the end user.
