### PR TITLE
Fixed up API index for cloudsearch docs

### DIFF
--- a/docs/source/ref/cloudsearch.rst
+++ b/docs/source/ref/cloudsearch.rst
@@ -7,7 +7,7 @@ Cloudsearch
 boto.cloudsearch
 ----------------
 
-.. automodule:: boto.swf
+.. automodule:: boto.cloudsearch
    :members:   
    :undoc-members:
 


### PR DESCRIPTION
This looks like a copy-paste mistake. It makes the cloudsearch API docs point to the wrong class.
