### PR TITLE
CRITICAL FIX

### DIFF
--- a/tests/integration/ec2/elb/test_connection.py
+++ b/tests/integration/ec2/elb/test_connection.py
@@ -30,15 +30,23 @@ from boto.ec2.elb import ELBConnection
 class ELBConnectionTest(unittest.TestCase):
     ec2 = True
 
+    def setup(self):
+        """Creates a named load balancer that can be safely
+        deleted at the end of each test"""
+        self.conn = ELBConnection()
+        self.name = 'elb-boto-unit-test'
+        self.availability_zones = ['us-east-1a']
+        self.listeners = [(80, 8000, 'HTTP')]
+        self.balancer = self.conn.create_load_balancer(name, availability_zones, listeners)
+
     def tearDown(self):
-        """ Deletes all load balancers after every test. """
-        for lb in ELBConnection().get_all_load_balancers():
-            lb.delete()
+        """ Deletes the test load balancer after every test.
+        It does not delete EVERY load balancer in your account"""
+        self.balancer.delete()
 
     def test_build_list_params(self):
-        c = ELBConnection()
         params = {}
-        c.build_list_params(
+        self.conn.build_list_params(
             params, ['thing1', 'thing2', 'thing3'], 'ThingName%d')
         expected_params = {
             'ThingName1': 'thing1',
@@ -52,76 +60,60 @@ class ELBConnectionTest(unittest.TestCase):
     # balancer.dns_name, along the lines of the existing EC2 unit tests.
 
     def test_create_load_balancer(self):
-        c = ELBConnection()
-        name = 'elb-boto-unit-test'
-        availability_zones = ['us-east-1a']
-        listeners = [(80, 8000, 'HTTP')]
-        balancer = c.create_load_balancer(name, availability_zones, listeners)
-        self.assertEqual(balancer.name, name)
-        self.assertEqual(balancer.availability_zones, availability_zones)
-        self.assertEqual(balancer.listeners, listeners)
+        self.assertEqual(self.balancer.name, self.name)
+        self.assertEqual(self.balancer.availability_zones,\
+            self.availability_zones)
+        self.assertEqual(self.balancer.listeners, self.listeners)
 
-        balancers = c.get_all_load_balancers()
-        self.assertEqual([lb.name for lb in balancers], [name])
+        balancers = self.conn.get_all_load_balancers()
+        self.assertEqual([lb.name for lb in balancers], [self.name])
 
     def test_create_load_balancer_listeners(self):
-        c = ELBConnection()
-        name = 'elb-boto-unit-test'
-        availability_zones = ['us-east-1a']
-        listeners = [(80, 8000, 'HTTP')]
-        balancer = c.create_load_balancer(name, availability_zones, listeners)
-
         more_listeners = [(443, 8001, 'HTTP')]
-        c.create_load_balancer_listeners(name, more_listeners)
-        balancers = c.get_all_load_balancers()
-        self.assertEqual([lb.name for lb in balancers], [name])
+        self.conn.create_load_balancer_listeners(self.name, more_listeners)
+        balancers = self.conn.get_all_load_balancers()
+        self.assertEqual([lb.name for lb in balancers], [self.name])
         self.assertEqual(
             sorted(l.get_tuple() for l in balancers[0].listeners),
-            sorted(listeners + more_listeners)
+            sorted(self.listeners + more_listeners)
             )
 
     def test_delete_load_balancer_listeners(self):
-        c = ELBConnection()
-        name = 'elb-boto-unit-test'
-        availability_zones = ['us-east-1a']
-        listeners = [(80, 8000, 'HTTP'), (443, 8001, 'HTTP')]
-        balancer = c.create_load_balancer(name, availability_zones, listeners)
+        mod_listeners = [(80, 8000, 'HTTP'), (443, 8001, 'HTTP')]
+        mod_name = self.name + "_mod"
+        self.mod_balancer = self.conn.create_load_balancer(mod_name,\
+            self.availability_zones, mod_listeners)
 
-        balancers = c.get_all_load_balancers()
-        self.assertEqual([lb.name for lb in balancers], [name])
+        mod_balancers = self.conn.get_all_load_balancers(load_balancer_names=[mod_name])
+        self.assertEqual([lb.name for lb in mod_balancers], [mod_name])
         self.assertEqual(
-            sorted([l.get_tuple() for l in balancers[0].listeners]),
-            sorted(listeners))
+            sorted([l.get_tuple() for l in mod_balancers[0].listeners]),
+            sorted(mod_listeners))
 
-        c.delete_load_balancer_listeners(name, [443])
-        balancers = c.get_all_load_balancers()
-        self.assertEqual([lb.name for lb in balancers], [name])
-        self.assertEqual([l.get_tuple() for l in balancers[0].listeners],
-                         listeners[:1])
+        self.conn.delete_load_balancer_listeners(self.mod_balancer.name, [443])
+        mod_balancers = self.conn.get_all_load_balancers(load_balancer_names=[mod_name])
+        self.assertEqual([lb.name for lb in mod_balancers], [mod_name])
+        self.assertEqual([l.get_tuple() for l in mod_balancers[0].listeners],
+                         mod_listeners[:1])
+        self.mod_balancer.delete()
 
     def test_create_load_balancer_listeners_with_policies(self):
-        c = ELBConnection()
-        name = 'elb-boto-unit-test-policy'
-        availability_zones = ['us-east-1a']
-        listeners = [(80, 8000, 'HTTP')]
-        balancer = c.create_load_balancer(name, availability_zones, listeners)
-
         more_listeners = [(443, 8001, 'HTTP')]
-        c.create_load_balancer_listeners(name, more_listeners)
+        self.conn.create_load_balancer_listeners(self.name, more_listeners)
 
         lb_policy_name = 'lb-policy'
-        c.create_lb_cookie_stickiness_policy(1000, name, lb_policy_name)
-        c.set_lb_policies_of_listener(name, listeners[0][0], lb_policy_name)
+        self.conn.create_lb_cookie_stickiness_policy(1000, self.name, lb_policy_name)
+        self.conn.set_lb_policies_of_listener(self.name, self.listeners[0][0], lb_policy_name)
 
         app_policy_name = 'app-policy'
-        c.create_app_cookie_stickiness_policy('appcookie', name, app_policy_name)
-        c.set_lb_policies_of_listener(name, more_listeners[0][0], app_policy_name)
+        self.conn.create_app_cookie_stickiness_policy('appcookie', self.name, app_policy_name)
+        self.conn.set_lb_policies_of_listener(self.name, more_listeners[0][0], app_policy_name)
 
-        balancers = c.get_all_load_balancers()
-        self.assertEqual([lb.name for lb in balancers], [name])
+        balancers = self.conn.get_all_load_balancers(load_balancer_names=[self.name])
+        self.assertEqual([lb.name for lb in balancers], [self.name])
         self.assertEqual(
             sorted(l.get_tuple() for l in balancers[0].listeners),
-            sorted(listeners + more_listeners)
+            sorted(self.listeners + more_listeners)
             )
         # Policy names should be checked here once they are supported
         # in the Listener object.


### PR DESCRIPTION
The teardown method used to delete ALL LOAD BALANCERS in your account.
    Though this is not necessarily a bad thing on its own, it can really
    burn you if you happen to run the integration tests in a staging
    environment that you care about.

```
The fix makes all assertions that are based on modifications to load
balancers refer to the fixture that is created in the setup method.
There was repeated code that was doing the same thing as the setup
method--this code also cleans this up.

NOTE: THIS IS JUST A FIX TO elb/test_connection.py. All of the
integration tests need to be looked at with this issue in mind.
```
