### PR TITLE
more fault tolerant and works with fakes3

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -493,7 +493,10 @@ class Key(object):
         elif name == 'LastModified':
             self.last_modified = value
         elif name == 'Size':
-            self.size = int(value)
+            try:
+                self.size = int(value)
+            except:
+                self.size = 0
         elif name == 'StorageClass':
             self.storage_class = value
         elif name == 'Owner':
@@ -907,7 +910,9 @@ class Key(object):
         if 200 <= response.status <= 299:
             self.etag = response.getheader('etag')
 
-            if self.etag != '"%s"' % self.md5:
+            if self.etag != '"%s"' % self.md5 and \
+                str(self.etag).strip('"') != str(self.md5).strip('"'):
+
                 raise provider.storage_data_error(
                     'ETag from S3 did not match computed MD5')
 


### PR DESCRIPTION
while getting duplicity to work with fakes3 (https://github.com/jubos/fake-s3) I found there is a small discrepancy in response values. This patch makes sure boto doesn't fail silently on a bad typecast (None to Int). Also a secondary check on the ETags values is needed (for fakes3) to satisfy a mismatch.
