### PR TITLE
Improve error reporting for glacier uploads

### DIFF
--- a/boto/glacier/concurrent.py
+++ b/boto/glacier/concurrent.py
@@ -224,7 +224,7 @@ class UploadWorkerThread(TransferThread):
 
     def _process_chunk(self, work):
         result = None
-        for i in xrange(self._num_retries):
+        for i in xrange(self._num_retries + 1):
             try:
                 result = self._upload_chunk(work)
                 break


### PR DESCRIPTION
We now get more detailed error logs such as:

```
ERROR Exception caught uploading part number 0 for vault vault_name, attempt: (2 / 3), filename: /var/folders/rb/i, exception: <type 'exceptions.Exception'>, msg: foo
```

I also had to fix the num_retries to be more sensical.  The
"attempts" part of the above log message uses num_retries + 1 for the
total number of attempts which is more intuitive.
