### PR TITLE
Fix boto.ec2.connection get_all_instances kwarg

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -453,7 +453,7 @@ class EC2Connection(AWSQueryConnection):
         :return: A list of  :class:`boto.ec2.instance.Reservation`
         """
         params = {}
-        if instance_ids:
+        if instance_ids is not None:
             self.build_list_params(params, instance_ids, 'InstanceId')
         if filters:
             if 'group-id' in filters:


### PR DESCRIPTION
Passing an empty list to instance_ids returns all of the
instances on the account, which is contradictory to how
the kwarg should function.  This fix makes it so this full
list is only retrieved when None is passed as the argument
(as is the default)
