### PR TITLE
Fixing the bug in logic of object's string representation.

### DIFF
--- a/boto/swf/layer2.py
+++ b/boto/swf/layer2.py
@@ -41,9 +41,9 @@ class SWFBase(object):
 
     def __repr__(self):
         """Generate string representation."""
-        rep_str = self.name
+        rep_str = str(self.name)
         if hasattr(self, 'version'):
-            rep_str += '-' + getattr(self, 'version')
+            rep_str += '-' + str(getattr(self, 'version'))
         return '<%s %r at 0x%x>' % (self.__class__.__name__, rep_str, id(self))
 
 class Domain(SWFBase):


### PR DESCRIPTION
The `__repr__` method incorrectly assumes a presence of a string in the `name` attribute of an SWFBase object. When an object has an empty name (used to set worker's identity in SWF) and a version attribute exists on it, the following happens:

```
>>> from boto.swf.layer2 import Decider
>>> Decider(version=None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "boto/swf/layer2.py", line 46, in __repr__
    rep_str += '-' + getattr(self, 'version')
TypeError: cannot concatenate 'str' and 'NoneType' objects
>>> 
```

With this fix, the undesider behavior goes away.

```
>>> from boto.swf.layer2 import Decider
>>> Decider(version=None)
<Decider 'None-None' at 0x7fb3745d9390>
>>>
```
