### PR TITLE
Allow arbitrary regions in connect_to_region

### DIFF
--- a/boto/ec2/__init__.py
+++ b/boto/ec2/__init__.py
@@ -72,6 +72,10 @@ def connect_to_region(region_name, **kw_params):
     :return: A connection to the given region, or None if an invalid region
              name is given
     """
+    
+    if kw_params['region'] and region_name == kw_params['region'].name:
+        return EC2Connection(**kw_params)
+    
     for region in regions(**kw_params):
         if region.name == region_name:
             return region.connect(**kw_params)


### PR DESCRIPTION
I was using boto to test Openstacks's AWS compatibility and I couldn't use the connect_to_region function because it only allows you to connect to hard coded AWS regions.

This change will use the region from kw_params, if it is present.
