### PR TITLE
Fix for metadata usage

### DIFF
--- a/boto/core/credentials.py
+++ b/boto/core/credentials.py
@@ -66,8 +66,11 @@ def _search_md(url='http://169.254.169.254/latest/meta-data/iam/'):
 def search_metadata(**kwargs):
     credentials = None
     metadata = _search_md()
-    # Assuming there's only one role on the instance profile.
-    if metadata:
+    # Assuming there's only one role on the instance profile and checking
+    # if there is an 'iam' key in the dict (handle error cases like:
+    #
+    # {'info': {'Message': 'Instance Profile with Id ... cannot be found' ...}}
+    if metadata and metadata.get('iam'):
         metadata = metadata['iam']['security-credentials'].values()[0]
         credentials = Credentials(metadata['AccessKeyId'],
                                   metadata['SecretAccessKey'],


### PR DESCRIPTION
Fixes this error:

``` python
Traceback (most recent call last):
  File "test.py", line 2, in <module>
    print get_credentials()
  File "/tmp/src/boto/boto/core/credentials.py", line 152, in get_credentials
    secret_key_name='secret_key')
  File "/tmp/src/boto/boto/core/credentials.py", line 72, in search_metadata
    metadata = metadata['iam']['security-credentials'].values()[0]
KeyError: 'iam'
```

Which is produced when the metadata holds:

``` text
{'info': {'Message': 'Instance Profile with Id AIP...NJO cannot be found.  Please see documentation at http://docs.amazonwebservices.com/IAM/latest/UserGuide/RolesTroubleshooting.html.', 'Code': 'InstanceProfileNotFound', 'LastUpdated': '2013-06-03T17:09:24Z'}}

```
