### PR TITLE
Copy deviceIndex into the device_index property

### DIFF
--- a/boto/ec2/networkinterface.py
+++ b/boto/ec2/networkinterface.py
@@ -59,6 +59,8 @@ class Attachment(object):
             self.id = value
         elif name == 'instanceId':
             self.instance_id = value
+        elif name == 'deviceIndex':
+            self.device_index = value
         elif name == 'instanceOwnerId':
             self.instance_owner_id = value
         elif name == 'status':


### PR DESCRIPTION
Prior to this patch the device_index of an attachment was always shown
as zero.

Addresses issue #1631
