### PR TITLE
Fix DescribeVpnConnections call argument

### DIFF
--- a/boto/vpc/__init__.py
+++ b/boto/vpc/__init__.py
@@ -813,7 +813,7 @@ class VPCConnection(EC2Connection):
         params = {}
         if vpn_connection_ids:
             self.build_list_params(params, vpn_connection_ids,
-                                   'Vpn_ConnectionId')
+                                   'VpnConnectionId')
         if filters:
             self.build_filter_params(params, dict(filters))
         return self.get_list('DescribeVpnConnections', params,


### PR DESCRIPTION
The DescribeVpnConnections accepts VpnConnectionId argument without underscore
