### PR TITLE
Use default availability zone when creating EBS volumes

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -1662,7 +1662,7 @@ class EC2Connection(AWSQueryConnection):
             params['AutoEnableIO.Value'] = new_value
         return self.get_status('ModifyVolumeAttribute', params, verb='POST')
 
-    def create_volume(self, size, zone, snapshot=None,
+    def create_volume(self, size, zone = None, snapshot=None,
                       volume_type=None, iops=None):
         """
         Create a new EBS Volume.
@@ -1671,7 +1671,8 @@ class EC2Connection(AWSQueryConnection):
         :param size: The size of the new volume, in GiB
 
         :type zone: string or :class:`boto.ec2.zone.Zone`
-        :param zone: The availability zone in which the Volume will be created.
+        :param zone: The availability zone in which the Volume will be created (optional).
+            If None, will be set to the default availability zone.
 
         :type snapshot: string or :class:`boto.ec2.snapshot.Snapshot`
         :param snapshot: The snapshot from which the new Volume will be
@@ -1685,9 +1686,10 @@ class EC2Connection(AWSQueryConnection):
         :param iops: The provisioned IOPs you want to associate with
             this volume. (optional)
         """
-        if isinstance(zone, Zone):
+        if zone and isinstance(zone, Zone):
             zone = zone.name
-        params = {'AvailabilityZone': zone}
+            params = {'AvailabilityZone': zone}
+        
         if size:
             params['Size'] = size
         if snapshot:


### PR DESCRIPTION
Presently, in the `EC2Connection.create_volume` method, `zone` is a required parameter despite the fact that the [CreateVolume](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-CreateVolume.html) describes it as being optional. Thus, with this patch, we only include it if it's not `None`.
