### PR TITLE
Amazon S3 date format

### DIFF
--- a/boto/__init__.py
+++ b/boto/__init__.py
@@ -36,7 +36,7 @@ import logging.config
 import urlparse
 from boto.exception import InvalidUriError
 
-__version__ = '2.8.0'
+__version__ = '2.8.0-dev'
 Version = __version__  # for backware compatibility
 
 UserAgent = 'Boto/%s (%s)' % (__version__, sys.platform)


### PR DESCRIPTION
S3 returns wrong date format.

Now trying strptime on RFC1123 = '%a, %d %b %Y %H:%M:%S %Z'

http://code.larlet.fr/django-storages/issue/156/s3boto-backend-valueerror-time-data-thu-07
