### PR TITLE
Remove unused code that causes an exception in rare cases and add a unit...

### DIFF
--- a/boto/ec2/instance.py
+++ b/boto/ec2/instance.py
@@ -340,14 +340,6 @@ class Instance(TaggedEC2Object):
             self.ami_launch_index = value
         elif name == 'previousState':
             self.previous_state = value
-        elif name == 'name':
-            self.state = value
-        elif name == 'code':
-            try:
-                self.state_code = int(value)
-            except ValueError:
-                boto.log.warning('Error converting code (%s) to int' % value)
-                self.state_code = value
         elif name == 'instanceType':
             self.instance_type = value
         elif name == 'rootDeviceName':

--- a/tests/unit/ec2/test_connection.py
+++ b/tests/unit/ec2/test_connection.py
@@ -1192,5 +1192,32 @@ class TestRegisterImage(TestEC2ConnectionBase):
             'Version'
         ])
 
+
+class TestTerminateInstances(TestEC2ConnectionBase):
+    def default_body(self):
+        return """<?xml version="1.0" ?>
+            <TerminateInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-07-15/">
+                <requestId>req-59a9ad52-0434-470c-ad48-4f89ded3a03e</requestId>
+                <instancesSet>
+                    <item>
+                        <instanceId>i-000043a2</instanceId>
+                        <shutdownState>
+                            <code>16</code>
+                            <name>running</name>
+                        </shutdownState>
+                        <previousState>
+                            <code>16</code>
+                            <name>running</name>
+                        </previousState>
+                    </item>
+                </instancesSet>
+            </TerminateInstancesResponse>
+        """
+
+    def test_terminate_bad_response(self):
+        self.set_http_response(status_code=200)
+        self.ec2.terminate_instances('foo')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
... test for that case. Fixes #1748. It looks like the name and code are fetched at the start element method above, which catches `currentState`, `previousState`, and `instanceState`. In those cases this removed code was never called, but in a rare error case with an incorrect string passed for state it was triggered and that in turn triggered exceptions.
