### PR TITLE
Allow kwargs to be passed through to uploader

### DIFF
--- a/boto/glacier/concurrent.py
+++ b/boto/glacier/concurrent.py
@@ -96,6 +96,11 @@ class ConcurrentUploader(ConcurrentTransferer):
             the archive parts.  The part size must be a megabyte multiplied by
             a power of two.
 
+        :type num_threads: int
+        :param num_threads: The number of threads to spawn for the thread pool.
+            The number of threads will control how much parts are being
+            concurrently uploaded.
+
         """
         super(ConcurrentUploader, self).__init__(part_size, num_threads)
         self._api = api

--- a/boto/glacier/vault.py
+++ b/boto/glacier/vault.py
@@ -237,7 +237,8 @@ class Vault(object):
         return resume_file_upload(
             self, upload_id, part_size, file_obj, part_hash_map)
 
-    def concurrent_create_archive_from_file(self, filename, description):
+    def concurrent_create_archive_from_file(self, filename, description,
+                                            **kwargs):
         """
         Create a new archive from a file and upload the given
         file.
@@ -250,6 +251,12 @@ class Vault(object):
         :type filename: str
         :param filename: A filename to upload
 
+        :param kwargs: Additional kwargs to pass through to
+            :py:class:`boto.glacier.concurrent.ConcurrentUploader`.
+            You can pass any argument besides the ``api`` and
+            ``vault_name`` param (these arguments are already
+            passed to the ``ConcurrentUploader`` for you).
+
         :raises: `boto.glacier.exception.UploadArchiveError` is an error
             occurs during the upload process.
 
@@ -257,7 +264,7 @@ class Vault(object):
         :return: The archive id of the newly created archive
 
         """
-        uploader = ConcurrentUploader(self.layer1, self.name)
+        uploader = ConcurrentUploader(self.layer1, self.name, **kwargs)
         archive_id = uploader.upload(filename, description)
         return archive_id
 

--- a/tests/unit/glacier/test_vault.py
+++ b/tests/unit/glacier/test_vault.py
@@ -95,6 +95,16 @@ class TestConcurrentUploads(unittest.TestCase):
                                                      'my description')
         self.assertEqual(archive_id, 'archive_id')
 
+    def test_concurrent_upload_forwards_kwargs(self):
+        v = vault.Vault(None, None)
+        with mock.patch('boto.glacier.vault.ConcurrentUploader') as c:
+            c.return_value.upload.return_value = 'archive_id'
+            archive_id = v.concurrent_create_archive_from_file(
+                'filename', 'my description', num_threads=10,
+                part_size=1024 * 1024 * 1024 * 8)
+            c.assert_called_with(None, None, num_threads=10,
+                                 part_size=1024 * 1024 * 1024 * 8)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Rather than keep concurrent_create_archive_from_file and ConcurrentUploader in
sync with their arguments,
**kwargs is now forwarded to ConcurrentUploader so that whatever args
ConcurrentUploader may grow, concurrent_create_archive_from_file will support
those args.

I also plan on adding a few kwargs to ConcurrentUploader in the
relatively near future.
