### PR TITLE
Fixing bugs related to starting an EBS with no instance store volume

### DIFF
--- a/boto/ec2/blockdevicemapping.py
+++ b/boto/ec2/blockdevicemapping.py
@@ -125,17 +125,18 @@ class BlockDeviceMapping(dict):
                 params['%s.VirtualName' % pre] = block_dev.ephemeral_name
             else:
                 if block_dev.no_device:
-                    params['%s.Ebs.NoDevice' % pre] = 'true'
-                if block_dev.snapshot_id:
-                    params['%s.Ebs.SnapshotId' % pre] = block_dev.snapshot_id
-                if block_dev.size:
-                    params['%s.Ebs.VolumeSize' % pre] = block_dev.size
-                if block_dev.delete_on_termination:
-                    params['%s.Ebs.DeleteOnTermination' % pre] = 'true'
+                    params['%s.NoDevice' % pre] = ''
                 else:
-                    params['%s.Ebs.DeleteOnTermination' % pre] = 'false'
-                if block_dev.volume_type:
-                    params['%s.Ebs.VolumeType' % pre] = block_dev.volume_type
-                if block_dev.iops is not None:
-                    params['%s.Ebs.Iops' % pre] = block_dev.iops
+                    if block_dev.snapshot_id:
+                        params['%s.Ebs.SnapshotId' % pre] = block_dev.snapshot_id
+                    if block_dev.size:
+                        params['%s.Ebs.VolumeSize' % pre] = block_dev.size
+                    if block_dev.delete_on_termination:
+                        params['%s.Ebs.DeleteOnTermination' % pre] = 'true'
+                    else:
+                        params['%s.Ebs.DeleteOnTermination' % pre] = 'false'
+                    if block_dev.volume_type:
+                        params['%s.Ebs.VolumeType' % pre] = block_dev.volume_type
+                    if block_dev.iops is not None:
+                        params['%s.Ebs.Iops' % pre] = block_dev.iops
             i += 1


### PR DESCRIPTION
1. Removed invalid ".Ebs." from the "NoDevice" parameter.
2. If "NoDevice" is needed, will no longer list any "Ebs" type parameters as they were causing AWS to launch instances with no root device at all (even if a 3nd block device was defined).
3. Removed  "true" value from ".NoDevice" parameter.
