### PR TITLE
Fix #1792 by retrying 502, 504 HTTP errors.

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -901,7 +901,7 @@ class AWSAuthConnection(object):
                             boto.log.debug(msg)
                         time.sleep(next_sleep)
                         continue
-                if response.status == 500 or response.status == 503:
+                if response.status in [500, 502, 503, 504]:
                     msg = 'Received %d response.  ' % response.status
                     msg += 'Retrying in %3.1f seconds' % next_sleep
                     boto.log.debug(msg)


### PR DESCRIPTION
Fixes #1792. Includes tests to make sure those failure codes are retried.

@toastdriven, please sanity check.
