### PR TITLE
Fixed parameter type for attach_network_interfaces

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -3359,7 +3359,7 @@ class EC2Connection(AWSQueryConnection):
         :param instance_id: The ID of the instance that will be attached
             to the network interface.
 
-        :type device_index: int
+        :type device_index: str
         :param device_index: The index of the device for the network
             interface attachment on the instance.
         """


### PR DESCRIPTION
Real simple fix, the device index is supposed to be sent as a string, not an integer. I was getting parameter errors from the ec2 api and tried it out with a string in ec2-api-tools and it worked. 

proof here : http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/ApiReference-cmd-AttachNetworkInterface.html
