### PR TITLE
Add get_logging_config for GCS

### DIFF
--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -737,6 +737,56 @@ class Bucket(S3Bucket):
 
         self.set_subresource('logging', xml_str, headers=headers)
 
+    def get_logging_config_with_xml(self, headers=None):
+        """Returns the current status of logging configuration on the bucket as
+        unparsed XML.
+
+        :param dict headers: Additional headers to send with the request.
+
+        :rtype: 2-Tuple
+        :returns: 2-tuple containing:
+
+            1) A dictionary containing a Python representation of the XML
+               response from GCS. The overall structure is:
+
+              * Logging
+
+                * LogObjectPrefix: Prefix that is prepended to log objects.
+                * LogBucket: Target bucket for lob objects.
+
+            2) Unparsed XML describing the bucket's loggin configuration.
+        """
+        response = self.connection.make_request('GET', self.name,
+                                                query_args='logging',
+                                                headers=headers)
+        body = response.read()
+        boto.log.debug(body)
+
+        if response.status != 200:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+        e = boto.jsonresponse.Element()
+        h = boto.jsonresponse.XmlHandler(e, None)
+        h.parse(body)
+        return e, body
+
+    def get_logging_config(self, headers=None):
+        """Returns the current status of logging configuration on the bucket.
+
+        :param dict headers: Additional headers to send with the request.
+
+        :rtype: dict
+        :returns: A dictionary containing a Python representation of the XML
+            response from GCS. The overall structure is:
+
+            * Logging
+
+              * LogObjectPrefix: Prefix that is prepended to log objects.
+              * LogBucket: Target bucket for lob objects.
+        """
+        return self.get_logging_config_with_xml(headers)[0]
+
     def configure_website(self, main_page_suffix=None, error_key=None,
                           headers=None):
         """Configure this bucket to act as a website
@@ -793,7 +843,7 @@ class Bucket(S3Bucket):
               * NotFoundPage: name of an object to serve when site visitors
                 encounter a 404.
         """
-        return self.get_website_configuration_xml(self, headers)[0]
+        return self.get_website_configuration_with_xml(headers)[0]
 
     def get_website_configuration_with_xml(self, headers=None):
         """Returns the current status of website configuration on the bucket as

--- a/boto/storage_uri.py
+++ b/boto/storage_uri.py
@@ -704,8 +704,14 @@ class BucketStorageUri(StorageUri):
         bucket = self.get_bucket(validate, headers)
         bucket.disable_logging(headers=headers)
 
+    def get_logging_config(self, validate=False, headers=None, version_id=None):
+        self._check_bucket_uri('get_logging_config')
+        bucket = self.get_bucket(validate, headers)
+        return bucket.get_logging_config(headers=headers)
+
     def set_website_config(self, main_page_suffix=None, error_key=None,
                            validate=False, headers=None):
+        self._check_bucket_uri('set_website_config')
         bucket = self.get_bucket(validate, headers)
         if not (main_page_suffix or error_key):
             bucket.delete_website_configuration(headers)
@@ -713,10 +719,12 @@ class BucketStorageUri(StorageUri):
             bucket.configure_website(main_page_suffix, error_key, headers)
 
     def get_website_config(self, validate=False, headers=None):
+        self._check_bucket_uri('get_website_config')
         bucket = self.get_bucket(validate, headers)
-        return bucket.get_website_configuration_with_xml(headers)
+        return bucket.get_website_configuration(headers)
 
     def get_versioning_config(self, headers=None):
+        self._check_bucket_uri('get_versioning_config')
         bucket = self.get_bucket(False, headers)
         return bucket.get_versioning_status(headers)
 

--- a/tests/integration/s3/mock_storage_service.py
+++ b/tests/integration/s3/mock_storage_service.py
@@ -250,6 +250,9 @@ class MockBucket(object):
     def enable_logging(self, target_bucket_prefix):
         self.logging = True
 
+    def get_logging_config(self):
+        return {"Logging": {}}
+
     def get_acl(self, key_name='', headers=NOT_IMPL, version_id=NOT_IMPL):
         if key_name:
             # Return ACL for the key.
@@ -470,6 +473,10 @@ class MockBucketStorageUri(object):
     def enable_logging(self, target_bucket, target_prefix, validate=NOT_IMPL,
                        headers=NOT_IMPL, version_id=NOT_IMPL):
         self.get_bucket().enable_logging(target_bucket)
+
+    def get_logging_config(self, validate=NOT_IMPL, headers=NOT_IMPL,
+                           version_id=NOT_IMPL):
+        return self.get_bucket().get_logging_config()
 
     def equals(self, uri):
         return self.uri == uri.uri


### PR DESCRIPTION
This adds get_logging_config functionality to gs buckets and storage_uri, to retrieve the logging configuration of a Google Cloud Storage bucket. Also makes a number of smaller fixes for consistency.

Note that this breaks the getwebcfg command in gsutil. A change to address that is that being submitted concurrently.
