### PR TITLE
CloudFront invalidations do not work for paths with query strings due to...

### DIFF
--- a/boto/cloudfront/invalidation.py
+++ b/boto/cloudfront/invalidation.py
@@ -20,7 +20,8 @@
 # IN THE SOFTWARE.
 
 import uuid
-import urllib
+
+from xml.sax import saxutils
 
 from boto.resultset import ResultSet
 
@@ -71,7 +72,7 @@ class InvalidationBatch(object):
         """Escape a path, make sure it begins with a slash and contains no invalid characters"""
         if not p[0] == "/":
             p = "/%s" % p
-        return urllib.quote(p)
+        return saxutils.escape(p)
 
     def to_xml(self):
         """Get this batch as XML"""


### PR DESCRIPTION
... incorrect escaping. Proposed fix.

Hi!

CloudFront invalidations are broken for paths that include query string parameters. We should not be url escaping but rather XML escaping:

Instead of this:

```
/page.html%3Fsection%3Done%26subSubsection%3Dtwo
```

we should send:

```
/page.html?section=one&amp;subSubsection=two
```

Could not figure out how to write any unit test for this, nor can I find any unit tests for CloudFront.

Happy to disccus this change.
/JT
