### PR TITLE
add MFA as option to sts.assume_role()

### DIFF
--- a/boto/sts/connection.py
+++ b/boto/sts/connection.py
@@ -229,7 +229,7 @@ class STSConnection(AWSQueryConnection):
                                 FederationToken, verb='POST')
 
     def assume_role(self, role_arn, role_session_name, policy=None,
-                    duration_seconds=None, external_id=None):
+                    duration_seconds=None, external_id=None, security_token=None):
         """
         Returns a set of temporary security credentials (consisting of
         an access key ID, a secret access key, and a security token)
@@ -330,6 +330,8 @@ class STSConnection(AWSQueryConnection):
             params['DurationSeconds'] = duration_seconds
         if external_id is not None:
             params['ExternalId'] = external_id
+        if security_token is not None:
+            params['SecurityToken'] = security_token
         return self.get_object('AssumeRole', params, AssumedRole, verb='POST')
 
     def assume_role_with_web_identity(self, role_arn, role_session_name,


### PR DESCRIPTION
IAM role policies may require that the user authentication using MFA, but sts.assume_role does not allow passing in the session_token from sts.get_session_token

For example, an IAM role policy that requires "Condition": { "Null": { "aws:MultiFactorAuthAge": "False" }  }

SecurityToken is an allowed common parameter from: http://docs.aws.amazon.com/STS/latest/APIReference/CommonParameters.html

Patch adds security_token to sts.assume_role in similar style to connect_ec2()

ex:

  # connect to STS as user, use MFA to get session token
  sts = boto_connect_sts()
  tok = sts.get_session_token(mfa_serial_number = 'arn:aws:iam::123456789:mfa/wrathofchris', mfa_token='123456')

  # use session token to re-connect to STS for role assumption
  rolests = boto_connect_sts(tok.access_key, tok.secret_key)
  roletok = rolests.assume_role('arn:aws:iam::123456789:role/myrole', 'wrathofchris', security_token=tok.session_token)
