### PR TITLE
Add cancel_update_stack method to CloudFormation

### DIFF
--- a/boto/cloudformation/connection.py
+++ b/boto/cloudformation/connection.py
@@ -281,6 +281,19 @@ class CloudFormationConnection(AWSQueryConnection):
             boto.log.error('%s' % body)
             raise self.ResponseError(response.status, response.reason, body)
 
+    def cancel_update_stack(self, stack_name_or_id):
+        params = {'ContentType': "JSON", 'StackName': stack_name_or_id}
+        # TODO: change this to get_status ?
+        response = self.make_request('CancelUpdateStack', params, '/', 'GET')
+        body = response.read()
+        if response.status == 200:
+            return json.loads(body)
+        else:
+            boto.log.error('%s %s' % (response.status, response.reason))
+            boto.log.error('%s' % body)
+            raise self.ResponseError(response.status, response.reason, body)
+
+
     def describe_stack_events(self, stack_name_or_id=None, next_token=None):
         params = {}
         if stack_name_or_id:

--- a/tests/unit/cloudformation/test_connection.py
+++ b/tests/unit/cloudformation/test_connection.py
@@ -193,6 +193,28 @@ class TestCloudFormationDeleteStack(CloudFormationConnectionBase):
         with self.assertRaises(self.service_connection.ResponseError):
             api_response = self.service_connection.delete_stack('stack_name')
 
+class TestCloudFormationCancelUpdateStack(CloudFormationConnectionBase):
+    def default_body(self):
+        return json.dumps(
+            {u'CancelUpdateStackResponse':
+                 {u'ResponseMetadata': {u'RequestId': u'1'}}})
+
+    def test_cancel_update_stack(self):
+        self.set_http_response(status_code=200)
+        api_response = self.service_connection.cancel_update_stack('stack_name')
+        self.assertEqual(api_response, json.loads(self.default_body()))
+        self.assert_request_parameters({
+            'Action': 'CancelUpdateStack',
+            'ContentType': 'JSON',
+            'StackName': 'stack_name',
+            'Version': '2010-05-15',
+        })
+
+    def test_cancel_update_fails(self):
+        self.set_http_response(status_code=400)
+        with self.assertRaises(self.service_connection.ResponseError):
+            api_response = self.service_connection.cancel_update_stack('stack_name')
+
 
 class TestCloudFormationDescribeStackResource(CloudFormationConnectionBase):
     def default_body(self):


### PR DESCRIPTION
Amazon has an action in the CloudFormation API called CancelUpdateStack
that rolls back a stack in the UPDATE_IN_PROGRESS state. This change
introduces a method to execute this action to the
cloudformation.connection.CloudFormationConnection class, based off of
the delete_stack method.
