### PR TITLE
_sign_string private_key_file can now be file-like

### DIFF
--- a/boto/cloudfront/distribution.py
+++ b/boto/cloudfront/distribution.py
@@ -654,12 +654,14 @@ class Distribution:
             raise ValueError("Only specify the private_key_file or the private_key_string not both")
         if not private_key_file and not private_key_string:
             raise ValueError("You must specify one of private_key_file or private_key_string")
-        # If private_key_file is a file, read its contents. Otherwise, open it and then read it
-        if isinstance(private_key_file, file):
-            private_key_string = private_key_file.read()
-        elif private_key_file:
-            with open(private_key_file, 'r') as file_handle:
-                private_key_string = file_handle.read()
+        # If private_key_file is a file name, open it and read it
+        if private_key_string is None:
+            if isinstance(private_key_file, basestring):
+                with open(private_key_file, 'r') as file_handle:
+                    private_key_string = file_handle.read()
+            # Otherwise, treat it like a file
+            else:
+                private_key_string = private_key_file.read()
 
         # Sign it!
         private_key = rsa.PrivateKey.load_pkcs1(private_key_string)

--- a/tests/unit/cloudfront/test_signed_urls.py
+++ b/tests/unit/cloudfront/test_signed_urls.py
@@ -4,6 +4,7 @@ try:
     import simplejson as json
 except ImportError:
     import json
+from cStringIO import StringIO
 from textwrap import dedent
 
 from boto.cloudfront.distribution import Distribution
@@ -129,6 +130,22 @@ class CloudfrontSignedUrlsTest(unittest.TestCase):
         pk_file.write(self.pk_str)
         pk_file.flush()
         sig = self.dist._sign_string(self.canned_policy, private_key_file=pk_file.name)
+        encoded_sig = self.dist._url_base64_encode(sig)
+        self.assertEqual(expected, encoded_sig)
+
+    def test_sign_canned_policy_pk_file_like(self):
+        """
+        Test signing the canned policy from amazon's cloudfront documentation
+        with a file-like object (not a subclass of 'file' type)
+        """
+        expected = ("Nql641NHEUkUaXQHZINK1FZ~SYeUSoBJMxjdgqrzIdzV2gyEXPDN"
+                    "v0pYdWJkflDKJ3xIu7lbwRpSkG98NBlgPi4ZJpRRnVX4kXAJK6td"
+                    "Nx6FucDB7OVqzcxkxHsGFd8VCG1BkC-Afh9~lOCMIYHIaiOB6~5j"
+                    "t9w2EOwi6sIIqrg_")
+        pk_file = StringIO()
+        pk_file.write(self.pk_str)
+        pk_file.seek(0)
+        sig = self.dist._sign_string(self.canned_policy, private_key_file=pk_file)
         encoded_sig = self.dist._url_base64_encode(sig)
         self.assertEqual(expected, encoded_sig)
 


### PR DESCRIPTION
Distribution._sign_string is now a little bit more flexible, allowing
the private_key_file to be a file-like object (or really anything with a
.read() method).

My experiments in the world of signed cloudfront URLs were being impeded by the inability to pass file-like objects through _sign_string. This builds on the unit tests I wrote a little bit ago (https://github.com/boto/boto/pull/1271), and I'm pretty confident that it's backward compatible.

Test included.
