### PR TITLE
bugfix: removed unsupported params in ec2 image_modify_attibute product_...

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -412,6 +412,8 @@ class EC2Connection(AWSQueryConnection):
         if groups:
             self.build_list_params(params, groups, 'UserGroup')
         if product_codes:
+            params.pop('Attribute')
+            params.pop('OperationType')
             self.build_list_params(params, product_codes, 'ProductCode')
         return self.get_status('ModifyImageAttribute', params, verb='POST')
 


### PR DESCRIPTION
...codes

rational:

```
- Attribute and OperationType are not supported when assigning a
  product_code. If included, the request will return an error.

- The correct fix would be to not define them in the first place with
  default values, but would break backwards compatibility, so just
  removing them from params is the lesser evil.
```
