### PR TITLE
restore DefaultPartSize for create_archive_from_file

### DIFF
--- a/boto/glacier/vault.py
+++ b/boto/glacier/vault.py
@@ -162,8 +162,8 @@ class Vault(object):
             file_size = os.path.getsize(filename)
             try:
                 min_part_size = minimum_part_size(file_size)
-		if (min_part_size>part_size):
-			part_size=min_part_size
+                if (min_part_size>part_size):
+                     part_size=min_part_size
             except ValueError:
                 raise UploadArchiveError("File size of %s bytes exceeds "
                                          "40,000 GB archive limit of Glacier.")


### PR DESCRIPTION
When create_archive_from_file was modified to automatically detect when part sizes were too small, the change ignored the existing DefaultPartSize.   This change only replaces the part_size if the DefaultPartSize is lower than the calculated size.
