### PR TITLE
Allow Route 53 to work with zones that have health checks.

### DIFF
--- a/boto/route53/connection.py
+++ b/boto/route53/connection.py
@@ -51,10 +51,10 @@ class Route53Connection(AWSAuthConnection):
     DefaultHost = 'route53.amazonaws.com'
     """The default Route53 API endpoint to connect to."""
 
-    Version = '2012-02-29'
+    Version = '2012-12-12'
     """Route53 API version."""
 
-    XMLNameSpace = 'https://route53.amazonaws.com/doc/2012-02-29/'
+    XMLNameSpace = 'https://route53.amazonaws.com/doc/2012-12-12/'
     """XML schema for this Route53 API version."""
 
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,


### PR DESCRIPTION
I have tested the following scenarios:
- Weighted record with health check.
- Latency based record with health check.
- Failover based record (primary and secondary) with associated health check.
- The alias versions of all the above.
- Setting the "Evaluate Target Health" option for alias records.
- Printing out records with all the aforementioned setups. So "route53 get" works and gives you information about health records.

Some notes:
- "Evaluate Target Health" defaults to "false".
- "Failover Record Type" has no default.

Remaining items to do:
- Update "zone.py".
- Write tests.
- Upgrade the route53 utility.
- Update Route 53 to allow it to work with health checks.

The code I'm using to test the new features looks like this:

``` python
import boto
from boto.route53.record import ResourceRecordSets

conn = boto.connect_route53()
changes = ResourceRecordSets(conn, "<example.com_zone_id>")
change = changes.add_change("CREATE", "test2.example.com", 'A',
    identifier = "alias-health", health_check_id = "<health_check_id>",
    failover_type = "SECONDARY", alias_evaluate_target_health = "true")
change.set_alias("<example.com_zone_id>", "test.example.com")
print changes.commit()
```

This would add an alias (test2.example.com) that checks the health of the target record and is itself a secondary record in a failover configuration. Printing the zone's records would, along with the usual information, give us:

```
ALIAS <example.com_zone_id> test.example.com. Check alias health: true (Failover id=alias-health, Failover Type=SECONDARY, Health Check id=<health_check_id>)
```
