### PR TITLE
Update connection.py: get_path when suppress_consec_slashes is False

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -598,7 +598,7 @@ class AWSAuthConnection(object):
         # https://groups.google.com/forum/#!topic/boto-dev/-ft0XPUy0y8
         # You can override that behavior with the suppress_consec_slashes param.
         if not self.suppress_consec_slashes:
-            return self.path + re.sub('^/*', "", path)
+            return self.path + re.sub('^(/*)/', "\\1", path)
         pos = path.find('?')
         if pos >= 0:
             params = path[pos:]


### PR DESCRIPTION
Should fix boto/boto#1387

When suppressing consec slashes is set to False, slashes at the beginning of the key are suppressed too aggressively.  It shouldn't turn all slashes at the beginning to empty. It should decrease the number of prefix slashes by 1.

This likely depends on self.path being ending in a "/".  I don't have a test case yet.
