### PR TITLE
Fixing cloudformation time stamps when API returns milliseconds

### DIFF
--- a/boto/cloudformation/stack.py
+++ b/boto/cloudformation/stack.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import re
 
 from boto.resultset import ResultSet
 
@@ -41,7 +42,11 @@ class Stack(object):
 
     def endElement(self, name, value, connection):
         if name == 'CreationTime':
-            self.creation_time = datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
+            p = re.compile('\d{4,4}-\d{2,2}-\d{2,2}T\d{2,2}:\d{2,2}:\d{2,2}\.\d{1,6}Z')
+            if p.match(value):
+                self.creation_time = datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%fZ')
+            else:
+                self.creation_time = datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
         elif name == "Description":
             self.description = value
         elif name == "DisableRollback":
@@ -351,7 +356,11 @@ class StackEvent(object):
         elif name == "StackName":
             self.stack_name = value
         elif name == "Timestamp":
-            self.timestamp = datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
+            p = re.compile('\d{4,4}-\d{2,2}-\d{2,2}T\d{2,2}:\d{2,2}:\d{2,2}\.\d{1,6}Z')
+            if p.match(value):
+                self.timestamp = datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%fZ')
+            else:
+                self.timestamp = datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
         else:
             setattr(self, name, value)
 


### PR DESCRIPTION
Found that boto was causing exceptions today when creating stacks in the ap-southeast-2 region. Tracked it down to the time stamp being returned by the cloudformation API containing milliseconds, for example '2013-05-15T06:59:38.245Z'. I tried creating stacks in us-west-1 and us-west-2 but didn't see this behaviour. I have opened a case with amazon to help understand why this would be.

In the mean time, this patch handles the two time stamp formats correctly.
