### PR TITLE
Added positional argument markers to format() for python 2.6

### DIFF
--- a/boto/cloudsearch/document.py
+++ b/boto/cloudsearch/document.py
@@ -221,8 +221,8 @@ class CommitResponse(object):
         try:
             self.content = json.loads(response.content)
         except:
-            boto.log.error('Error indexing documents.\nResponse Content:\n{}\n\n'
-                'SDF:\n{}'.format(response.content, self.sdf))
+            boto.log.error('Error indexing documents.\nResponse Content:\n{0}\n\n'
+                'SDF:\n{1}'.format(response.content, self.sdf))
             raise boto.exception.BotoServerError(self.response.status_code, '',
                 body=response.content)
 
@@ -259,5 +259,5 @@ class CommitResponse(object):
 
         if response_num != commit_num:
             raise CommitMismatchError(
-                'Incorrect number of {}s returned. Commit: {} Response: {}'\
+                'Incorrect number of {0}s returned. Commit: {1} Response: {2}'\
                 .format(type_, commit_num, response_num))

--- a/boto/dynamodb/condition.py
+++ b/boto/dynamodb/condition.py
@@ -92,7 +92,7 @@ class ConditionSeveralArgs(Condition):
         self.values = values
 
     def __repr__(self):
-        return '{}({})'.format(self.__class__.__name__,
+        return '{0}({1})'.format(self.__class__.__name__,
                                ', '.join(self.values))
 
     def to_dict(self):


### PR DESCRIPTION
Boto docs still say python2.6 is supported so I'm changing these format strings to match. Two of them are in error messages which have the potential to make things even more confusing.
