### PR TITLE
DynamoDbConnection expects RegionInfo not string

### DIFF
--- a/docs/source/dynamodb2_tut.rst
+++ b/docs/source/dynamodb2_tut.rst
@@ -75,6 +75,7 @@ A full example::
 
     >>> from boto.dynamodb2.fields import HashKey, RangeKey, KeysOnlyIndex, AllIndex
     >>> from boto.dynamodb2.layer1 import DynamoDBConnection
+    >>> from boto.dynamodb2.layer1 import RegionInfo
     >>> from boto.dynamodb2.table import Table
     >>> from boto.dynamodb2.types import NUMBER
 
@@ -93,7 +94,7 @@ A full example::
     ... connection=DynamoDBConnection(
     ...     aws_access_key_id='key',
     ...     aws_secret_access_key='key',
-    ...     region='us-west-2'
+    ...     region=RegionInfo(name='us-west-2')
     ... ))
 
 


### PR DESCRIPTION
I guess there has been a change in the way DynamoDBConnetion works.
