### PR TITLE
Fix typo in IAMConnection documentation

### DIFF
--- a/boto/iam/connection.py
+++ b/boto/iam/connection.py
@@ -836,7 +836,7 @@ class IAMConnection(AWSQueryConnection):
         :param user_name: The username of the user
 
         :type serial_number: string
-        :param seriasl_number: The serial number which uniquely identifies
+        :param serial_number: The serial number which uniquely identifies
             the MFA device.
 
         :type auth_code_1: string
@@ -862,7 +862,7 @@ class IAMConnection(AWSQueryConnection):
         :param user_name: The username of the user
 
         :type serial_number: string
-        :param seriasl_number: The serial number which uniquely identifies
+        :param serial_number: The serial number which uniquely identifies
             the MFA device.
 
         """
@@ -879,7 +879,7 @@ class IAMConnection(AWSQueryConnection):
         :param user_name: The username of the user
 
         :type serial_number: string
-        :param seriasl_number: The serial number which uniquely identifies
+        :param serial_number: The serial number which uniquely identifies
             the MFA device.
 
         :type auth_code_1: string


### PR DESCRIPTION
### seriasl_number != serial_number
