### PR TITLE
Fix serialization of SNS attributes parameter of type map

### DIFF
--- a/boto/sns/connection.py
+++ b/boto/sns/connection.py
@@ -91,7 +91,8 @@ class SNSConnection(AWSQueryConnection):
       :param dictionary: dict - value of the serialized parameter
       :param name: name of the serialized parameter
       """
-      for kv, index in zip(dictionary.items(), range(1, len(dictionary.items())+1)):
+      items = sorted(dictionary.items(), key=lambda x:x[0])
+      for kv, index in zip(items, range(1, len(items)+1)):
         key, value = kv
         prefix = '%s.entry.%s' % (name, index)
         params['%s.key' % prefix] = key

--- a/tests/unit/sns/test_connection.py
+++ b/tests/unit/sns/test_connection.py
@@ -127,6 +127,72 @@ class TestSNSConnection(AWSMockServiceTestCase):
             'Message': 'message',
         }, ignore_params_values=['Version', 'ContentType'])
 
+    def test_create_platform_application(self):
+        self.set_http_response(status_code=200)
+
+        self.service_connection.create_platform_application(name='MyApp',
+                                                            platform='APNS',
+                                                            attributes={'PlatformPrincipal': 'a ssl certificate',
+                                                                        'PlatformCredential': 'a private key'})
+        self.assert_request_parameters({
+            'Action': 'CreatePlatformApplication',
+            'Name': 'MyApp',
+            'Platform': 'APNS',
+            'Attributes.entry.1.key': 'PlatformCredential',
+            'Attributes.entry.1.value': 'a private key',
+            'Attributes.entry.2.key': 'PlatformPrincipal',
+            'Attributes.entry.2.value': 'a ssl certificate',
+        }, ignore_params_values=['Version', 'ContentType'])
+
+    def test_set_platform_application_attributes(self):
+        self.set_http_response(status_code=200)
+
+        self.service_connection.set_platform_application_attributes(
+            platform_application_arn='arn:myapp',
+            attributes={'PlatformPrincipal': 'a ssl certificate',
+                        'PlatformCredential': 'a private key'})
+        self.assert_request_parameters({
+            'Action': 'SetPlatformApplicationAttributes',
+            'PlatformApplicationArn': 'arn:myapp',
+            'Attributes.entry.1.key': 'PlatformCredential',
+            'Attributes.entry.1.value': 'a private key',
+            'Attributes.entry.2.key': 'PlatformPrincipal',
+            'Attributes.entry.2.value': 'a ssl certificate',
+        }, ignore_params_values=['Version', 'ContentType'])
+
+    def test_create_platform_endpoint(self):
+        self.set_http_response(status_code=200)
+
+        self.service_connection.create_platform_endpoint(
+            platform_application_arn='arn:myapp',
+            token='abcde12345',
+            custom_user_data='john',
+            attributes={'Enabled': False})
+        self.assert_request_parameters({
+            'Action': 'CreatePlatformEndpoint',
+            'PlatformApplicationArn': 'arn:myapp',
+            'Token': 'abcde12345',
+            'CustomUserData': 'john',
+            'Attributes.entry.1.key': 'Enabled',
+            'Attributes.entry.1.value': False,
+        }, ignore_params_values=['Version', 'ContentType'])
+
+    def test_set_endpoint_attributes(self):
+        self.set_http_response(status_code=200)
+
+        self.service_connection.set_endpoint_attributes(
+            endpoint_arn='arn:myendpoint',
+            attributes={'CustomUserData': 'john',
+                        'Enabled': False})
+        self.assert_request_parameters({
+            'Action': 'SetEndpointAttributes',
+            'EndpointArn': 'arn:myendpoint',
+            'Attributes.entry.1.key': 'CustomUserData',
+            'Attributes.entry.1.value': 'john',
+            'Attributes.entry.2.key': 'Enabled',
+            'Attributes.entry.2.value': False,
+        }, ignore_params_values=['Version', 'ContentType'])
+
     def test_message_is_required(self):
         self.set_http_response(status_code=200)
 


### PR DESCRIPTION
Current boto (2.10) fails when making sns request with 'attributes' parameter which are of type map (e.g. create_platform_application(name='App', platform='APNS', attributes={'PlatformPrincipal': 'a ssl cert', 'PlatformCredential': 'a private key'}). 

It looks like the map (python dictionary) is literally serialized as json dict which AWS doesn't like, i.e. resulting in 400 Bad Request, e.g.
ERROR:boto:{"Error":{"Code":"MalformedInput","Message":"End of list found where not expected","Type":"Sender"},"RequestId":"2011cb93-23f4-5c62-8158-81002d27407a"}.

Looking at http://docs.aws.amazon.com/sns/latest/APIReference/API_CreatePlatformApplication.html suggested that a map/dictionary is expected to be serialized as name.entry.1.key, name.entry.1.value, name.entry.2.key, name.entry.2.value, ... 

This PR implements that serialization.
