### PR TITLE
Add missing ap-southeast-2 region to the S3WebsiteEndpointTranslate class

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -63,6 +63,7 @@ class S3WebsiteEndpointTranslate:
     trans_region['sa-east-1'] = 's3-website-sa-east-1'
     trans_region['ap-northeast-1'] = 's3-website-ap-northeast-1'
     trans_region['ap-southeast-1'] = 's3-website-ap-southeast-1'
+    trans_region['ap-southeast-2'] = 's3-website-ap-southeast-2'
 
     @classmethod
     def translate_region(self, reg):


### PR DESCRIPTION
When creating a bucket in the `ap-southeast-2` region, the `get_website_endpoint()` returns incorrect information. It's because that region is missing from the `S3WebsiteEndpointTranslate` class.

An example:

```
$ python2
Python 2.7.5 (default, Aug 24 2013, 12:06:38) 
[GCC 4.7.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import boto
>>> s3 = boto.connect_s3()
>>> b = s3.create_bucket('testauf1aip', location='ap-southeast-2')
>>> b.configure_website(suffix='index.html')
True
>>> b.get_website_endpoint()
'testauf1aip.s3-website-us-east-1.amazonaws.com'
```

The problem above is that the endpoints points to us-east-1 instead of ap-southeast-2. After the changes it works correctly:

```
$ python2
Python 2.7.5 (default, Aug 24 2013, 12:06:38) 
[GCC 4.7.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import boto
>>> s3 = boto.connect_s3()
>>> b = s3.create_bucket('testauf1ais', location='ap-southeast-2')
>>> b.get_website_endpoint()
'testauf1ais.s3-website-ap-southeast-2.amazonaws.com'
```
