### PR TITLE
Tests for #1554: Synchronize get_all_snapshots() with current version of API

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -2237,12 +2237,6 @@ class EC2Connection(AWSQueryConnection):
         if snapshot_ids:
             self.build_list_params(params, snapshot_ids, 'SnapshotId')
 
-        # backward compatibility layer
-        if isinstance(owner, basestring):
-           owner = [owner]
-        if isinstance(restorable_by, basestring):
-           restorable_by = [restorable_by]
-
         if owner:
             self.build_list_params(params, owner, 'Owner')
         if restorable_by:

--- a/tests/unit/ec2/test_snapshot.py
+++ b/tests/unit/ec2/test_snapshot.py
@@ -1,0 +1,59 @@
+from tests.unit import AWSMockServiceTestCase
+
+from boto.ec2.connection import EC2Connection
+from boto.ec2.snapshot import Snapshot
+
+
+class TestDescribeSnapshots(AWSMockServiceTestCase):
+
+    connection_class = EC2Connection
+
+    def default_body(self):
+        return """
+            <DescribeSnapshotsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-01/">
+               <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+               <snapshotSet>
+                  <item>
+                     <snapshotId>snap-1a2b3c4d</snapshotId>
+                     <volumeId>vol-1a2b3c4d</volumeId>
+                     <status>pending</status>
+                     <startTime>YYYY-MM-DDTHH:MM:SS.SSSZ</startTime>
+                     <progress>30%</progress>
+                     <ownerId>111122223333</ownerId>
+                     <volumeSize>15</volumeSize>
+                     <description>Daily Backup</description>
+                     <tagSet>
+                        <item>
+                           <key>Purpose</key>
+                           <value>demo_db_14_backup</value>
+                        </item>
+                     </tagSet>
+                  </item>
+               </snapshotSet>
+            </DescribeSnapshotsResponse>
+        """
+
+    def test_cancel_spot_instance_requests(self):
+        self.set_http_response(status_code=200)
+        response = self.service_connection.get_all_snapshots(['snap-1a2b3c4d', 'snap-9f8e7d6c'],
+                                                             owner=['self', '111122223333'],
+                                                             restorable_by='999988887777',
+                                                             filters={'status': 'pending',
+                                                                      'tag-value': '*db_*'})
+        self.assert_request_parameters({
+            'Action': 'DescribeSnapshots',
+            'SnapshotId.1': 'snap-1a2b3c4d',
+            'SnapshotId.2': 'snap-9f8e7d6c',
+            'Owner.1': 'self',
+            'Owner.2': '111122223333',
+            'RestorableBy.1': '999988887777',
+            'Filter.1.Name': 'status',
+            'Filter.1.Value.1': 'pending',
+            'Filter.2.Name': 'tag-value',
+            'Filter.2.Value.1': '*db_*'},
+            ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
+                                  'SignatureVersion', 'Timestamp',
+                                  'Version'])
+        self.assertEqual(len(response), 1)
+        self.assertIsInstance(response[0], Snapshot)
+        self.assertEqual(response[0].id, 'snap-1a2b3c4d')


### PR DESCRIPTION
Small change made to original code to remove unnecessary wrapping into a list of non-list arguments; build_list_params already does that. Unit test covers this case.

Pull request is against master, like original pull request; let me know if it should go against develop.
