### PR TITLE
Modifiy EbsOptimized param type in LauchConfig.

### DIFF
--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -238,9 +238,9 @@ class AutoScaleConnection(AWSQueryConnection):
         if launch_config.instance_profile_name is not None:
             params['IamInstanceProfile'] = launch_config.instance_profile_name
         if launch_config.ebs_optimized:
-            params['EbsOptimized'] = True
+            params['EbsOptimized'] = 'true'
         else:
-            params['EbsOptimized'] = False
+            params['EbsOptimized'] = 'false'
         return self.get_object('CreateLaunchConfiguration', params,
                                Request, verb='POST')
 


### PR DESCRIPTION
Since a couple of days ago, API expects a xsd1.1 boolean type for paramenter
EbsOptimized when LaunchConfiguration is created. This commit change old
True and False native python types for new lowercase string ones.

Currently boto fails with error:

 File "/home/ajdiaz/env/boto/lib/python2.7/site-packages/boto/connection.py", line 1069, in get_object
    raise self.ResponseError(response.status, response.reason, body)
BotoServerError: BotoServerError: 400 Bad Request
<ErrorResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
  <Error>
    <Type>Sender</Type>
    <Code>MalformedInput</Code>
    <Message>boolean must follow xsd1.1 definition</Message>
  </Error>
  <RequestId>436a281a-c3ba-11e2-9cf1-e5c6f739aba9</RequestId>
</ErrorResponse>
