### PR TITLE
fix element name typo in xml parsing for InstanceStatusSet

### DIFF
--- a/boto/ec2/instancestatus.py
+++ b/boto/ec2/instancestatus.py
@@ -201,7 +201,7 @@ class InstanceStatusSet(list):
             return None
 
     def endElement(self, name, value, connection):
-        if name == 'NextToken':
+        if name == 'nextToken':
             self.next_token = value
         setattr(self, name, value)
 


### PR DESCRIPTION
The correct XML element name is 'nextToken', not 'NextToken'. (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeInstanceStatus.html)
