### PR TITLE
Fixed-up inline doc for boto.elasticache.regions()

### DIFF
--- a/boto/elasticache/__init__.py
+++ b/boto/elasticache/__init__.py
@@ -25,7 +25,7 @@ from boto.regioninfo import RegionInfo
 
 def regions():
     """
-    Get all available regions for the AWS Elastic Beanstalk service.
+    Get all available regions for the AWS ElastiCache service.
 
     :rtype: list
     :return: A list of :class:`boto.regioninfo.RegionInfo`


### PR DESCRIPTION
This looks like it was copy-pasted from elastic beanstalk and the documentation wasn't updated to match.
