### PR TITLE
Cloudformation Bugfix: s/LastUpdatedTimestamp/LastUpdatedTime

### DIFF
--- a/boto/cloudformation/stack.py
+++ b/boto/cloudformation/stack.py
@@ -295,7 +295,7 @@ class StackResource(object):
 class StackResourceSummary(object):
     def __init__(self, connection=None):
         self.connection = connection
-        self.last_updated_timestamp = None
+        self.last_updated_time = None
         self.logical_resource_id = None
         self.physical_resource_id = None
         self.resource_status = None
@@ -306,14 +306,14 @@ class StackResourceSummary(object):
         return None
 
     def endElement(self, name, value, connection):
-        if name == "LastUpdatedTimestamp":
+        if name == "LastUpdatedTime":
             try:
-                self.last_updated_timestamp = datetime.strptime(
+                self.last_updated_time = datetime.strptime(
                     value,
                     '%Y-%m-%dT%H:%M:%SZ'
                 )
             except ValueError:
-                self.last_updated_timestamp = datetime.strptime(
+                self.last_updated_time = datetime.strptime(
                     value,
                     '%Y-%m-%dT%H:%M:%S.%fZ'
                 )

--- a/tests/unit/cloudformation/test_connection.py
+++ b/tests/unit/cloudformation/test_connection.py
@@ -462,14 +462,14 @@ class TestCloudFormationListStackResources(CloudFormationConnectionBase):
                   <member>
                     <ResourceStatus>CREATE_COMPLETE</ResourceStatus>
                     <LogicalResourceId>SampleDB</LogicalResourceId>
-                    <LastUpdatedTimestamp>2011-06-21T20:25:57Z</LastUpdatedTimestamp>
+                    <LastUpdatedTime>2011-06-21T20:25:57Z</LastUpdatedTime>
                     <PhysicalResourceId>My-db-ycx</PhysicalResourceId>
                     <ResourceType>AWS::RDS::DBInstance</ResourceType>
                   </member>
                   <member>
                     <ResourceStatus>CREATE_COMPLETE</ResourceStatus>
                     <LogicalResourceId>CPUAlarmHigh</LogicalResourceId>
-                    <LastUpdatedTimestamp>2011-06-21T20:29:23Z</LastUpdatedTimestamp>
+                    <LastUpdatedTime>2011-06-21T20:29:23Z</LastUpdatedTime>
                     <PhysicalResourceId>MyStack-CPUH-PF</PhysicalResourceId>
                     <ResourceType>AWS::CloudWatch::Alarm</ResourceType>
                   </member>
@@ -486,7 +486,7 @@ class TestCloudFormationListStackResources(CloudFormationConnectionBase):
         resources = self.service_connection.list_stack_resources('MyStack',
                                                               next_token='next_token')
         self.assertEqual(len(resources), 2)
-        self.assertEqual(resources[0].last_updated_timestamp,
+        self.assertEqual(resources[0].last_updated_time,
                          datetime(2011, 6, 21, 20, 25, 57))
         self.assertEqual(resources[0].logical_resource_id, 'SampleDB')
         self.assertEqual(resources[0].physical_resource_id, 'My-db-ycx')
@@ -494,7 +494,7 @@ class TestCloudFormationListStackResources(CloudFormationConnectionBase):
         self.assertEqual(resources[0].resource_status_reason, None)
         self.assertEqual(resources[0].resource_type, 'AWS::RDS::DBInstance')
 
-        self.assertEqual(resources[1].last_updated_timestamp,
+        self.assertEqual(resources[1].last_updated_time,
                          datetime(2011, 6, 21, 20, 29, 23))
         self.assertEqual(resources[1].logical_resource_id, 'CPUAlarmHigh')
         self.assertEqual(resources[1].physical_resource_id, 'MyStack-CPUH-PF')

--- a/tests/unit/cloudformation/test_stack.py
+++ b/tests/unit/cloudformation/test_stack.py
@@ -116,14 +116,14 @@ LIST_STACK_RESOURCES_XML = r"""
       <member>
         <ResourceStatus>CREATE_COMPLETE</ResourceStatus>
         <LogicalResourceId>DBSecurityGroup</LogicalResourceId>
-        <LastUpdatedTimestamp>2011-06-21T20:15:58Z</LastUpdatedTimestamp>
+        <LastUpdatedTime>2011-06-21T20:15:58Z</LastUpdatedTime>
         <PhysicalResourceId>gmarcteststack-dbsecuritygroup-1s5m0ez5lkk6w</PhysicalResourceId>
         <ResourceType>AWS::RDS::DBSecurityGroup</ResourceType>
       </member>
       <member>
         <ResourceStatus>CREATE_COMPLETE</ResourceStatus>
         <LogicalResourceId>SampleDB</LogicalResourceId>
-        <LastUpdatedTimestamp>2011-06-21T20:25:57.875643Z</LastUpdatedTimestamp>
+        <LastUpdatedTime>2011-06-21T20:25:57.875643Z</LastUpdatedTime>
         <PhysicalResourceId>MyStack-sampledb-ycwhk1v830lx</PhysicalResourceId>
         <ResourceType>AWS::RDS::DBInstance</ResourceType>
       </member>
@@ -207,12 +207,12 @@ class TestStackParse(unittest.TestCase):
         ])
         h = boto.handler.XmlHandler(rs, None)
         xml.sax.parseString(LIST_STACK_RESOURCES_XML, h)
-        timestamp_1 = rs[0].last_updated_timestamp
+        timestamp_1 = rs[0].last_updated_time
         self.assertEqual(
             timestamp_1,
             datetime.datetime(2011, 6, 21, 20, 15, 58)
         )
-        timestamp_2 = rs[1].last_updated_timestamp
+        timestamp_2 = rs[1].last_updated_time
         self.assertEqual(
             timestamp_2,
             datetime.datetime(2011, 6, 21, 20, 25, 57, 875643)


### PR DESCRIPTION
The cloudformation api is returning xml that does not have
LastUpdatedTimestamp elements, but rather LastUpdatedTime elements. Here
is an example:

This commit fixes this and adjusts a couple of tests accordingly.
