### PR TITLE
Remove fp seek check in s3 set_contents_from_file if fp cannot seek

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1032,7 +1032,8 @@ class Key(object):
         if rewind:
             # caller requests reading from beginning of fp.
             fp.seek(0, os.SEEK_SET)
-        else:
+        elif hasattr(fp, "seek"):
+            # Only perform the following seek sanity check if the fp supports seeking
             spos = fp.tell()
             fp.seek(0, os.SEEK_END)
             if fp.tell() == spos:


### PR DESCRIPTION
Some file-like objects do not support seeking. If the size and md5 of the
underlying data are already known in advance, it is possible and desirable to
read the stream only when we are actually sending the bytes to the storage
service. The current fp.seek calls in this block are simply a sanity check that 
a user didn't pass in an already-advanced fp, and can safely be avoided if the 
fp does not support seeking.
