### PR TITLE
Make s3 key buffer size configurable.

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -82,7 +82,7 @@ class Key(object):
       </RestoreRequest>"""
 
 
-    BufferSize = 8192
+    BufferSize = boto.config.getint('Boto', 'key_buffer_size', 8192)
 
     # The object metadata fields a user can set, other than custom metadata
     # fields (i.e., those beginning with a provider-specific prefix like


### PR DESCRIPTION
Being able to configure the buffer size helps to experiment with increasing throughput.
