### PR TITLE
Add new CloudSearch regions. Closes #1465.

### DIFF
--- a/boto/cloudsearch/__init__.py
+++ b/boto/cloudsearch/__init__.py
@@ -38,6 +38,16 @@ def regions():
             RegionInfo(name='eu-west-1',
                        endpoint='cloudsearch.eu-west-1.amazonaws.com',
                        connection_cls=boto.cloudsearch.layer1.Layer1),
+            RegionInfo(name='us-west-1',
+                       endpoint='cloudsearch.us-west-1.amazonaws.com',
+                       connection_cls=boto.cloudsearch.layer1.Layer1),
+            RegionInfo(name='us-west-2',
+                       endpoint='cloudsearch.us-west-2.amazonaws.com',
+                       connection_cls=boto.cloudsearch.layer1.Layer1),
+            RegionInfo(name='ap-southeast-1',
+                       endpoint='cloudsearch.ap-southeast-1.amazonaws.com',
+                       connection_cls=boto.cloudsearch.layer1.Layer1),
+
             ]
 
 


### PR DESCRIPTION
Adds all currently supported zones according to:

http://docs.aws.amazon.com/general/latest/gr/rande.html#cloudsearch_region

Tested each.
