### PR TITLE
Bubbling up md5 and upload_id for use in manifests.

### DIFF
--- a/boto/gs/resumable_upload_handler.py
+++ b/boto/gs/resumable_upload_handler.py
@@ -163,6 +163,22 @@ class ResumableUploadHandler(object):
         """
         return self.tracker_uri
 
+    def get_upload_id(self):
+        """
+        Returns the upload ID for the resumable upload, or None if the upload
+        has not yet started.
+        """
+        # We extract the upload_id from the tracker uri. We could retrieve the
+        # upload_id from the headers in the response but this only works for
+        # the case where we get the tracker uri from the service. In the case
+        # where we get the tracker from the tracking file we need to do this
+        # logic anyway.
+        delim = '?upload_id='
+        if self.tracker_uri and delim in self.tracker_uri:
+          return uri[uri.index(delim) + len(delim):]
+        else:
+          return None
+
     def _remove_tracker_file(self):
         if (self.tracker_file_name and
             os.path.exists(self.tracker_file_name)):

--- a/boto/storage_uri.py
+++ b/boto/storage_uri.py
@@ -304,13 +304,15 @@ class BucketStorageUri(StorageUri):
       self._update_from_values(
           getattr(key, 'version_id', None),
           getattr(key, 'generation', None),
-          getattr(key, 'is_latest', None))
+          getattr(key, 'is_latest', None),
+          getattr(key, 'md5', None))
 
-    def _update_from_values(self, version_id, generation, is_latest):
+    def _update_from_values(self, version_id, generation, is_latest, md5):
       self.version_id = version_id
       self.generation = generation
       self.is_latest = is_latest
       self._build_uri_strings()
+      self.md5 = md5
 
     def get_key(self, validate=False, headers=None, version_id=None):
         self._check_object_uri('get_key')
@@ -652,7 +654,7 @@ class BucketStorageUri(StorageUri):
                 rewind=rewind, res_upload_handler=res_upload_handler)
             if res_upload_handler:
                 self._update_from_values(None, res_upload_handler.generation,
-                                         None)
+                                         None, md5)
         else:
             self._warn_about_args('set_contents_from_file',
                                   res_upload_handler=res_upload_handler)


### PR DESCRIPTION
This change was made to expose the md5 and upload_id properties for use in gsutil manifest files.
