### PR TITLE
Added GetServiceStatus for Sellers API

### DIFF
--- a/boto/mws/connection.py
+++ b/boto/mws/connection.py
@@ -811,3 +811,9 @@ class MWSConnection(AWSQueryConnection):
            or ListMarketplaceParticipationsByNextToken.
         """
         return self.post_request(path, kw, response)
+        
+    @api_action('Sellers', 15, 60, 'GetServiceStatus')
+    def get_inbound_service_status(self, path, response, **kw):
+        """Returns the operational status of the Sellers API section.
+        """
+        return self.post_request(path, kw, response)


### PR DESCRIPTION
Was looking for the GetServiceStatus for the Sellers API but it looks like it wasn't in the code base. I've followed the structure of the other Service Status functions for the addition of the Sellers API function.
