### PR TITLE
Altered DDBv2's ``batch_write`` to work with ``UnprocessedItems``.

### DIFF
--- a/boto/dynamodb2/layer1.py
+++ b/boto/dynamodb2/layer1.py
@@ -1491,6 +1491,7 @@ class DynamoDBConnection(AWSQueryConnection):
 
     def _retry_handler(self, response, i, next_sleep):
         status = None
+        boto.log.debug("Saw HTTP status: %s" % response.status)
         if response.status == 400:
             response_body = response.read()
             boto.log.debug(response_body)


### PR DESCRIPTION
Per #1679 & #1566, DDBv2 currently just drops `UnprocessedItems` (search on page for http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html) on the floor. AFAIK, this only happens when the data is valid/retryable, but the throughput has been exceeded.

The solution is simply to enqueue them then process through once all the other records are done. Reviews would be appreciated @danielgtaylor @jamesls @garnaat.
