### PR TITLE
Use HEAD request in get_redirect

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -506,7 +506,7 @@ class Key(object):
 
         """
         response = self.bucket.connection.make_request(
-            'GET', self.bucket.name, self.name)
+            'HEAD', self.bucket.name, self.name)
         if response.status == 200:
             return response.getheader('x-amz-website-redirect-location')
         else:


### PR DESCRIPTION
The get_redirect function is currently using a GET request, downloading
the entire file just to access metadata. The pull request changes this
to a HEAD request.
