### PR TITLE
[EC2] Allow arbitrary regions in connect_to_region

### DIFF
--- a/boto/ec2/__init__.py
+++ b/boto/ec2/__init__.py
@@ -72,13 +72,14 @@ def connect_to_region(region_name, **kw_params):
     :return: A connection to the given region, or None if an invalid region
              name is given
     """
-
-    if kw_params['region'] and region_name == kw_params['region'].name:
+    if 'region' in kw_params and isinstance(kw_params['region'], RegionInfo)\
+       and region_name == kw_params['region'].name:
         return EC2Connection(**kw_params)
 
     for region in regions(**kw_params):
         if region.name == region_name:
             return region.connect(**kw_params)
+
     return None
 
 


### PR DESCRIPTION
This request merges #1616 from @cjellick as well as the following:
1. Remove trailing whitespace / PEP8
2. Check whether `region` exists in kw_params before trying to use it, and make sure it's an instance of `RegionInfo`
3. Add tests for `boto.ec2.connect_to_region(...)` behavior given various options

The new tests borrow a little bit of functionality from `AWSMockServiceTestCase`, but probably not enough to warrant refactoring that code to make it work for these cases.
