### PR TITLE
fixes #1828 make connection.authorize not mutate headers

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -371,8 +371,6 @@ class HTTPRequest(object):
     def authorize(self, connection, **kwargs):
         for key in self.headers:
             val = self.headers[key]
-            if isinstance(val, unicode):
-                self.headers[key] = urllib.quote_plus(val.encode('utf-8'))
 
         connection._auth_handler.add_auth(self, **kwargs)
 

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -141,6 +141,8 @@ def canonical_string(method, path, headers, expires=None,
     buf = "%s\n" % method
     for key in sorted_header_keys:
         val = interesting_headers[key]
+        if isinstance(val, unicode):
+            val = urllib.quote_plus(val.encode('utf-8'))
         if key.startswith(provider.header_prefix):
             buf += "%s:%s\n" % (key, val)
         else:


### PR DESCRIPTION
Make connection.authorize not mutate headers; instead moving urlencoding down to util.canonical_string for auth to still work correctly
