### PR TITLE
Fixed the creation of EC2 VPC instances with public IPs.

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -66,7 +66,7 @@ from boto.exception import EC2ResponseError
 
 class EC2Connection(AWSQueryConnection):
 
-    APIVersion = boto.config.get('Boto', 'ec2_version', '2013-02-01')
+    APIVersion = boto.config.get('Boto', 'ec2_version', '2013-07-15')
     DefaultRegionName = boto.config.get('Boto', 'ec2_region_name', 'us-east-1')
     DefaultRegionEndpoint = boto.config.get('Boto', 'ec2_region_endpoint',
                                             'ec2.us-east-1.amazonaws.com')

--- a/boto/ec2/networkinterface.py
+++ b/boto/ec2/networkinterface.py
@@ -23,6 +23,7 @@
 """
 Represents an EC2 Elastic Network Interface
 """
+from boto.exception import BotoClientError
 from boto.ec2.ec2object import TaggedEC2Object
 from boto.resultset import ResultSet
 from boto.ec2.group import Group
@@ -196,13 +197,15 @@ class NetworkInterfaceCollection(list):
 
     def build_list_params(self, params, prefix=''):
         for i, spec in enumerate(self):
-            full_prefix = '%sNetworkInterface.%s.' % (prefix, i+1)
+            full_prefix = '%sNetworkInterface.%s.' % (prefix, i)
             if spec.network_interface_id is not None:
                 params[full_prefix + 'NetworkInterfaceId'] = \
                         str(spec.network_interface_id)
             if spec.device_index is not None:
                 params[full_prefix + 'DeviceIndex'] = \
                         str(spec.device_index)
+            else:
+                params[full_prefix + 'DeviceIndex'] = 0
             if spec.subnet_id is not None:
                 params[full_prefix + 'SubnetId'] = str(spec.subnet_id)
             if spec.description is not None:
@@ -218,20 +221,47 @@ class NetworkInterfaceCollection(list):
                         str(spec.private_ip_address)
             if spec.groups is not None:
                 for j, group_id in enumerate(spec.groups):
-                    query_param_key = '%sSecurityGroupId.%s' % (full_prefix, j+1)
+                    query_param_key = '%sSecurityGroupId.%s' % (full_prefix, j)
                     params[query_param_key] = str(group_id)
             if spec.private_ip_addresses is not None:
                 for k, ip_addr in enumerate(spec.private_ip_addresses):
                     query_param_key_prefix = (
-                        '%sPrivateIpAddresses.%s' % (full_prefix, k+1))
+                        '%sPrivateIpAddresses.%s' % (full_prefix, k))
                     params[query_param_key_prefix + '.PrivateIpAddress'] = \
                             str(ip_addr.private_ip_address)
                     if ip_addr.primary is not None:
                         params[query_param_key_prefix + '.Primary'] = \
                                 'true' if ip_addr.primary else 'false'
+
+            # Associating Public IPs have special logic around them:
+            #
+            # * Only assignable on an device_index of ``0``
+            # * Only on one interface
+            # * Only if there are no other interfaces being created
+            # * Only if it's a new interface (which we can't really guard
+            #   against)
+            #
+            # More details on http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-RunInstances.html
             if spec.associate_public_ip_address is not None:
-                params[full_prefix + 'AssociatePublicIpAddress'] = \
-                        'true' if spec.associate_public_ip_address else 'false'
+                if not params[full_prefix + 'DeviceIndex'] in (0, '0'):
+                    raise BotoClientError(
+                            "Only the interface with device index of 0 can " + \
+                            "be provided when using " + \
+                            "'associate_public_ip_address'."
+                        )
+
+                if len(self) > 1:
+                    raise BotoClientError(
+                        "Only one interface can be provided when using " + \
+                        "'associate_public_ip_address'."
+                    )
+
+                key = full_prefix + 'AssociatePublicIpAddress'
+
+                if spec.associate_public_ip_address:
+                    params[key] = 'true'
+                else:
+                    params[key] = 'false'
 
 
 class NetworkInterfaceSpecification(object):

--- a/tests/unit/ec2/test_networkinterface.py
+++ b/tests/unit/ec2/test_networkinterface.py
@@ -23,7 +23,7 @@
 
 from tests.unit import unittest
 
-
+from boto.exception import BotoClientError
 from boto.ec2.networkinterface import NetworkInterfaceCollection
 from boto.ec2.networkinterface import NetworkInterfaceSpecification
 from boto.ec2.networkinterface import PrivateIPAddress
@@ -42,7 +42,8 @@ class TestNetworkInterfaceCollection(unittest.TestCase):
             description='description1',
             private_ip_address='10.0.0.54', delete_on_termination=False,
             private_ip_addresses=[self.private_ip_address1,
-                                  self.private_ip_address2])
+                                  self.private_ip_address2]
+        )
 
         self.private_ip_address3 = PrivateIPAddress(
             private_ip_address='10.0.1.10', primary=False)
@@ -54,8 +55,18 @@ class TestNetworkInterfaceCollection(unittest.TestCase):
             groups=['group_id1', 'group_id2'],
             private_ip_address='10.0.1.54', delete_on_termination=False,
             private_ip_addresses=[self.private_ip_address3,
+                                  self.private_ip_address4]
+        )
+
+        self.network_interfaces_spec3 = NetworkInterfaceSpecification(
+            device_index=0, subnet_id='subnet_id2',
+            description='description2',
+            groups=['group_id1', 'group_id2'],
+            private_ip_address='10.0.1.54', delete_on_termination=False,
+            private_ip_addresses=[self.private_ip_address3,
                                   self.private_ip_address4],
-            associate_public_ip_address=True)
+            associate_public_ip_address=True
+        )
 
     def test_param_serialization(self):
         collection = NetworkInterfaceCollection(self.network_interfaces_spec1,
@@ -63,30 +74,29 @@ class TestNetworkInterfaceCollection(unittest.TestCase):
         params = {}
         collection.build_list_params(params)
         self.assertDictEqual(params, {
-            'NetworkInterface.1.DeviceIndex': '1',
+            'NetworkInterface.0.DeviceIndex': '1',
+            'NetworkInterface.0.DeleteOnTermination': 'false',
+            'NetworkInterface.0.Description': 'description1',
+            'NetworkInterface.0.PrivateIpAddress': '10.0.0.54',
+            'NetworkInterface.0.SubnetId': 'subnet_id',
+            'NetworkInterface.0.PrivateIpAddresses.0.Primary': 'false',
+            'NetworkInterface.0.PrivateIpAddresses.0.PrivateIpAddress':
+                '10.0.0.10',
+            'NetworkInterface.0.PrivateIpAddresses.1.Primary': 'false',
+            'NetworkInterface.0.PrivateIpAddresses.1.PrivateIpAddress':
+                '10.0.0.11',
+            'NetworkInterface.1.DeviceIndex': '2',
+            'NetworkInterface.1.Description': 'description2',
             'NetworkInterface.1.DeleteOnTermination': 'false',
-            'NetworkInterface.1.Description': 'description1',
-            'NetworkInterface.1.PrivateIpAddress': '10.0.0.54',
-            'NetworkInterface.1.SubnetId': 'subnet_id',
+            'NetworkInterface.1.PrivateIpAddress': '10.0.1.54',
+            'NetworkInterface.1.SubnetId': 'subnet_id2',
+            'NetworkInterface.1.SecurityGroupId.0': 'group_id1',
+            'NetworkInterface.1.SecurityGroupId.1': 'group_id2',
+            'NetworkInterface.1.PrivateIpAddresses.0.Primary': 'false',
+            'NetworkInterface.1.PrivateIpAddresses.0.PrivateIpAddress':
+                '10.0.1.10',
             'NetworkInterface.1.PrivateIpAddresses.1.Primary': 'false',
             'NetworkInterface.1.PrivateIpAddresses.1.PrivateIpAddress':
-                '10.0.0.10',
-            'NetworkInterface.1.PrivateIpAddresses.2.Primary': 'false',
-            'NetworkInterface.1.PrivateIpAddresses.2.PrivateIpAddress':
-                '10.0.0.11',
-            'NetworkInterface.2.DeviceIndex': '2',
-            'NetworkInterface.2.Description': 'description2',
-            'NetworkInterface.2.DeleteOnTermination': 'false',
-            'NetworkInterface.2.PrivateIpAddress': '10.0.1.54',
-            'NetworkInterface.2.SubnetId': 'subnet_id2',
-            'NetworkInterface.2.AssociatePublicIpAddress': 'true',
-            'NetworkInterface.2.SecurityGroupId.1': 'group_id1',
-            'NetworkInterface.2.SecurityGroupId.2': 'group_id2',
-            'NetworkInterface.2.PrivateIpAddresses.1.Primary': 'false',
-            'NetworkInterface.2.PrivateIpAddresses.1.PrivateIpAddress':
-                '10.0.1.10',
-            'NetworkInterface.2.PrivateIpAddresses.2.Primary': 'false',
-            'NetworkInterface.2.PrivateIpAddresses.2.PrivateIpAddress':
                 '10.0.1.11',
         })
 
@@ -99,42 +109,90 @@ class TestNetworkInterfaceCollection(unittest.TestCase):
         # we're just checking a few keys to make sure we get the proper
         # prefix.
         self.assertDictEqual(params, {
-            'LaunchSpecification.NetworkInterface.1.DeviceIndex': '1',
+            'LaunchSpecification.NetworkInterface.0.DeviceIndex': '1',
+            'LaunchSpecification.NetworkInterface.0.DeleteOnTermination':
+                'false',
+            'LaunchSpecification.NetworkInterface.0.Description':
+                'description1',
+            'LaunchSpecification.NetworkInterface.0.PrivateIpAddress':
+                '10.0.0.54',
+            'LaunchSpecification.NetworkInterface.0.SubnetId': 'subnet_id',
+            'LaunchSpecification.NetworkInterface.0.PrivateIpAddresses.0.Primary':
+                'false',
+            'LaunchSpecification.NetworkInterface.0.PrivateIpAddresses.0.PrivateIpAddress':
+                '10.0.0.10',
+            'LaunchSpecification.NetworkInterface.0.PrivateIpAddresses.1.Primary': 'false',
+            'LaunchSpecification.NetworkInterface.0.PrivateIpAddresses.1.PrivateIpAddress':
+                '10.0.0.11',
+            'LaunchSpecification.NetworkInterface.1.DeviceIndex': '2',
+            'LaunchSpecification.NetworkInterface.1.Description':
+                'description2',
             'LaunchSpecification.NetworkInterface.1.DeleteOnTermination':
                 'false',
-            'LaunchSpecification.NetworkInterface.1.Description':
-                'description1',
             'LaunchSpecification.NetworkInterface.1.PrivateIpAddress':
-                '10.0.0.54',
-            'LaunchSpecification.NetworkInterface.1.SubnetId': 'subnet_id',
+                '10.0.1.54',
+            'LaunchSpecification.NetworkInterface.1.SubnetId': 'subnet_id2',
+            'LaunchSpecification.NetworkInterface.1.SecurityGroupId.0':
+                'group_id1',
+            'LaunchSpecification.NetworkInterface.1.SecurityGroupId.1':
+                'group_id2',
+            'LaunchSpecification.NetworkInterface.1.PrivateIpAddresses.0.Primary':
+                'false',
+            'LaunchSpecification.NetworkInterface.1.PrivateIpAddresses.0.PrivateIpAddress':
+                '10.0.1.10',
             'LaunchSpecification.NetworkInterface.1.PrivateIpAddresses.1.Primary':
                 'false',
             'LaunchSpecification.NetworkInterface.1.PrivateIpAddresses.1.PrivateIpAddress':
-                '10.0.0.10',
-            'LaunchSpecification.NetworkInterface.1.PrivateIpAddresses.2.Primary': 'false',
-            'LaunchSpecification.NetworkInterface.1.PrivateIpAddresses.2.PrivateIpAddress':
-                '10.0.0.11',
-            'LaunchSpecification.NetworkInterface.2.DeviceIndex': '2',
-            'LaunchSpecification.NetworkInterface.2.Description':
-                'description2',
-            'LaunchSpecification.NetworkInterface.2.DeleteOnTermination':
-                'false',
-            'LaunchSpecification.NetworkInterface.2.PrivateIpAddress':
-                '10.0.1.54',
-            'LaunchSpecification.NetworkInterface.2.SubnetId': 'subnet_id2',
-            'LaunchSpecification.NetworkInterface.2.AssociatePublicIpAddress': 'true',
-            'LaunchSpecification.NetworkInterface.2.SecurityGroupId.1':
-                'group_id1',
-            'LaunchSpecification.NetworkInterface.2.SecurityGroupId.2':
-                'group_id2',
-            'LaunchSpecification.NetworkInterface.2.PrivateIpAddresses.1.Primary':
-                'false',
-            'LaunchSpecification.NetworkInterface.2.PrivateIpAddresses.1.PrivateIpAddress':
-                '10.0.1.10',
-            'LaunchSpecification.NetworkInterface.2.PrivateIpAddresses.2.Primary':
-                'false',
-            'LaunchSpecification.NetworkInterface.2.PrivateIpAddresses.2.PrivateIpAddress':
                 '10.0.1.11',
+        })
+
+    def test_cant_use_public_ip(self):
+        collection = NetworkInterfaceCollection(self.network_interfaces_spec3,
+                                                self.network_interfaces_spec1)
+        params = {}
+
+        # First, verify we can't incorrectly create multiple interfaces with
+        # on having a public IP.
+        with self.assertRaises(BotoClientError):
+            collection.build_list_params(params, prefix='LaunchSpecification.')
+
+        # Next, ensure it can't be on device index 1.
+        self.network_interfaces_spec3.device_index = 1
+        collection = NetworkInterfaceCollection(self.network_interfaces_spec3)
+        params = {}
+
+        with self.assertRaises(BotoClientError):
+            collection.build_list_params(params, prefix='LaunchSpecification.')
+
+    def test_public_ip(self):
+        # With public IP.
+        collection = NetworkInterfaceCollection(self.network_interfaces_spec3)
+        params = {}
+        collection.build_list_params(params, prefix='LaunchSpecification.')
+
+        self.assertDictEqual(params, {
+            'LaunchSpecification.NetworkInterface.0.AssociatePublicIpAddress':
+                'true',
+            'LaunchSpecification.NetworkInterface.0.DeviceIndex': '0',
+            'LaunchSpecification.NetworkInterface.0.DeleteOnTermination':
+                'false',
+            'LaunchSpecification.NetworkInterface.0.Description':
+                'description2',
+            'LaunchSpecification.NetworkInterface.0.PrivateIpAddress':
+                '10.0.1.54',
+            'LaunchSpecification.NetworkInterface.0.SubnetId': 'subnet_id2',
+            'LaunchSpecification.NetworkInterface.0.PrivateIpAddresses.0.Primary':
+                'false',
+            'LaunchSpecification.NetworkInterface.0.PrivateIpAddresses.0.PrivateIpAddress':
+                '10.0.1.10',
+            'LaunchSpecification.NetworkInterface.0.PrivateIpAddresses.1.Primary':
+                'false',
+            'LaunchSpecification.NetworkInterface.0.PrivateIpAddresses.1.PrivateIpAddress':
+                '10.0.1.11',
+            'LaunchSpecification.NetworkInterface.0.SecurityGroupId.0':
+                'group_id1',
+            'LaunchSpecification.NetworkInterface.0.SecurityGroupId.1':
+                'group_id2',
         })
 
 


### PR DESCRIPTION
Currently, though we added support for public IPs in VPC (SHA: be132d1da48fced8bc7cd774916c373ae1b9a962), I missed bumping the API version (so it's an unrecognized param :unamused:) & there's special logic around where a public IP can be applied that wasn't present in the JSON model.

Passing all tests. Review would be appreciated, especially on the change related to the numbering of the network interfaces. @jamesls @garnaat @danielgtaylor
