### PR TITLE
Set secure connection to elb api as default, as for any other connection

### DIFF
--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -87,7 +87,7 @@ class ELBConnection(AWSQueryConnection):
                                             'elasticloadbalancing.us-east-1.amazonaws.com')
 
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
-                 is_secure=False, port=None, proxy=None, proxy_port=None,
+                 is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
                  security_token=None, validate_certs=True):


### PR DESCRIPTION
Any connection to aws' services are done using HTTPS by default. elb should be no exception.
