### PR TITLE
Fix DescribeVpnConnections call argument, support static_routes_only

### DIFF
--- a/boto/vpc/__init__.py
+++ b/boto/vpc/__init__.py
@@ -1299,7 +1299,7 @@ class VPCConnection(EC2Connection):
                              [('item', VpnConnection)])
 
     def create_vpn_connection(self, type, customer_gateway_id, vpn_gateway_id,
-                              dry_run=False):
+                              static_routes_only=None, dry_run=False):
         """
         Create a new VPN Connection.
 
@@ -1313,15 +1313,24 @@ class VPCConnection(EC2Connection):
         :type vpn_gateway_id: str
         :param vpn_gateway_id: The ID of the VPN gateway.
 
+        :type static_routes_only: bool
+        :param static_routes_only: Indicates whether the VPN connection
+        requires static routes. If you are creating a VPN connection
+        for a device that does not support BGP, you must specify true.
+
         :type dry_run: bool
         :param dry_run: Set to True if the operation should not actually run.
 
         :rtype: The newly created VpnConnection
         :return: A :class:`boto.vpc.vpnconnection.VpnConnection` object
         """
-        params = {'Type' : type,
-                  'CustomerGatewayId' : customer_gateway_id,
-                  'VpnGatewayId' : vpn_gateway_id}
+        params = {'Type': type,
+                  'CustomerGatewayId': customer_gateway_id,
+                  'VpnGatewayId': vpn_gateway_id}
+        if static_routes_only is not None:
+            if isinstance(static_routes_only, bool):
+                static_routes_only = str(static_routes_only).lower()
+            params['Options.StaticRoutesOnly'] = static_routes_only
         if dry_run:
             params['DryRun'] = 'true'
         return self.get_object('CreateVpnConnection', params, VpnConnection)

--- a/tests/unit/vpc/test_vpnconnection.py
+++ b/tests/unit/vpc/test_vpnconnection.py
@@ -2,7 +2,7 @@
 from tests.unit import unittest
 from tests.unit import AWSMockServiceTestCase
 
-from boto.vpc import VPCConnection
+from boto.vpc import VPCConnection, VpnConnection
 
 DESCRIBE_VPNCONNECTIONS = r'''<?xml version="1.0" encoding="UTF-8"?>
 <DescribeVpnConnectionsResponse xmlns="http://ec2.amazonaws.com/doc/2013-02-01/">
@@ -130,6 +130,125 @@ class TestDescribeVPNConnections(AWSMockServiceTestCase):
         self.assertDictEqual(vpn1.tags, {})
         self.assertEqual(vpn1.static_routes[0].source, 'static')
         self.assertEqual(vpn1.static_routes[0].state, 'pending')
+
+
+class TestCreateVPNConnection(AWSMockServiceTestCase):
+
+    connection_class = VPCConnection
+
+    def default_body(self):
+        return """
+            <CreateVpnConnectionResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-01/">
+              <requestId>5cc7891f-1f3b-4fc4-a626-bdea8f63ff5a</requestId>
+              <vpnConnection>
+                <vpnConnectionId>vpn-83ad48ea</vpnConnectionId>
+                <state>pending</state>
+                <customerGatewayConfiguration>
+                    &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+                </customerGatewayConfiguration>
+                <customerGatewayId>cgw-b4dc3961</customerGatewayId>
+                <vpnGatewayId>vgw-8db04f81</vpnGatewayId>
+                <options>
+                  <staticRoutesOnly>true</staticRoutesOnly>
+                </options>
+                <routes/>
+              </vpnConnection>
+            </CreateVpnConnectionResponse>
+        """
+
+    def test_create_vpn_connection(self):
+        self.set_http_response(status_code=200)
+        api_response = self.service_connection.create_vpn_connection(
+            'ipsec.1', 'cgw-b4dc3961', 'vgw-8db04f81', static_routes_only=True)
+        self.assert_request_parameters({
+            'Action': 'CreateVpnConnection',
+            'Type': 'ipsec.1',
+            'CustomerGatewayId': 'cgw-b4dc3961',
+            'VpnGatewayId': 'vgw-8db04f81',
+            'Options.StaticRoutesOnly': 'true'},
+            ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
+                                  'SignatureVersion', 'Timestamp',
+                                  'Version'])
+        self.assertIsInstance(api_response, VpnConnection)
+        self.assertEquals(api_response.id, 'vpn-83ad48ea')
+        self.assertEquals(api_response.customer_gateway_id, 'cgw-b4dc3961')
+        self.assertEquals(api_response.options.static_routes_only, True)
+
+
+class TestDeleteVPNConnection(AWSMockServiceTestCase):
+
+    connection_class = VPCConnection
+
+    def default_body(self):
+        return """
+            <DeleteVpnConnectionResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-01/">
+               <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
+               <return>true</return>
+            </DeleteVpnConnectionResponse>
+        """
+
+    def test_delete_vpn_connection(self):
+        self.set_http_response(status_code=200)
+        api_response = self.service_connection.delete_vpn_connection('vpn-44a8938f')
+        self.assert_request_parameters({
+            'Action': 'DeleteVpnConnection',
+            'VpnConnectionId': 'vpn-44a8938f'},
+            ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
+                                  'SignatureVersion', 'Timestamp',
+                                  'Version'])
+        self.assertEquals(api_response, True)
+
+
+class TestCreateVPNConnectionRoute(AWSMockServiceTestCase):
+
+    connection_class = VPCConnection
+
+    def default_body(self):
+        return """
+            <CreateVpnConnectionRouteResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-01/">
+                <requestId>4f35a1b2-c2c3-4093-b51f-abb9d7311990</requestId>
+                <return>true</return>
+            </CreateVpnConnectionRouteResponse>
+        """
+
+    def test_create_vpn_connection_route(self):
+        self.set_http_response(status_code=200)
+        api_response = self.service_connection.create_vpn_connection_route(
+            '11.12.0.0/16', 'vpn-83ad48ea')
+        self.assert_request_parameters({
+            'Action': 'CreateVpnConnectionRoute',
+            'DestinationCidrBlock': '11.12.0.0/16',
+            'VpnConnectionId': 'vpn-83ad48ea'},
+            ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
+                                  'SignatureVersion', 'Timestamp',
+                                  'Version'])
+        self.assertEquals(api_response, True)
+
+
+class TestDeleteVPNConnectionRoute(AWSMockServiceTestCase):
+
+    connection_class = VPCConnection
+
+    def default_body(self):
+        return """
+            <DeleteVpnConnectionRouteResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-01/">
+                <requestId>4f35a1b2-c2c3-4093-b51f-abb9d7311990</requestId>
+                <return>true</return>
+            </DeleteVpnConnectionRouteResponse>
+        """
+
+    def test_delete_vpn_connection_route(self):
+        self.set_http_response(status_code=200)
+        api_response = self.service_connection.delete_vpn_connection_route(
+            '11.12.0.0/16', 'vpn-83ad48ea')
+        self.assert_request_parameters({
+            'Action': 'DeleteVpnConnectionRoute',
+            'DestinationCidrBlock': '11.12.0.0/16',
+            'VpnConnectionId': 'vpn-83ad48ea'},
+            ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
+                                  'SignatureVersion', 'Timestamp',
+                                  'Version'])
+        self.assertEquals(api_response, True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request takes the fix from #1481 and modifies an existing test to ensure the fix sticks.

It also adds support for static_routes_only flag in create_vpn_connections, functionality not previously exposed
It also adds tests for all other VPN connection related functions.
