### PR TITLE
RangeKey was missing from the import there was two hashkeys in Table.create

### DIFF
--- a/docs/source/migrations/dynamodb_v1_to_v2.rst
+++ b/docs/source/migrations/dynamodb_v1_to_v2.rst
@@ -35,11 +35,12 @@ DynamoDB v1::
 DynamoDB v2::
 
     >>> from boto.dynamodb2.fields import HashKey
+    >>> from boto.dynamodb2.fields import RangeKey
     >>> from boto.dynamodb2.table import Table
 
     >>> table = Table.create('messages', schema=[
     ...     HashKey('forum_name'),
-    ...     HashKey('subject'),
+    ...     RangeKey('subject'),
     ... ], throughput={
     ...     'read': 10,
     ...     'write': 10,


### PR DESCRIPTION
Just a problem in the migration guide, 
Missing import and using two hashkeys instead of a hashkey and a rangekey
