### PR TITLE
Preserve trailing / when canonicalizing URI path for signature V4

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -388,6 +388,8 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         normalized = posixpath.normpath(http_request.auth_path)
         # Then urlencode whatever's left.
         encoded = urllib.quote(normalized)
+        if http_request.auth_path.endswith('/'):
+          encoded = encoded + '/'
         return encoded
 
     def payload(self, http_request):


### PR DESCRIPTION
The recently added URI path canonicalization for signature V4 incorrectly removes a trailing / from the end of the path. This pull request checks if the path originally ended with a / and if so adds it back to the canonicalized path.

It is not possible to work around this issue by leaving the / out of the URL used for a request as the HTTP client adds a trailing / to the configured path.

This issue impacts use of boto with Eucalyptus which currently uses paths for services such as "/services/Euare/" for the IAM service.
