### PR TITLE
Ignore the venv directory from the contributing docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ MANIFEST
 .tox
 .coverage
 *flymake.py
+venv


### PR DESCRIPTION
Silly small, but the Contributing docs (http://docs.pythonboto.org/en/latest/contributing.html) recommend a virtualenv in `venv` & ignoring yields less noise in `git status`.
