### PR TITLE
Fix AttributeErrors thrown when LoadBalancerZones is used by adding endE...

### DIFF
--- a/boto/ec2/elb/loadbalancer.py
+++ b/boto/ec2/elb/loadbalancer.py
@@ -42,6 +42,8 @@ class LoadBalancerZones(object):
         if name == 'AvailabilityZones':
             return self.zones
 
+    def endElement(self, name, value, connection):
+        pass
 
 class LoadBalancer(object):
     """


### PR DESCRIPTION
LoadBalancerZones right now isn't actually a valid xml.sax Handler.  We just need to add an endElement stub so that the sax parser has something to call while parsing the object, otherwise it throws the below AttributeError:

"""
  File "/usr/lib/pymodules/python2.7/boto/ec2/elb/loadbalancer.py", line 173, in disable_zones
    new_zones = self.connection.disable_availability_zones(self.name, zones)
  File "/usr/lib/pymodules/python2.7/boto/ec2/elb/**init**.py", line 322, in disable_availability_zones
    params, LoadBalancerZones)
  File "/usr/lib/pymodules/python2.7/boto/connection.py", line 1114, in get_object
    xml.sax.parseString(body, h)
  File "/usr/lib/python2.7/xml/sax/**init**.py", line 49, in parseString
    parser.parse(inpsrc)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 107, in parse
    xmlreader.IncrementalParser.parse(self, source)
  File "/usr/lib/python2.7/xml/sax/xmlreader.py", line 123, in parse
    self.feed(buffer)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 207, in feed
    self._parser.Parse(data, isFinal)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 304, in end_element
    self._cont_handler.endElement(name)
  File "/usr/lib/pymodules/python2.7/boto/handler.py", line 39, in endElement
    self.nodes[-1][1].endElement(name, self.current_text, self.connection)
AttributeError: 'LoadBalancerZones' object has no attribute 'endElement'
"""

Maybe all these classes should inherit from a base class which has a stub for startElement and endElement to make sure there is a safe fallback for the future?
