### PR TITLE
[Develop] Add support for supported_products

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -301,6 +301,11 @@ class EmrConnection(AWSQueryConnection):
 
         :rtype: str
         :return: The jobflow id
+
+        :type supported_products: str
+        :param supported_products: Installs supported products in EMR
+            current supported options are ``mapr-m3``, ``mapr-m5`` and
+            ``karmasphere-enterprise-utility``.
         """
         params = {}
         if action_on_failure:


### PR DESCRIPTION
Amazon allow installing MapR + Karmasphere via the API. This patch adds a keyword arg (`supported_products`) to the `run_jobflow` code.

Reference link: [here](http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_RunJobFlow.html)

Tested with all available products.
