### PR TITLE
Fix glacier layer2.list_vaults and related tests.

### DIFF
--- a/boto/glacier/layer2.py
+++ b/boto/glacier/layer2.py
@@ -89,5 +89,13 @@ class Layer2(object):
         :rtype: List of :class:`boto.glacier.vault.Vault`
         :return: A list of Vault objects.
         """
-        response_data = self.layer1.list_vaults()
-        return [Vault(self.layer1, rd) for rd in response_data['VaultList']]
+        vaults = []
+        marker = None
+        while True:
+            response_data = self.layer1.list_vaults(marker=marker, limit=1000)
+            vaults.extend([Vault(self.layer1, rd) for rd in response_data['VaultList']])
+            marker = response_data.get('Marker')
+            if not marker:
+                break
+
+        return vaults


### PR DESCRIPTION
Although Amazon claims "get vaults" operation returns 1000 items by default, I recently found it only returns 10 items now. I think it'd be great if layer2.list_vaults can deal with that by itself.

The patch also tries to fix the related tests.
