### PR TITLE
Change GS calls to make_request to always convert to utf-8 bytes.

### DIFF
--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -33,6 +33,7 @@ from boto.gs.cors import Cors
 from boto.gs.key import Key as GSKey
 from boto.s3.acl import Policy
 from boto.s3.bucket import Bucket as S3Bucket
+from boto.utils import get_utf8_value
 
 # constants for http query args
 DEF_OBJ_ACL = 'defaultObjectAcl'
@@ -407,8 +408,9 @@ class Bucket(S3Bucket):
         if if_metageneration is not None:
             headers['x-goog-if-metageneration-match'] = str(if_metageneration)
 
-        response = self.connection.make_request('PUT', self.name, key_name,
-                data=data, headers=headers, query_args=query_args)
+        response = self.connection.make_request(
+            'PUT', get_utf8_value(self.name), get_utf8_value(key_name),
+            data=get_utf8_value(data), headers=headers, query_args=query_args)
         body = response.read()
         if response.status != 200:
             raise self.connection.provider.storage_response_error(
@@ -552,11 +554,9 @@ class Bucket(S3Bucket):
         :param str cors: A string containing the CORS XML.
         :param dict headers: Additional headers to send with the request.
         """
-        cors_xml = cors.encode('UTF-8')
-        response = self.connection.make_request('PUT', self.name,
-                                                data=cors_xml,
-                                                query_args=CORS_ARG,
-                                                headers=headers)
+        response = self.connection.make_request(
+            'PUT', get_utf8_value(self.name), data=get_utf8_value(cors),
+            query_args=CORS_ARG, headers=headers)
         body = response.read()
         if response.status != 200:
             raise self.connection.provider.storage_response_error(
@@ -817,9 +817,9 @@ class Bucket(S3Bucket):
             error_frag = ''
 
         body = self.WebsiteBody % (main_page_frag, error_frag)
-        response = self.connection.make_request('PUT', self.name, data=body,
-                                                query_args='websiteConfig',
-                                                headers=headers)
+        response = self.connection.make_request(
+            'PUT', get_utf8_value(self.name), data=get_utf8_value(body),
+            query_args='websiteConfig', headers=headers)
         body = response.read()
         if response.status == 200:
             return True

--- a/boto/gs/connection.py
+++ b/boto/gs/connection.py
@@ -23,6 +23,7 @@ from boto.gs.bucket import Bucket
 from boto.s3.connection import S3Connection
 from boto.s3.connection import SubdomainCallingFormat
 from boto.s3.connection import check_lowercase_bucketname
+from boto.utils import get_utf8_value
 
 class Location:
     DEFAULT = 'US'
@@ -89,8 +90,9 @@ class GSConnection(S3Connection):
             storage_class_elem = ''
         data = ('<CreateBucketConfiguration>%s%s</CreateBucketConfiguration>'
                  % (location_elem, storage_class_elem))
-        response = self.make_request('PUT', bucket_name, headers=headers,
-                data=data)
+        response = self.make_request(
+            'PUT', get_utf8_value(bucket_name), headers=headers,
+            data=get_utf8_value(data))
         body = response.read()
         if response.status == 409:
             raise self.provider.storage_create_error(

--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -28,6 +28,7 @@ from boto.exception import BotoClientError
 from boto.s3.key import Key as S3Key
 from boto.s3.keyfile import KeyFile
 from boto.utils import compute_hash
+from boto.utils import get_utf8_value
 
 class Key(S3Key):
     """
@@ -653,9 +654,7 @@ class Key(S3Key):
         self.md5 = None
         self.base64md5 = None
 
-        if isinstance(s, unicode):
-            s = s.encode("utf-8")
-        fp = StringIO.StringIO(s)
+        fp = StringIO.StringIO(get_utf8_value(s))
         r = self.set_contents_from_file(fp, headers, replace, cb, num_cb,
                                         policy, md5,
                                         if_generation=if_generation)
@@ -883,10 +882,10 @@ class Key(S3Key):
         headers = headers or {}
         if content_type:
             headers['Content-Type'] = content_type
-        resp = self.bucket.connection.make_request('PUT', self.bucket.name,
-                                                   self.name, headers=headers,
-                                                   query_args='compose',
-                                                   data=compose_req_xml)
+        resp = self.bucket.connection.make_request(
+            'PUT', get_utf8_value(self.bucket.name), get_utf8_value(self.name),
+            headers=headers, query_args='compose',
+            data=get_utf8_value(compose_req_xml))
         if resp.status < 200 or resp.status > 299:
             raise self.bucket.connection.provider.storage_response_error(
                 resp.status, resp.reason, resp.read())


### PR DESCRIPTION
Previously, if the body string was encoded as bytes but a parameter (e.g. key
name) was a unicode string, the underlying httplib/socket layer would get
unicode decode errors when the mixing would force a unicode cast.
