### PR TITLE
SQS messages support for Python 'in' keyword

### DIFF
--- a/boto/sqs/message.py
+++ b/boto/sqs/message.py
@@ -199,6 +199,9 @@ class MHMessage(Message):
             s = s + '%s: %s\n' % (item[0], item[1])
         return s
 
+    def __contains__(self, key):
+        return key in self._body
+
     def __getitem__(self, key):
         if key in self._body:
             return self._body[key]


### PR DESCRIPTION
Noticed that SQS messages are not supporting the 'in' keyword due to lacking a **contains** method and the fall-back method of integer iteration of **getitem** is nonsensical for this data type.  I don't believe an **iter** method is needed, so leaving that out.
