### PR TITLE
Solving bugs on empty results and between comparisions

### DIFF
--- a/boto/dynamodb2/results.py
+++ b/boto/dynamodb2/results.py
@@ -58,7 +58,10 @@ class ResultSet(object):
 
             self.fetch_more()
 
-        return self._results[self._offset]
+        if self._offset < len(self._results):
+            return self._results[self._offset]
+        else:
+            raise StopIteration()
 
     def to_call(self, the_callable, *args, **kwargs):
         """

--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -611,12 +611,7 @@ class Table(object):
                 'AttributeValueList': [],
                 'ComparisonOperator': op,
             }
-
-            # Fix up the value for encoding, because it was built to only work
-            # with ``set``s.
-            if isinstance(value, (list, tuple)):
-                value = set(value)
-
+ 
             # Special-case the ``NULL/NOT_NULL`` case.
             if field_bits[-1] == 'null':
                 del lookup['AttributeValueList']
@@ -625,7 +620,20 @@ class Table(object):
                     lookup['ComparisonOperator'] = 'NOT_NULL'
                 else:
                     lookup['ComparisonOperator'] = 'NULL'
+            # Special-case the ``BETWEEN`` case.
+            elif field_bits[-1] == 'between':
+                if len(value) == 2 and isinstance(value, (list, tuple)):
+                    lookup['AttributeValueList'].append(
+                        self._dynamizer.encode(value[0])
+                    )
+                    lookup['AttributeValueList'].append(
+                        self._dynamizer.encode(value[1])
+                    )
             else:
+                # Fix up the value for encoding, because it was built to only work
+                # with ``set``s.
+                if isinstance(value, (list, tuple)):
+                    value = set(value)
                 lookup['AttributeValueList'].append(
                     self._dynamizer.encode(value)
                 )


### PR DESCRIPTION
When it returns empty result the result _results_left is true by
default and it tries to get data that doesn't exist.
When a between condition is added on the query the parameters needs to
be two separated string values ( not a SS field )
