### PR TITLE
Add facets in CloudSearch's SearchResults

### DIFF
--- a/boto/cloudsearch/search.py
+++ b/boto/cloudsearch/search.py
@@ -51,6 +51,11 @@ class SearchResults(object):
         self.query = attrs['query']
         self.search_service = attrs['search_service']
 
+        self.facets = {}
+        if 'facets' in attrs:
+            for (facet, values) in attrs['facets'].iteritems():
+                self.facets[facet] = dict((k, v) for (k, v) in map(lambda x: (x['value'], x['count']), values['constraints']))
+
         self.num_pages_needed = ceil(self.hits / self.query.real_size)
 
     def __len__(self):


### PR DESCRIPTION
It's currently possible to ask CloudSearch to retrieve facets, but the API does not actually pass those back to the user.

This patch adds in this functionality. This merge is similar to #836 and a part of #782, but this merge is slightly different in that the data is converted out of the straight JSON-imported format and into a normalised dictionary.
