### PR TITLE
fix parameter passing in Cloudsearch Layer2 -> Layer1 -> AWSAuthConnection

### DIFF
--- a/boto/cloudsearch/layer1.py
+++ b/boto/cloudsearch/layer1.py
@@ -51,14 +51,22 @@ class Layer1(AWSQueryConnection):
             region = RegionInfo(self, self.DefaultRegionName,
                                 self.DefaultRegionEndpoint)
         self.region = region
-        AWSQueryConnection.__init__(self, aws_access_key_id,
-                                    aws_secret_access_key,
-                                    is_secure, port, proxy, proxy_port,
-                                    proxy_user, proxy_pass,
-                                    self.region.endpoint, debug,
-                                    https_connection_factory, path,
-                                    security_token,
-                                    validate_certs=validate_certs)
+        AWSQueryConnection.__init__(
+            self,
+            host=self.region.endpoint,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            is_secure=is_secure,
+            port=port,
+            proxy=proxy,
+            proxy_port=proxy_port,
+            proxy_user=proxy_user,
+            proxy_pass=proxy_pass,
+            debug=debug,
+            https_connection_factory=https_connection_factory,
+            path=path,
+            security_token=security_token,
+            validate_certs=validate_certs)
 
     def _required_auth_capability(self):
         return ['sign-v2']

--- a/boto/cloudsearch/layer2.py
+++ b/boto/cloudsearch/layer2.py
@@ -32,10 +32,18 @@ class Layer2(object):
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  host=None, debug=0, session_token=None, region=None,
                  validate_certs=True):
-        self.layer1 = Layer1(aws_access_key_id, aws_secret_access_key,
-                             is_secure, port, proxy, proxy_port,
-                             host, debug, session_token, region,
-                             validate_certs=validate_certs)
+        self.layer1 = Layer1(
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            is_secure=is_secure,
+            port=port,
+            proxy=proxy,
+            proxy_port=proxy_port,
+            host=host,
+            debug=debug,
+            security_token=session_token,
+            region=region,
+            validate_certs=validate_certs)
 
     def list_domains(self, domain_names=None):
         """


### PR DESCRIPTION
This fix issue #1629
The parameters passing from Layer 2 to Layer 1 constructor are misaligned; host is before port in Layer 1 but not in Layer 2. In fact, let's avoid accidental positional problem all together by fully qualifying the parameter names. 

Things to verify: 
- is Layer 2's session_token supposed to be Layer 1's security_token?
- Is AWSAuthConnection's host supposed to be Layer 1's region.endpoint? 
