### PR TITLE
Adding epub output format, even though it requires a newer version of Sp...

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,7 @@ PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
-.PHONY: help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest
+.PHONY: help clean html dirhtml pickle json epub htmlhelp qthelp latex changes linkcheck doctest
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -20,6 +20,7 @@ help:
 	@echo "  dirhtml   to make HTML files named index.html in directories"
 	@echo "  pickle    to make pickle files"
 	@echo "  json      to make JSON files"
+	@echo "  epub      to make ePub files (sphinx >= v1.2b2)"
 	@echo "  htmlhelp  to make HTML files and a HTML help project"
 	@echo "  qthelp    to make HTML files and a qthelp project"
 	@echo "  latex     to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
@@ -50,6 +51,11 @@ json:
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
+epub:
+        $(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
+        @echo
+        @echo "Build finished. The e-Pub pages are in $(BUILDDIR)/epub."
+        
 htmlhelp:
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo


### PR DESCRIPTION
Fix for Issue #1758 

Main motivation is people might want to read the documentation for the definitive Amazon AWS interface library, being Boto, on an Amazon Kindle. ePub is easily converted to any other ebook format, such as .mobi for Kindle.
