### PR TITLE
Fix a bug always connecting to the default end point in dynamodb2

### DIFF
--- a/boto/dynamodb2/layer1.py
+++ b/boto/dynamodb2/layer1.py
@@ -63,8 +63,10 @@ class DynamoDBConnection(AWSQueryConnection):
         if not region:
             region_name = boto.config.get('DynamoDB', 'region',
                                           self.DefaultRegionName)
-            region = RegionInfo(self, region_name,
-                                self.DefaultRegionEndpoint)
+            for reg in boto.dynamodb2.regions():
+                if reg.name == region_name:
+                    region = reg
+                    break
         kwargs['host'] = region.endpoint
         AWSQueryConnection.__init__(self, **kwargs)
         self.region = region


### PR DESCRIPTION
Fix a bug always connecting to the default end point in dynamodb2's DynamoDBConnection.
