### PR TITLE
Fix CloudFront docs to match current reality.

### DIFF
--- a/docs/source/cloudfront_tut.rst
+++ b/docs/source/cloudfront_tut.rst
@@ -31,7 +31,8 @@ Working with CloudFront Distributions
 -------------------------------------
 Create a new :class:`boto.cloudfront.distribution.Distribution`::
 
-    >>> distro = c.create_distribution(origin='mybucket.s3.amazonaws.com', enabled=False, comment='My new Distribution')
+    >>> origin = boto.cloudfront.origin.S3Origin('mybucket.s3.amazonaws.com')
+    >>> distro = c.create_distribution(origin=origin, enabled=False, comment='My new Distribution')
     >>> d.domain_name
     u'd2oxf3980lnb8l.cloudfront.net'
     >>> d.id


### PR DESCRIPTION
CloudFront's create_distribution requires origin object. To match
the spirit of the docs, update docs to reflect creating the S3Origin
object first. Failure to do this results in to_xml() being called on your str, which breaks (exception thrown).

This might be worse than just assuming (and documenting) that passing a
string into origin for create_distribution implies
S3Origin(dns_name='thestr'). Design decision left for later.
