### PR TITLE
Prep work for making get_all_instances actually return all instances

### DIFF
--- a/bin/elbadmin
+++ b/bin/elbadmin
@@ -114,9 +114,8 @@ def get(elb, name):
         instances = [state.instance_id for state in instance_health]
 
         names = {}
-        for r in ec2.get_all_instances(instances):
-            for i in r.instances:
-                names[i.id] = i.tags.get('Name', '')
+        for i in ec2.get_only_instances(instances):
+            names[i.id] = i.tags.get('Name', '')
 
         name_column_width = max([4] + [len(v) for k,v in names.iteritems()]) + 2
 

--- a/bin/instance_events
+++ b/bin/instance_events
@@ -51,7 +51,7 @@ def list(region, headers, order, completed):
 
     ec2 = boto.connect_ec2(region=region)
 
-    reservations = ec2.get_all_instances()
+    reservations = ec2.get_all_reservations()
 
     instanceinfo = {}
     events = {}

--- a/bin/list_instances
+++ b/bin/list_instances
@@ -76,7 +76,7 @@ def main():
         print format_string % headers
         print "-" * len(format_string % headers)
 
-    for r in ec2.get_all_instances(filters=filters):
+    for r in ec2.get_all_reservations(filters=filters):
         groups = [g.name for g in r.groups]
         for i in r.instances:
             i.groups = ','.join(groups)

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -436,7 +436,64 @@ class EC2Connection(AWSQueryConnection):
 
     def get_all_instances(self, instance_ids=None, filters=None):
         """
+        Retrieve all the instance reservations associated with your account.
+
+        .. note::
+        This method's current behavior is deprecated in favor of
+        :meth:`get_all_reservations`.  A future major release will change
+        :meth:`get_all_instances` to return a list of
+        :class:`boto.ec2.instance.Instance` objects as its name suggests.
+        To obtain that behavior today, use :meth:`get_only_instances`.
+
+        :type instance_ids: list
+        :param instance_ids: A list of strings of instance IDs
+
+        :type filters: dict
+        :param filters: Optional filters that can be used to limit the
+            results returned.  Filters are provided in the form of a
+            dictionary consisting of filter names as the key and
+            filter values as the value.  The set of allowable filter
+            names/values is dependent on the request being performed.
+            Check the EC2 API guide for details.
+
+        :rtype: list
+        :return: A list of  :class:`boto.ec2.instance.Reservation`
+
+        """
+        warnings.warn(('The current get_all_instances implementation will be '
+                       'replaced with get_all_reservations.'),
+                      PendingDeprecationWarning)
+        return self.get_all_reservations(instance_ids=instance_ids,
+                                         filters=filters)
+
+    def get_only_instances(self, instance_ids=None, filters=None):
+        # A future release should rename this method to get_all_instances
+        # and make get_only_instances an alias for that.
+        """
         Retrieve all the instances associated with your account.
+
+        :type instance_ids: list
+        :param instance_ids: A list of strings of instance IDs
+
+        :type filters: dict
+        :param filters: Optional filters that can be used to limit the
+            results returned.  Filters are provided in the form of a
+            dictionary consisting of filter names as the key and
+            filter values as the value.  The set of allowable filter
+            names/values is dependent on the request being performed.
+            Check the EC2 API guide for details.
+
+        :rtype: list
+        :return: A list of  :class:`boto.ec2.instance.Instance`
+        """
+        reservations = self.get_all_reservations(instance_ids=instance_ids,
+                                                 filters=filters)
+        return [instance for reservation in reservations
+                for instance in reservation.instances]
+
+    def get_all_reservations(self, instance_ids=None, filters=None):
+        """
+        Retrieve all the instance reservations associated with your account.
 
         :type instance_ids: list
         :param instance_ids: A list of strings of instance IDs

--- a/boto/ec2/instance.py
+++ b/boto/ec2/instance.py
@@ -418,7 +418,7 @@ class Instance(TaggedEC2Object):
                          raise a ValueError exception if no data is
                          returned from EC2.
         """
-        rs = self.connection.get_all_instances([self.id])
+        rs = self.connection.get_all_reservations([self.id])
         if len(rs) > 0:
             r = rs[0]
             for i in r.instances:

--- a/boto/ec2/securitygroup.py
+++ b/boto/ec2/securitygroup.py
@@ -271,7 +271,7 @@ class SecurityGroup(TaggedEC2Object):
         # It would be more efficient to do this with filters now
         # but not all services that implement EC2 API support filters.
         instances = []
-        rs = self.connection.get_all_instances()
+        rs = self.connection.get_all_reservations()
         for reservation in rs:
             uses_group = [g.name for g in reservation.groups if g.name == self.name]
             if uses_group:

--- a/boto/manage/server.py
+++ b/boto/manage/server.py
@@ -353,7 +353,7 @@ class Server(Model):
         for region in regions:
             ec2 = region.connect()
             try:
-                rs = ec2.get_all_instances([instance_id])
+                rs = ec2.get_all_reservations([instance_id])
             except:
                 rs = []
             if len(rs) == 1:
@@ -377,7 +377,7 @@ class Server(Model):
         regions = boto.ec2.regions()
         for region in regions:
             ec2 = region.connect()
-            rs = ec2.get_all_instances()
+            rs = ec2.get_all_reservations()
             for reservation in rs:
                 for instance in reservation.instances:
                     try:
@@ -413,7 +413,7 @@ class Server(Model):
                         self.ec2 = region.connect()
                         if self.instance_id and not self._instance:
                             try:
-                                rs = self.ec2.get_all_instances([self.instance_id])
+                                rs = self.ec2.get_all_reservations([self.instance_id])
                                 if len(rs) >= 1:
                                     for instance in rs[0].instances:
                                         if instance.id == self.instance_id:

--- a/boto/mashups/server.py
+++ b/boto/mashups/server.py
@@ -114,7 +114,7 @@ class Server(Model):
         if not self._instance:
             if self.instance_id:
                 try:
-                    rs = self.ec2.get_all_instances([self.instance_id])
+                    rs = self.ec2.get_all_reservations([self.instance_id])
                 except:
                     return None
                 if len(rs) > 0:

--- a/boto/pyami/installers/ubuntu/ebs.py
+++ b/boto/pyami/installers/ubuntu/ebs.py
@@ -122,7 +122,7 @@ class EBSInstaller(Installer):
         while volume.update() != 'available':
             boto.log.info('Volume %s not yet available. Current status = %s.' % (volume.id, volume.status))
             time.sleep(5)
-        instance = ec2.get_all_instances([self.instance_id])[0].instances[0]
+        instance = ec2.get_only_instances([self.instance_id])[0]
         attempt_attach = True
         while attempt_attach:
             try:

--- a/docs/source/autoscale_tut.rst
+++ b/docs/source/autoscale_tut.rst
@@ -201,8 +201,7 @@ To retrieve the instances in your autoscale group:
 >>> ec2 = boto.ec2.connect_to_region('us-west-2)
 >>> conn.get_all_groups(names=['my_group'])[0]
 >>> instance_ids = [i.instance_id for i in group.instances]
->>> reservations = ec2.get_all_instances(instance_ids)
->>> instances = [i for r in reservations for i in r.instances]
+>>> instances = ec2.get_only_instances(instance_ids)
 
 To delete your autoscale group, we first need to shutdown all the
 instances:

--- a/docs/source/ec2_tut.rst
+++ b/docs/source/ec2_tut.rst
@@ -88,7 +88,7 @@ Checking What Instances Are Running
 -----------------------------------
 You can also get information on your currently running instances::
 
-    >>> reservations = conn.get_all_instances()
+    >>> reservations = conn.get_all_reservations()
     >>> reservations
     [Reservation:r-00000000]
 

--- a/tests/integration/ec2/test_cert_verification.py
+++ b/tests/integration/ec2/test_cert_verification.py
@@ -37,4 +37,4 @@ class CertVerificationTest(unittest.TestCase):
     def test_certs(self):
         for region in boto.ec2.regions():
             c = region.connect()
-            c.get_all_instances()
+            c.get_all_reservations()

--- a/tests/integration/ec2/vpc/test_connection.py
+++ b/tests/integration/ec2/vpc/test_connection.py
@@ -69,7 +69,7 @@ class TestVPCConnection(unittest.TestCase):
         time.sleep(10)
         instance = reservation.instances[0]
         self.addCleanup(self.terminate_instance, instance)
-        retrieved = self.api.get_all_instances(instance_ids=[instance.id])
+        retrieved = self.api.get_all_reservations(instance_ids=[instance.id])
         self.assertEqual(len(retrieved), 1)
         retrieved_instances = retrieved[0].instances
         self.assertEqual(len(retrieved_instances), 1)

--- a/tests/unit/ec2/test_instance.py
+++ b/tests/unit/ec2/test_instance.py
@@ -216,7 +216,7 @@ class TestDescribeInstances(AWSMockServiceTestCase):
     def test_multiple_private_ip_addresses(self):
         self.set_http_response(status_code=200)
 
-        api_response = self.service_connection.get_all_instances()
+        api_response = self.service_connection.get_all_reservations()
         self.assertEqual(len(api_response), 1)
 
         instances = api_response[0].instances


### PR DESCRIPTION
`get_all_instances` doesn't actually get all instances, but rather gets all _reservations_, which themselves contain instances.  This commit starts the process of making `get_all_instances` actually return a list of instances by doing a few things:
1. Rename the current `get_all_instances` to `get_all_reservations`.
2. Make `get_all_instances` a stub that warns and then calls `get_all_reservations`.
3. Add a new `get_only_instances` method that will eventually become the new behavior of `get_all_instances`.

People can then transition to `get_all_reservations` and `get_only_instances` as appropriate until `get_all_instances` finally switches over in a future release.
