### PR TITLE
mod utils.py:get_instance_metadata allowing access to dynamic data

### DIFF
--- a/boto/utils.py
+++ b/boto/utils.py
@@ -311,7 +311,7 @@ class LazyLoadMetadata(dict):
 
 
 def get_instance_metadata(version='latest', url='http://169.254.169.254',
-                          timeout=None, num_retries=5):
+                          data='meta-data', timeout=None, num_retries=5):
     """
     Returns the instance metadata as a nested Python dictionary.
     Simple values (e.g. local_hostname, hostname, etc.) will be
@@ -327,7 +327,7 @@ def get_instance_metadata(version='latest', url='http://169.254.169.254',
         original = socket.getdefaulttimeout()
         socket.setdefaulttimeout(timeout)
     try:
-        return _get_instance_metadata('%s/%s/meta-data/' % (url, version),
+        return _get_instance_metadata('%s/%s/%s/' % (url, version, data),
                                       num_retries=num_retries)
     except urllib2.URLError, e:
         return None


### PR DESCRIPTION
dynamic metadata gives some more info about an instance and is exposed through the metadata api, namely different are:
accountId
architecture
availabilityZone
billingProducts
devpayProductCodes
imageId
instanceId
instanceType
kernelId
pendingTime
pkcs7
privateIp
ramdiskId
region
signature
version

I kept the default behavior of grabbing "meta-data", but removed it from being hard-coded so you can access the above by passing data="dynamic".
