### PR TITLE
Add block_device_mapping to EC2Connection.create_image. Fixes #1766.

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -364,7 +364,8 @@ class EC2Connection(AWSQueryConnection):
         return result
 
     def create_image(self, instance_id, name,
-                     description=None, no_reboot=False, dry_run=False):
+                     description=None, no_reboot=False,
+                     block_device_mapping=None, dry_run=False):
         """
         Will create an AMI from the instance in the running or stopped
         state.
@@ -386,6 +387,10 @@ class EC2Connection(AWSQueryConnection):
             responsibility of maintaining file system integrity is
             left to the owner of the instance.
 
+        :type block_device_mapping: :class:`boto.ec2.blockdevicemapping.BlockDeviceMapping`
+        :param block_device_mapping: A BlockDeviceMapping data structure
+            describing the EBS volumes associated with the Image.
+
         :type dry_run: bool
         :param dry_run: Set to True if the operation should not actually run.
 
@@ -398,6 +403,8 @@ class EC2Connection(AWSQueryConnection):
             params['Description'] = description
         if no_reboot:
             params['NoReboot'] = 'true'
+        if block_device_mapping:
+            block_device_mapping.ec2_build_list_params(params)
         if dry_run:
             params['DryRun'] = 'true'
         img = self.get_object('CreateImage', params, Image, verb='POST')

--- a/tests/unit/ec2/test_connection.py
+++ b/tests/unit/ec2/test_connection.py
@@ -9,6 +9,7 @@ from tests.unit import AWSMockServiceTestCase
 import boto.ec2
 
 from boto.regioninfo import RegionInfo
+from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping
 from boto.ec2.connection import EC2Connection
 from boto.ec2.snapshot import Snapshot
 from boto.ec2.reservedinstance import ReservedInstancesConfiguration
@@ -150,6 +151,42 @@ class TestPurchaseReservedInstanceOffering(TestEC2ConnectionBase):
             'ReservedInstancesOfferingId': 'offering_id',
             'LimitPrice.Amount': '100.0',
             'LimitPrice.CurrencyCode': 'USD',},
+             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
+                                   'SignatureVersion', 'Timestamp',
+                                   'Version'])
+
+
+class TestCreateImage(TestEC2ConnectionBase):
+    def default_body(self):
+        return """<CreateImageResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-01/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+   <imageId>ami-4fa54026</imageId>
+</CreateImageResponse>"""
+
+    def test_minimal(self):
+        self.set_http_response(status_code=200)
+        response = self.ec2.create_image(
+                'instance_id', 'name')
+        self.assert_request_parameters({
+            'Action': 'CreateImage',
+            'InstanceId': 'instance_id',
+            'Name': 'name'},
+             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
+                                   'SignatureVersion', 'Timestamp',
+                                   'Version'])
+
+    def test_block_device_mapping(self):
+        self.set_http_response(status_code=200)
+        bdm = BlockDeviceMapping()
+        bdm['test'] = BlockDeviceType()
+        response = self.ec2.create_image(
+                'instance_id', 'name', block_device_mapping=bdm)
+        self.assert_request_parameters({
+            'Action': 'CreateImage',
+            'InstanceId': 'instance_id',
+            'Name': 'name',
+            'BlockDeviceMapping.1.DeviceName': 'test',
+            'BlockDeviceMapping.1.Ebs.DeleteOnTermination': 'false'},
              ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                    'SignatureVersion', 'Timestamp',
                                    'Version'])


### PR DESCRIPTION
Adds `block_device_mapping` parameter and a simple set of tests.

@toastdriven, please sanity check.
