### PR TITLE
Allow CloudFront API calls using IAM roles

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -188,6 +188,9 @@ class HmacAuthV2Handler(AuthHandler, HmacKeys):
         headers = http_request.headers
         if 'Date' not in headers:
             headers['Date'] = formatdate(usegmt=True)
+        if self._provider.security_token:
+            key = self._provider.security_token_header
+            headers[key] = self._provider.security_token
 
         b64_hmac = self.sign_string(headers['Date'])
         auth_hdr = self._provider.auth_header


### PR DESCRIPTION
When picking up credentials from an IAM instance role,
need to add header x-amz-security-token to the request.
Otherwise you get InvalidClientTokenId.
