### PR TITLE
InstanceAttribute now handles ebsOptimized

### DIFF
--- a/boto/ec2/instance.py
+++ b/boto/ec2/instance.py
@@ -618,7 +618,7 @@ class InstanceAttribute(dict):
                    'disableApiTermination',
                    'instanceInitiatedShutdownBehavior',
                    'rootDeviceName', 'blockDeviceMapping', 'sourceDestCheck',
-                   'groupSet']
+                   'groupSet', 'ebsOptimized']
 
     def __init__(self, parent=None):
         dict.__init__(self)


### PR DESCRIPTION
boto.ec2.instance.get_attribute and boto.ec2.connection.get_instance_attribute
returned an empty dictionary when the value of the attribute 'ebsOptimized' was requested. 
