### PR TITLE
Add metadata_service_num_attempts config option

### DIFF
--- a/boto/provider.py
+++ b/boto/provider.py
@@ -275,7 +275,11 @@ class Provider(object):
         boto.log.debug("Retrieving credentials from metadata server.")
         from boto.utils import get_instance_metadata
         timeout = config.getfloat('Boto', 'metadata_service_timeout', 1.0)
-        metadata = get_instance_metadata(timeout=timeout, num_retries=1)
+        attempts = config.getint('Boto', 'metadata_service_num_attempts', 1)
+        # The num_retries arg is actually the total number of attempts made,
+        # so the config options is named *_num_attempts to make this more
+        # clear to users.
+        metadata = get_instance_metadata(timeout=timeout, num_retries=attempts)
         # I'm assuming there's only one role on the instance profile.
         if metadata and 'iam' in metadata:
             security = metadata['iam']['security-credentials'].values()[0]

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -220,12 +220,12 @@ def retry_url(url, retry_on_404=True, num_retries=10):
                 code = e.code
             if code == 404 and not retry_on_404:
                 return ''
-        except urllib2.URLError, e:
-            raise e
         except Exception, e:
             pass
         boto.log.exception('Caught exception reading instance data')
-        time.sleep(2 ** i)
+        # If not on the last iteration of the loop then sleep.
+        if i + 1 != num_retries:
+            time.sleep(2 ** i)
     boto.log.error('Unable to read instance data, giving up')
     return ''
 

--- a/docs/source/boto_config_tut.rst
+++ b/docs/source/boto_config_tut.rst
@@ -148,8 +148,24 @@ These settings will default to::
     is_secure = True
     https_validate_certificates = True
     ca_certificates_file = cacerts.txt
-    http_socket_timeout=60
+    http_socket_timeout = 60
     send_crlf_after_proxy_auth_headers = False
+
+You can control the timeouts and number of retries used when retrieving
+information from the Metadata Service (this is used for retrieving credentials
+for IAM roles on EC2 instances):
+
+:metadata_service_timeout: Number of seconds until requests to the metadata
+  service will timeout (float).
+:metadata_service_num_attempts: Number of times to attempt to retrieve
+  information from the metadata service before giving up (int).
+
+These settings will default to::
+
+    [Boto]
+    metadata_service_timeout = 1.0
+    metadata_service_num_attempts = 1
+
 
 This section is also used for specifying endpoints for non-AWS services such as
 Eucalyptus and Walrus.

--- a/tests/unit/provider/test_provider.py
+++ b/tests/unit/provider/test_provider.py
@@ -7,6 +7,21 @@ import mock
 from boto import provider
 
 
+INSTANCE_CONFIG = {
+    'iam': {
+        'security-credentials': {
+            'allowall': {u'AccessKeyId': u'iam_access_key',
+                            u'Code': u'Success',
+                            u'Expiration': u'2012-09-01T03:57:34Z',
+                            u'LastUpdated': u'2012-08-31T21:43:40Z',
+                            u'SecretAccessKey': u'iam_secret_key',
+                            u'Token': u'iam_token',
+                            u'Type': u'AWS-HMAC'}
+        }
+    }
+}
+
+
 class TestProvider(unittest.TestCase):
     def setUp(self):
         self.environ = {}
@@ -170,6 +185,19 @@ class TestProvider(unittest.TestCase):
         self.assertEqual(p.access_key, 'second_access_key')
         self.assertEqual(p.secret_key, 'second_secret_key')
         self.assertEqual(p.security_token, 'second_token')
+
+    @mock.patch('boto.provider.config.getint')
+    @mock.patch('boto.provider.config.getfloat')
+    def test_metadata_config_params(self, config_float, config_int):
+        config_int.return_value = 10
+        config_float.return_value = 4.0
+        self.get_instance_metadata.return_value = INSTANCE_CONFIG
+        p = provider.Provider('aws')
+        self.assertEqual(p.access_key, 'iam_access_key')
+        self.assertEqual(p.secret_key, 'iam_secret_key')
+        self.assertEqual(p.security_token, 'iam_token')
+        self.get_instance_metadata.assert_called_with(timeout=4.0,
+                                                      num_retries=10)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When retrieving credentials from the metadata service,
it is possible to set a config option to specify the number
of seconds before timing out the request, but no option
exists that specifies the number of attempts to make to
the metadata service.

I also made two changes to the metadata retrieval process:
- If we're on the last iteration of our retry loop we
  don't sleep.  This allows us to maintain our 1 second max delay
  by default if no metadata credentials are available.
- Remove urllib2 error catching. This is raised when a timeout
  occurs and this is something we definitely want to retry.

Added a unittest for the config option and also verified
on an EC2 instance with an IAM role specified that the failure
conditions are retried appropriately when
metadata_service_num_attempts is set.

cc @garnaat @toastdriven
