### PR TITLE
[S3] Modify s3put to not require ListBucket access + docs

### DIFF
--- a/bin/s3put
+++ b/bin/s3put
@@ -37,7 +37,9 @@ try:
     multipart_capable = True
     usage_flag_multipart_capable = """ [--multipart]"""
     usage_string_multipart_capable = """
-        multipart - Upload files as multiple parts. This needs filechunkio."""
+        multipart - Upload files as multiple parts. This needs filechunkio.
+                    Requires ListBucket, ListMultipartUploadParts,
+                    ListBucketMultipartUploads and PutObject permissions."""
 except ImportError as err:
     multipart_capable = False
     usage_flag_multipart_capable = ""
@@ -313,7 +315,7 @@ def main():
         c = boto.connect_s3(aws_access_key_id=aws_access_key_id,
                         aws_secret_access_key=aws_secret_access_key)
     c.debug = debug
-    b = c.get_bucket(bucket_name)
+    b = c.get_bucket(bucket_name, validate=False)
     existing_keys_to_check_against = []
     files_to_check_for_upload = []
 


### PR DESCRIPTION
This should help to fix #1642 by doing the following:
- Do not require `ListBucket` permissions to do simple uploads
- Document extra permissions required for multi-part uploads

I also spent some time looking into what exactly is required for multi-part uploads, but getting down to the minimal set of permissions would require significant code changes to not only `s3put` but also potentially portions of the boto s3 multi-part implementation itself.

@toastdriven, @jamesls, @garnaat please review!
