### PR TITLE
added regions to elbadmin

### DIFF
--- a/bin/elbadmin
+++ b/bin/elbadmin
@@ -108,7 +108,12 @@ def get(elb, name):
         print
 
         # Make map of all instance Id's to Name tags
-        ec2 = boto.connect_ec2()
+        if not options.my_region:
+            ec2 = boto.connect_ec2()
+        else:
+            import boto.ec2
+            ec2 = boto.ec2.connect_to_region(options.my_region)
+
 
         instance_health = b.get_instance_health()
         instances = [state.instance_id for state in instance_health]


### PR DESCRIPTION
Added a --region flag to the elbadmin script so that you could have it connect to regions other than the default.

Old behavior:
elbadmin ls
elasticloadbalancing.us-east-1.amazonaws.com
## Name                 DNS Name

New behavior:
elbadmin -r us-west-2 ls
elasticloadbalancing.us-west-2.amazonaws.com
## Name                 DNS Name

blah-www-1        blah-www-1-123456789.us-west-2.elb.amazonaws.com
