### PR TITLE
Fixed #1687 - Headers involved with signing sent with S3 keys should be ...

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -522,7 +522,14 @@ class Key(object):
         return self.metadata.get(name)
 
     def set_metadata(self, name, value):
-        self.metadata[name] = value
+        # Ensure that metadata that is vital to signing is in the correct
+        # case. Applies to ``Content-Type`` & ``Content-MD5``.
+        if name.lower() == 'content-type':
+            self.metadata['Content-Type'] = value
+        elif name.lower() == 'content-md5':
+            self.metadata['Content-MD5'] = value
+        else:
+            self.metadata[name] = value
 
     def update_metadata(self, d):
         self.metadata.update(d)

--- a/tests/integration/s3/test_key.py
+++ b/tests/integration/s3/test_key.py
@@ -383,3 +383,14 @@ class S3KeyTest(unittest.TestCase):
         check = self.bucket.get_key('test_date')
         self.assertEqual(check.get_metadata('date'), u'20130524T155935Z')
         self.assertTrue('x-amz-meta-date' in check._get_remote_metadata())
+
+    def test_header_casing(self):
+        key = self.bucket.new_key('test_header_case')
+        # Using anything but CamelCase on ``Content-Type`` or ``Content-MD5``
+        # used to cause a signature error (when using ``s3`` for signing).
+        key.set_metadata('Content-type', 'application/json')
+        key.set_metadata('Content-md5', 'XmUKnus7svY1frWsVskxXg==')
+        key.set_contents_from_string('{"abc": 123}')
+
+        check = self.bucket.get_key('test_header_case')
+        self.assertEqual(check.content_type, 'application/json')


### PR DESCRIPTION
...case-insensitive for the user.

Review would be appreciated @danielgtaylor.
