### PR TITLE
Removing duplicate boto.s3.prefix entry to prevent Sphinx build errors.

### DIFF
--- a/docs/source/ref/s3.rst
+++ b/docs/source/ref/s3.rst
@@ -88,13 +88,6 @@ boto.s3.lifecycle
    :members:
    :undoc-members:
 
-boto.s3.prefix
------------------
-
-.. automodule:: boto.s3.prefix
-   :members:
-   :undoc-members:
-
 boto.s3.tagging
 ---------------
 


### PR DESCRIPTION
This change removes a redundant `boto.s3.prefix` reference (note, the reference already exists on line 56), thus eliminating the following documentation build problem in Sphinx v0.6.4. 

```
$ make html
sphinx-build -b html -d build/doctrees   source build/html
Making output directory...
Running Sphinx v0.6.4
HEAD
Adding github link roles
loading pickled environment... not found
WARNING: intersphinx inventory 'http://docs.python.org/objects.inv' not readable due to <type 'exceptions.ValueError'>: unknown or unsupported inventory version
building [html]: targets for 96 source files that are out of date
updating environment: 96 added, 0 changed, 0 removed
reading sources... [ 51%] ref/s3                                                                                              
reST markup error:
/home/pingwin/src/boto/docs/source/ref/s3.rst:: (SEVERE/4) Duplicate ID: "module-boto.s3.prefix".
make: *** [html] Error 1
```
