### PR TITLE
Updated requests to something more modern.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 mock==1.0.1
 nose==1.2.1
-requests==0.13.1
+# If you upgrade to ``requests>=1.2.1``, please update
+# ``boto/cloudsearch/document.py``.
+requests>=1.1.0
 rsa==3.1.1
 tox==1.4
 Sphinx==1.1.3


### PR DESCRIPTION
As part of #1367, I've updated `requirements.txt` to use a much more recent version of `requests`. As a result of this, I had to update `boto/cloudsearch/document.py` to build back in the pooling & retries.

The tests that were failing for me post-upgrade pass once this patch is applied.
