### PR TITLE
It requires a allocation_id when associating the VPC instance to an EIP.

### DIFF
--- a/boto/ec2/address.py
+++ b/boto/ec2/address.py
@@ -83,12 +83,18 @@ class Address(EC2Object):
 
     delete = release
 
-    def associate(self, instance_id):
+    def associate(self, instance_id, allow_reassociation=False):
         """
         Associate this Elastic IP address with a currently running instance.
         :see: :meth:`boto.ec2.connection.EC2Connection.associate_address`
         """
-        return self.connection.associate_address(instance_id, self.public_ip)
+        if self.allocation_id:
+            return self.connection.associate_address(instance_id,
+                allocation_id=self.allocation_id,
+                allow_reassociation=allow_reassociation)
+        else:
+            return self.connection.associate_address(instance_id, self.public_ip,
+                allow_reassociation=allow_reassociation)
 
     def disassociate(self):
         """


### PR DESCRIPTION
I found a bug inside boto.ec2.address.Address.associate method. 
It requires a allocation_id when associating the VPC instance to an EIP.

So, here is my fix:
1. If there is allocation_id for this address, provide it as a parameter, when calling associate_address.
2. allow passing 'allow_reassociation' to associate_address.
