### PR TITLE
add UniqueRequestToken option to mturk connection CreateHIT API

### DIFF
--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -183,7 +183,8 @@ class MTurkConnection(AWSQueryConnection):
                    reward=None, duration=datetime.timedelta(days=7),
                    approval_delay=None, annotation=None,
                    questions=None, qualifications=None,
-                   layout_params=None, response_groups=None):
+                   layout_params=None, response_groups=None,
+                   unique_request_token=None):
         """
         Creates a new HIT.
         Returns a ResultSet
@@ -250,6 +251,10 @@ class MTurkConnection(AWSQueryConnection):
         # add the annotation if specified
         if annotation is not None:
             params['RequesterAnnotation'] = annotation
+
+        # add the unique request token if specified
+        if unique_request_token is not None:
+            params['UniqueRequestToken'] = unique_request_token
 
         # Add the Qualifications if specified
         if qualifications is not None:

--- a/tests/mturk/common.py
+++ b/tests/mturk/common.py
@@ -37,6 +37,7 @@ class MTurkCommon(unittest.TestCase):
                         duration=datetime.timedelta(minutes=6),
                         approval_delay=60*60,
                         annotation='An annotation from boto create_hit test',
+                        unique_requst_token='A unique token',
                         response_groups=['Minimal',
                                 'HITDetail',
                                 'HITQuestion',

--- a/tests/mturk/create_free_text_question_regex.doctest
+++ b/tests/mturk/create_free_text_question_regex.doctest
@@ -38,6 +38,7 @@
 ...                                 duration=60*6,
 ...                                 approval_delay=60*60,
 ...                                 annotation='An annotation from boto create_hit test',
+...                                 unique_request_token='A unique token',
 ...                                 response_groups=['Minimal',
 ...                                                  'HITDetail',
 ...                                                  'HITQuestion',
@@ -95,6 +96,10 @@ u'Boto create_hit description'
 # annotation is correct
 >>> hit.RequesterAnnotation
 u'An annotation from boto create_hit test'
+
+# unique request token is correct
+>>> hit.UniqueRequestToken
+u'A unique token'
 
 >>> hit.HITReviewStatus
 u'NotReviewed'

--- a/tests/mturk/create_hit.doctest
+++ b/tests/mturk/create_hit.doctest
@@ -29,6 +29,7 @@
 ...                                 duration=60*6,
 ...                                 approval_delay=60*60,
 ...                                 annotation='An annotation from boto create_hit test',
+...                                 unique_request_token='A unique token',
 ...                                 response_groups=['Minimal',
 ...                                                  'HITDetail',
 ...                                                  'HITQuestion',
@@ -87,6 +88,10 @@ u'Boto create_hit description'
 # annotation is correct
 >>> hit.RequesterAnnotation
 u'An annotation from boto create_hit test'
+
+# unique request token is correct
+>>> hit.UniqueRequestToken
+u'A unique token'
 
 >>> hit.HITReviewStatus
 u'NotReviewed'

--- a/tests/mturk/create_hit_binary.doctest
+++ b/tests/mturk/create_hit_binary.doctest
@@ -31,6 +31,7 @@
 ...                                 duration=60*6,
 ...                                 approval_delay=60*60,
 ...                                 annotation='An annotation from boto create_hit test',
+...                                 unique_request_token='A unique token',
 ...                                 response_groups=['Minimal',
 ...                                                  'HITDetail',
 ...                                                  'HITQuestion',
@@ -89,6 +90,10 @@ u'Boto create_hit description'
 # annotation is correct
 >>> hit.RequesterAnnotation
 u'An annotation from boto create_hit test'
+
+# unique request token is correct
+>>> hit.UniqueRequestToken
+u'A unique token'
 
 >>> hit.HITReviewStatus
 u'NotReviewed'

--- a/tests/mturk/create_hit_external.py
+++ b/tests/mturk/create_hit_external.py
@@ -14,7 +14,7 @@ class Test(unittest.TestCase):
                 q = ExternalQuestion(external_url=external_url, frame_height=800)
                 conn = SetHostMTurkConnection()
                 keywords=['boto', 'test', 'doctest']
-                create_hit_rs = conn.create_hit(question=q, lifetime=60*65, max_assignments=2, title="Boto External Question Test", keywords=keywords, reward = 0.05, duration=60*6, approval_delay=60*60, annotation='An annotation from boto external question test', response_groups=['Minimal', 'HITDetail', 'HITQuestion', 'HITAssignmentSummary',])
+                create_hit_rs = conn.create_hit(question=q, lifetime=60*65, max_assignments=2, title="Boto External Question Test", keywords=keywords, reward = 0.05, duration=60*6, approval_delay=60*60, annotation='An annotation from boto external question test', unique_request_token='test' + str(datetime.datetime.now()), response_groups=['Minimal', 'HITDetail', 'HITQuestion', 'HITAssignmentSummary',])
                 assert(create_hit_rs.status == True)
 
 if __name__ == "__main__":

--- a/tests/mturk/create_hit_from_hit_type.doctest
+++ b/tests/mturk/create_hit_from_hit_type.doctest
@@ -38,6 +38,7 @@ u'...'
 ...                                 lifetime=60*65,
 ...                                 max_assignments=2,
 ...                                 annotation='An annotation from boto create_hit_from_hit_type test',
+...                                 unique_request_token='A unique token',
 ...                                 response_groups=['Minimal',
 ...                                                  'HITDetail',
 ...                                                  'HITQuestion',
@@ -97,6 +98,10 @@ u'HIT Type for testing Boto'
 # annotation is correct
 >>> hit.RequesterAnnotation
 u'An annotation from boto create_hit_from_hit_type test'
+
+# unique request token is correct
+>>> hit.UniqueRequestToken
+u'A unique token'
 
 # not reviewed yet
 >>> hit.HITReviewStatus


### PR DESCRIPTION
http://docs.aws.amazon.com/AWSMechTurk/2012-03-25/AWSMturkAPI/ApiReference_CreateHITOperation.html

"UniqueRequestToken
A unique identifier for this request. Allows you to retry the call on error without creating duplicate HITs."

Havn't been able to test this since running `python tests/test.py` seemed to stall forever (see below), but it's a simple change so it should just require a test run to make sure everything goes smoothly.

Stack trace from cancelling test.py:

```
File "/Users/scott/Code/boto/boto/manage/test_manage.py", line 6, in <module>
  volume = Volume.create()
File "/Users/scott/Code/boto/boto/manage/volume.py", line 99, in create
  getter.get(cls, params)
File "/Users/scott/Code/boto/boto/manage/volume.py", line 70, in get
  self.get_region(params)
File "/Users/scott/Code/boto/boto/manage/volume.py", line 40, in get_region
  params['region'] = propget.get(prop, choices=boto.ec2.regions)
File "/Users/scott/Code/boto/boto/manage/propget.py", line 42, in get
  value = raw_input('%s [%d-%d]: ' % (prompt, min, max))
KeyboardInterrupt
```
