### PR TITLE
support other ELB policies

### DIFF
--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -536,6 +536,23 @@ class ELBConnection(AWSQueryConnection):
             params['CookieExpirationPeriod'] = cookie_expiration_period
         return self.get_status('CreateLBCookieStickinessPolicy', params)
 
+    def create_lb_policy(self, lb_name, policy_name, policy_type, policy_attributes):
+        """
+        Creates a new policy that contais the necessary attributes depending on
+        the policy type. Policies are settings that are saved for your load
+        balancer and that can be applied to the front-end listener, or
+        the back-end application server.
+        """
+        params = {'LoadBalancerName': lb_name,
+                  'PolicyName': policy_name,
+                  'PolicyTypeName': policy_type}
+        for index, (name, value) in enumerate(policy_attributes.iteritems(), 1):
+            params['PolicyAttributes.member.%d.AttributeName' % index] = name
+            params['PolicyAttributes.member.%d.AttributeValue' % index] = value
+        else:
+            params['PolicyAttributes'] = ''
+        return self.get_status('CreateLoadBalancerPolicy', params)
+
     def delete_lb_policy(self, lb_name, policy_name):
         """
         Deletes a policy from the LoadBalancer. The specified policy must not
@@ -555,6 +572,19 @@ class ELBConnection(AWSQueryConnection):
                   'LoadBalancerPort': lb_port}
         self.build_list_params(params, policies, 'PolicyNames.member.%d')
         return self.get_status('SetLoadBalancerPoliciesOfListener', params)
+
+    def set_lb_policies_of_backend_server(self, lb_name, instance_port, policies):
+        """
+        Replaces the current set of policies associated with a port on which
+        the back-end server is listening with a new set of policies.
+        """
+        params = {'LoadBalancerName': lb_name,
+                  'InstancePort': instance_port}
+        if policies:
+            self.build_list_params(params, policies, 'PolicyNames.member.%d')
+        else:
+            params['PolicyNames'] = ''
+        return self.get_status('SetLoadBalancerPoliciesForBackendServer', params)
 
     def apply_security_groups_to_lb(self, name, security_groups):
         """

--- a/boto/ec2/elb/policies.py
+++ b/boto/ec2/elb/policies.py
@@ -60,6 +60,20 @@ class LBCookieStickinessPolicy(object):
             self.policy_name = value
 
 
+class OtherPolicy(object):
+    def __init__(self, connection=None):
+        self.policy_name = None
+
+    def __repr__(self):
+        return 'OtherPolicy(%s)' % (self.policy_name)
+
+    def startElement(self, name, attrs, connection):
+        pass
+
+    def endElement(self, name, value, connection):
+        self.policy_name = value
+
+
 class Policies(object):
     """
     ELB Policies
@@ -68,11 +82,13 @@ class Policies(object):
         self.connection = connection
         self.app_cookie_stickiness_policies = None
         self.lb_cookie_stickiness_policies = None
+        self.other_policies = None
 
     def __repr__(self):
         app = 'AppCookieStickiness%s' % self.app_cookie_stickiness_policies
         lb = 'LBCookieStickiness%s' % self.lb_cookie_stickiness_policies
-        return 'Policies(%s,%s)' % (app, lb)
+        other = 'Other%s' % self.other_policies
+        return 'Policies(%s,%s,%s)' % (app, lb, other)
 
     def startElement(self, name, attrs, connection):
         if name == 'AppCookieStickinessPolicies':
@@ -82,6 +98,10 @@ class Policies(object):
         elif name == 'LBCookieStickinessPolicies':
             rs = ResultSet([('member', LBCookieStickinessPolicy)])
             self.lb_cookie_stickiness_policies = rs
+            return rs
+        elif name == 'OtherPolicies':
+            rs = ResultSet([('member', OtherPolicy)])
+            self.other_policies = rs
             return rs
 
     def endElement(self, name, value, connection):

--- a/docs/source/ref/elb.rst
+++ b/docs/source/ref/elb.rst
@@ -8,40 +8,54 @@ boto.ec2.elb
 ------------
 
 .. automodule:: boto.ec2.elb
-   :members:   
+   :members:
    :undoc-members:
 
 boto.ec2.elb.healthcheck
 ------------------------
 
 .. automodule:: boto.ec2.elb.healthcheck
-   :members:   
+   :members:
    :undoc-members:
 
 boto.ec2.elb.instancestate
 --------------------------
 
 .. automodule:: boto.ec2.elb.instancestate
-   :members:   
+   :members:
    :undoc-members:
 
 boto.ec2.elb.listelement
 ------------------------
 
 .. automodule:: boto.ec2.elb.listelement
-   :members:   
+   :members:
    :undoc-members:
 
 boto.ec2.elb.listener
 ---------------------
 
 .. automodule:: boto.ec2.elb.listener
-   :members:   
+   :members:
    :undoc-members:
 
 boto.ec2.elb.loadbalancer
 -------------------------
 
 .. automodule:: boto.ec2.elb.loadbalancer
-   :members:   
+   :members:
+   :undoc-members:
+
+boto.ec2.elb.policies
+-------------------------
+
+.. automodule:: boto.ec2.elb.policies
+   :members:
+   :undoc-members:
+
+boto.ec2.elb.securitygroup
+-------------------------
+
+.. automodule:: boto.ec2.elb.securitygroup
+   :members:
    :undoc-members:

--- a/tests/integration/ec2/elb/test_connection.py
+++ b/tests/integration/ec2/elb/test_connection.py
@@ -118,6 +118,28 @@ class ELBConnectionTest(unittest.TestCase):
         # Policy names should be checked here once they are supported
         # in the Listener object.
 
+    def test_create_load_balancer_backend_with_policies(self):
+        other_policy_name = 'enable-proxy-protocol'
+        backend_port = 8081
+        self.conn.create_lb_policy(self.name, other_policy_name,
+                                   'ProxyProtocolPolicyType', {'ProxyProtocol': True})
+        self.conn.set_lb_policies_of_backend_server(self.name, backend_port, [other_policy_name])
+
+        balancers = self.conn.get_all_load_balancers(load_balancer_names=[self.name])
+        self.assertEqual([lb.name for lb in balancers], [self.name])
+        self.assertEqual(len(balancers[0].policies.other_policies), 1)
+        self.assertEqual(balancers[0].policies.other_policies[0].policy_name, other_policy_name)
+        self.assertEqual(len(balancers[0].backends), 1)
+        self.assertEqual(balancers[0].backends[0].instance_port, backend_port)
+        self.assertEqual(balancers[0].backends[0].policies[0].policy_name, other_policy_name)
+
+        self.conn.set_lb_policies_of_backend_server(self.name, backend_port, [])
+
+        balancers = self.conn.get_all_load_balancers(load_balancer_names=[self.name])
+        self.assertEqual([lb.name for lb in balancers], [self.name])
+        self.assertEqual(len(balancers[0].policies.other_policies), 1)
+        self.assertEqual(len(balancers[0].backends), 0)
+
     def test_create_load_balancer_complex_listeners(self):
         complex_listeners = [
             (8080, 80, 'HTTP', 'HTTP'),

--- a/tests/unit/ec2/elb/test_loadbalancer.py
+++ b/tests/unit/ec2/elb/test_loadbalancer.py
@@ -29,5 +29,83 @@ class TestInstanceStatusResponseParsing(unittest.TestCase):
         self.assertEqual(disabled, ['sample-zone'])
 
 
+DESCRIBE_RESPONSE = r"""<?xml version="1.0" encoding="UTF-8"?>
+<DescribeLoadBalancersResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
+  <DescribeLoadBalancersResult>
+    <LoadBalancerDescriptions>
+      <member>
+        <SecurityGroups/>
+        <CreatedTime>2013-07-09T19:18:00.520Z</CreatedTime>
+        <LoadBalancerName>elb-boto-unit-test</LoadBalancerName>
+        <HealthCheck/>
+        <ListenerDescriptions>
+          <member>
+            <PolicyNames/>
+            <Listener/>
+          </member>
+        </ListenerDescriptions>
+        <Instances/>
+        <Policies>
+          <AppCookieStickinessPolicies/>
+          <OtherPolicies>
+            <member>AWSConsole-SSLNegotiationPolicy-my-test-loadbalancer</member>
+            <member>EnableProxyProtocol</member>
+          </OtherPolicies>
+          <LBCookieStickinessPolicies/>
+        </Policies>
+        <AvailabilityZones>
+          <member>us-east-1a</member>
+        </AvailabilityZones>
+        <CanonicalHostedZoneName>elb-boto-unit-test-408121642.us-east-1.elb.amazonaws.com</CanonicalHostedZoneName>
+        <CanonicalHostedZoneNameID>Z3DZXE0Q79N41H</CanonicalHostedZoneNameID>
+        <Scheme>internet-facing</Scheme>
+        <SourceSecurityGroup>
+          <OwnerAlias>amazon-elb</OwnerAlias>
+          <GroupName>amazon-elb-sg</GroupName>
+        </SourceSecurityGroup>
+        <DNSName>elb-boto-unit-test-408121642.us-east-1.elb.amazonaws.com</DNSName>
+        <BackendServerDescriptions>
+          <member>
+            <PolicyNames>
+              <member>EnableProxyProtocol</member>
+            </PolicyNames>
+            <InstancePort>80</InstancePort>
+          </member>
+        </BackendServerDescriptions>
+        <Subnets/>
+      </member>
+    </LoadBalancerDescriptions>
+  </DescribeLoadBalancersResult>
+  <ResponseMetadata>
+    <RequestId>5763d932-e8cc-11e2-a940-11136cceffb8</RequestId>
+  </ResponseMetadata>
+</DescribeLoadBalancersResponse>
+"""
+
+class TestDescribeLoadBalancers(unittest.TestCase):
+    def test_other_policy(self):
+        elb = ELBConnection(aws_access_key_id='aws_access_key_id',
+                            aws_secret_access_key='aws_secret_access_key')
+        mock_response = mock.Mock()
+        mock_response.read.return_value = DESCRIBE_RESPONSE
+        mock_response.status = 200
+        elb.make_request = mock.Mock(return_value=mock_response)
+        load_balancers = elb.get_all_load_balancers()
+        self.assertEqual(len(load_balancers), 1)
+
+        lb = load_balancers[0]
+        self.assertEqual(len(lb.policies.other_policies), 2)
+        self.assertEqual(lb.policies.other_policies[0].policy_name,
+                         'AWSConsole-SSLNegotiationPolicy-my-test-loadbalancer')
+        self.assertEqual(lb.policies.other_policies[1].policy_name,
+                         'EnableProxyProtocol')
+
+        self.assertEqual(len(lb.backends), 1)
+        self.assertEqual(len(lb.backends[0].policies), 1)
+        self.assertEqual(lb.backends[0].policies[0].policy_name,
+                         'EnableProxyProtocol')
+        self.assertEqual(lb.backends[0].instance_port, 80)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I needed to enable proxy protocol on my ELBs (http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-proxy-protocol.html) and added a couple of requests, namely CreateLoadBalancerPolicy and SetLoadBalancerPoliciesForBackendServer.
Any comments on this, should I add tests?
