### PR TITLE
Update url explaining base64 SQS messages.

### DIFF
--- a/boto/sqs/message.py
+++ b/boto/sqs/message.py
@@ -144,7 +144,7 @@ class Message(RawMessage):
     encodes/decodes the message body using Base64 encoding to avoid any
     illegal characters in the message body.  See:
 
-    http://developer.amazonwebservices.com/connect/thread.jspa?messageID=49680%EC%88%90
+    https://forums.aws.amazon.com/thread.jspa?threadID=13067
 
     for details on why this is a good idea.  The encode/decode is meant to
     be transparent to the end-user.


### PR DESCRIPTION
The url for the details on why base64 encoding of SQS messages no longer takes you to a thread. The forum site seems to have changed.

I replace it with what seems to be the same thread on the current AWS site.
