### PR TITLE
Bugfix for 906929: blockdevicemapping.py does not populate request parameter as per AWS EC2 API reference

### DIFF
--- a/boto/ec2/blockdevicemapping.py
+++ b/boto/ec2/blockdevicemapping.py
@@ -125,7 +125,7 @@ class BlockDeviceMapping(dict):
                 params['%s.VirtualName' % pre] = block_dev.ephemeral_name
             else:
                 if block_dev.no_device:
-                    params['%s.Ebs.NoDevice' % pre] = 'true'
+                    params['%s.NoDevice' % pre] = 'true'
                 if block_dev.snapshot_id:
                     params['%s.Ebs.SnapshotId' % pre] = block_dev.snapshot_id
                 if block_dev.size:


### PR DESCRIPTION
blockdevicemapping,py does not follow AWS EC2 sytax for request parameter "NoDevice". EC2 expects "BlockDeviceMapping.n.NoDevice" but actually receives "BlockDeviceMapping.Ebs.n.NoDevice"

Fix involved removing the additional "Ebs." component in the request parameter construction for "NoDevice". 

Links to AWS EC2 API reference:
http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-RunInstances.html,
http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-RegisterImage.html

Link to the bug: https://bugzilla.redhat.com/show_bug.cgi?id=906929
