### PR TITLE
Fixed typo error

### DIFF
--- a/boto/ec2/instance.py
+++ b/boto/ec2/instance.py
@@ -386,8 +386,7 @@ class Instance(TaggedEC2Object):
             else:
                 self.persistent = False
         elif name == 'groupName':
-            if self._in_monitoring_element:
-                self.group_name = value
+            self.group_name = value
         elif name == 'clientToken':
             self.client_token = value
         elif name == "eventsSet":


### PR DESCRIPTION
Parameter 'groupName' doesn't live inside 'monitoring' section of XML response.

Also I'm not sure that this a valid parameter inside an 'instancesSet' tag.
I've looked documentation for EC2 API version 2010-08-31 and cannot find this parameter as a direct child of instancesSet/item element.

Furthermore, in current version of EC2 API there are a lot of 'groupName' tags and it's is possible that this parameter takes an ambiguous value.
