### PR TITLE
Fix variable overwrite in build_put_params

### DIFF
--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -185,8 +185,8 @@ class CloudWatchConnection(AWSQueryConnection):
             else:
                 raise Exception('Must specify a value or statistics to put.')
 
-            for key, value in metric_data.iteritems():
-                params['MetricData.member.%d.%s' % (index + 1, key)] = value
+            for key, val in metric_data.iteritems():
+                params['MetricData.member.%d.%s' % (index + 1, key)] = val
 
     def get_metric_statistics(self, period, start_time, end_time, metric_name,
                               namespace, statistics, dimensions=None,


### PR DESCRIPTION
Before this patch, the for loop at the bottom of `build_put_params`
would overwrite the passed in value variable, resulting in spurious
log messages:

```
'You supplied a value and statistics for a metric. Posting
 statistics and not value.'
```

I've changed the variable name from value to val to prevent the
overwrite and stop the spurious log messages.
