### PR TITLE
Adds get_logging_config to GS bucket and storage_uri

### DIFF
--- a/boto/storage_uri.py
+++ b/boto/storage_uri.py
@@ -704,8 +704,14 @@ class BucketStorageUri(StorageUri):
         bucket = self.get_bucket(validate, headers)
         bucket.disable_logging(headers=headers)
 
+    def get_logging_config(self, validate=False, headers=None, version_id=None):
+        self._check_bucket_uri('get_logging_config')
+        bucket = self.get_bucket(validate, headers)
+        return bucket.get_logging_config(headers=headers)
+
     def set_website_config(self, main_page_suffix=None, error_key=None,
                            validate=False, headers=None):
+        self._check_bucket_uri('set_website_config')
         bucket = self.get_bucket(validate, headers)
         if not (main_page_suffix or error_key):
             bucket.delete_website_configuration(headers)
@@ -713,10 +719,12 @@ class BucketStorageUri(StorageUri):
             bucket.configure_website(main_page_suffix, error_key, headers)
 
     def get_website_config(self, validate=False, headers=None):
+        self._check_bucket_uri('get_website_config')
         bucket = self.get_bucket(validate, headers)
-        return bucket.get_website_configuration_with_xml(headers)
+        return bucket.get_website_configuration(headers)
 
     def get_versioning_config(self, headers=None):
+        self._check_bucket_uri('get_versioning_config')
         bucket = self.get_bucket(False, headers)
         return bucket.get_versioning_status(headers)
 

--- a/tests/integration/s3/mock_storage_service.py
+++ b/tests/integration/s3/mock_storage_service.py
@@ -250,6 +250,9 @@ class MockBucket(object):
     def enable_logging(self, target_bucket_prefix):
         self.logging = True
 
+    def get_logging_config(self):
+        return {"Logging": {}}
+
     def get_acl(self, key_name='', headers=NOT_IMPL, version_id=NOT_IMPL):
         if key_name:
             # Return ACL for the key.
@@ -470,6 +473,10 @@ class MockBucketStorageUri(object):
     def enable_logging(self, target_bucket, target_prefix, validate=NOT_IMPL,
                        headers=NOT_IMPL, version_id=NOT_IMPL):
         self.get_bucket().enable_logging(target_bucket)
+
+    def get_logging_config(self, validate=NOT_IMPL, headers=NOT_IMPL,
+                           version_id=NOT_IMPL):
+        return self.get_bucket().get_logging_config()
 
     def equals(self, uri):
         return self.uri == uri.uri


### PR DESCRIPTION
This adds get_logging_config functionality to gs buckets and storage_uri, to
retrieve the logging configuration of a Google Cloud Storage bucket. Also makes
a number of smaller fixes for consistency.

Note that this breaks the getwebcfg command in gsutil. A change to address that
is that being submitted concurrently.

Code reviewed under https://codereview.appspot.com/7381057/
