### PR TITLE
added decode() for an rstrip to properly convert it

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -174,7 +174,7 @@ class Key(object):
 
     def _get_base64md5(self):
         if 'md5' in self.local_hashes and self.local_hashes['md5']:
-            return binascii.b2a_base64(self.local_hashes['md5'])decode().rstrip('\n')
+            return binascii.b2a_base64(self.local_hashes['md5']).decode().rstrip('\n')
 
     def _set_base64md5(self, value):
         if value:


### PR DESCRIPTION
was getting the following error:

  File "/usr/local/lib/python3.3/site-packages/boto/s3/key.py", line 177, in _get_base64md5
    return binascii.b2a_base64(self.local_hashes['md5']).rstrip('\n')
nose.proxy.TypeError: TypeError: Type str doesn't support the buffer API

which was fixed with the added decode()
