### PR TITLE
s3put: accept headers values containing "="

### DIFF
--- a/bin/s3put
+++ b/bin/s3put
@@ -290,7 +290,7 @@ def main():
         if o in ('-r', '--reduced'):
             reduced = True
         if o in ('--header'):
-            (k, v) = a.split("=")
+            (k, v) = a.split("=", 1)
             headers[k] = v
         if o in ('--host'):
             host = a


### PR DESCRIPTION
s3put tries to split headers on the "=" sign. Some headers include a "=" sign (e.g. max-age), and can't be used. 

This pull request splits on the first equal sign to support those.

Caveat: if a user uses the command correctly (`s3put ... --header "header1=value1 header2=value2" ...), they won't get an exception.
