### PR TITLE
Fix annoying typo in basic DynamoDB example

### DIFF
--- a/docs/source/dynamodb2_tut.rst
+++ b/docs/source/dynamodb2_tut.rst
@@ -76,7 +76,7 @@ A full example::
     >>> from boto.dynamodb2.fields import HashKey, RangeKey, KeysOnlyIndex
     >>> from boto.dynamodb2.layer1 import DynamoDBConnection
     >>> from boto.dynamodb2.table import Table
-    >>> from boto.dynamodb2.types import Number
+    >>> from boto.dynamodb2.types import NUMBER
 
     >>> users = Table.create('users', schema=[
     ...     HashKey('account_type', data_type=NUMBER),


### PR DESCRIPTION
This actually makes the example copy&paste 'able

Thanks a lot!
