### PR TITLE
Fixed a bug where a ``date`` couldn't be set as metadata on a S3 key.

### DIFF
--- a/boto/utils.py
+++ b/boto/utils.py
@@ -172,7 +172,7 @@ def merge_meta(headers, metadata, provider=None):
     for k in metadata.keys():
         if k.lower() in ['cache-control', 'content-md5', 'content-type',
                          'content-encoding', 'content-disposition',
-                         'date', 'expires']:
+                         'expires']:
             final_headers[k] = metadata[k]
         else:
             final_headers[metadata_prefix + k] = metadata[k]

--- a/tests/integration/s3/test_key.py
+++ b/tests/integration/s3/test_key.py
@@ -32,7 +32,7 @@ from boto.s3.key import Key
 from boto.exception import S3ResponseError
 
 
-class S3KeyTest (unittest.TestCase):
+class S3KeyTest(unittest.TestCase):
     s3 = True
 
     def setUp(self):
@@ -373,3 +373,13 @@ class S3KeyTest (unittest.TestCase):
         with self.assertRaises(key.provider.storage_response_error):
             # Must start with a / or http
             key.set_redirect('')
+
+    def test_setting_date(self):
+        key = self.bucket.new_key('test_date')
+        # This should actually set x-amz-meta-date & not fail miserably.
+        key.set_metadata('date', '20130524T155935Z')
+        key.set_contents_from_string('Some text here.')
+
+        check = self.bucket.get_key('test_date')
+        self.assertEqual(check.get_metadata('date'), u'20130524T155935Z')
+        self.assertTrue('x-amz-meta-date' in check._get_remote_metadata())


### PR DESCRIPTION
Fixes #888.
