### PR TITLE
Fix S3 website redirection from key to key through routing rules.

### DIFF
--- a/boto/s3/website.py
+++ b/boto/s3/website.py
@@ -228,7 +228,7 @@ class Redirect(object):
         if self.protocol is not None:
             inner_text.append(tag('Protocol', self.protocol))
         if self.replace_key is not None:
-            inner_text.append(tag('ReplaceKey', self.replace_key))
+            inner_text.append(tag('ReplaceKeyWith', self.replace_key))
         if self.replace_key_prefix is not None:
             inner_text.append(tag('ReplaceKeyPrefixWith',
                                   self.replace_key_prefix))


### PR DESCRIPTION
As specified in http://docs.aws.amazon.com/AmazonS3/latest/dev/HowDoIWebsiteConfiguration.html the correct name of the XML key is 'ReplaceKeyWith' instead of 'ReplaceKey'.
