### PR TITLE
Fixed a bug where URIs were properly canonicalized in Sig V4 signatures.

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -32,13 +32,14 @@ import boto.auth_handler
 import boto.exception
 import boto.plugin
 import boto.utils
-import hmac
-import sys
-import urllib
-import time
-import datetime
 import copy
+import datetime
 from email.utils import formatdate
+import hmac
+import os
+import sys
+import time
+import urllib
 
 from boto.auth_handler import AuthHandler
 from boto.exception import BotoClientError
@@ -375,7 +376,11 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         return ';'.join(l)
 
     def canonical_uri(self, http_request):
-        return http_request.auth_path
+        # Normalize the path.
+        normalized = os.path.normpath(http_request.auth_path)
+        # Then urlencode whatever's left.
+        encoded = urllib.quote(normalized)
+        return encoded
 
     def payload(self, http_request):
         body = http_request.body

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -62,6 +62,17 @@ class TestSigV4Handler(unittest.TestCase):
         query_string = auth.canonical_query_string(request)
         self.assertEqual(query_string, 'Foo.1=aaa&Foo.10=zzz')
 
+    def test_canonical_uri(self):
+        auth = HmacAuthV4Handler('glacier.us-east-1.amazonaws.com',
+                                 Mock(), self.provider)
+        request = HTTPRequest(
+            'GET', 'https', 'glacier.us-east-1.amazonaws.com', 443,
+            'x/./././x .html', None, {},
+            {'x-amz-glacier-version': '2012-06-01'}, '')
+        canonical_uri = auth.canonical_uri(request)
+        # This should be both normalized & urlencoded.
+        self.assertEqual(canonical_uri, 'x/x%20.html')
+
     def test_region_and_service_can_be_overriden(self):
         auth = HmacAuthV4Handler('queue.amazonaws.com',
                                  Mock(), self.provider)


### PR DESCRIPTION
Per http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html, item 2, paths are supposed to be normalized & URL encoded, which they were not being before. `boto` doesn't currently use this much of anywhere, but this should make the implementation a little more correct.

All unit tests pass & the integration tests for glacier/cloudformation/sqs pass.
