### PR TITLE
Autoscale: Added AssociatePublicIpAddress

### DIFF
--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -241,6 +241,10 @@ class AutoScaleConnection(AWSQueryConnection):
             params['EbsOptimized'] = 'true'
         else:
             params['EbsOptimized'] = 'false'
+        if launch_config.associate_public_ip:
+            params['AssociatePublicIpAddress'] = 'true'
+        else:
+            params['AssociatePublicIpAddress'] = 'false'
         return self.get_object('CreateLaunchConfiguration', params,
                                Request, verb='POST')
 

--- a/boto/ec2/autoscale/launchconfig.py
+++ b/boto/ec2/autoscale/launchconfig.py
@@ -94,7 +94,8 @@ class LaunchConfiguration(object):
                  instance_type='m1.small', kernel_id=None,
                  ramdisk_id=None, block_device_mappings=None,
                  instance_monitoring=False, spot_price=None,
-                 instance_profile_name=None, ebs_optimized=False):
+                 instance_profile_name=None, ebs_optimized=False,
+                 associate_public_ip=False):
         """
         A launch configuration.
 
@@ -144,6 +145,10 @@ class LaunchConfiguration(object):
         :type ebs_optimized: bool
         :param ebs_optimized: Specifies whether the instance is optimized
             for EBS I/O (true) or not (false).
+
+        :type associate_public_ip: bool
+        :param associate_public_ip: Specifies whether public IP will be
+            allocated for the instance.
         """
         self.connection = connection
         self.name = name
@@ -163,6 +168,7 @@ class LaunchConfiguration(object):
         self.instance_profile_name = instance_profile_name
         self.launch_configuration_arn = None
         self.ebs_optimized = ebs_optimized
+        self.associate_public_ip = associate_public_ip
 
     def __repr__(self):
         return 'LaunchConfiguration:%s' % self.name
@@ -208,6 +214,8 @@ class LaunchConfiguration(object):
             self.instance_profile_name = value
         elif name == 'EbsOptimized':
             self.ebs_optimized = True if value.lower() == 'true' else False
+        elif name == 'AssociatePublicIpAddress':
+            self.associate_public_ip = True if value.lower() == 'true' else False
         else:
             setattr(self, name, value)
 

--- a/boto/ec2/launchspecification.py
+++ b/boto/ec2/launchspecification.py
@@ -58,6 +58,7 @@ class LaunchSpecification(EC2Object):
         self.block_device_mapping = None
         self.instance_profile = None
         self.ebs_optimized = False
+        self.associate_public_ip = False
 
     def __repr__(self):
         return 'LaunchSpecification(%s)' % self.image_id
@@ -101,5 +102,7 @@ class LaunchSpecification(EC2Object):
                 self._in_monitoring_element = False
         elif name == 'ebsOptimized':
             self.ebs_optimized = (value == 'true')
+        elif name == 'associatePublicIpAddress':
+            self.associate_public_ip = (value == 'true')
         else:
             setattr(self, name, value)

--- a/tests/integration/ec2/autoscale/test_connection.py
+++ b/tests/integration/ec2/autoscale/test_connection.py
@@ -180,3 +180,18 @@ class AutoscaleConnectionTest(unittest.TestCase):
         # & the expected string variants.
         c.create_launch_configuration(lc)
         self.addCleanup(c.delete_launch_configuration, lc_name)
+
+    def test_associate_public_ip_regression(self):
+        c = AutoScaleConnection()
+        time_string = '%d' % int(time.time())
+        lc_name = 'lc-%s' % time_string
+        lc = LaunchConfiguration(
+            name=lc_name,
+            image_id='ami-2272864b',
+            instance_type='t1.micro',
+            associate_public_ip=True
+        )
+        # This failed due to the difference between native Python ``True/False``
+        # & the expected string variants.
+        c.create_launch_configuration(lc)
+        self.addCleanup(c.delete_launch_configuration, lc_name)

--- a/tests/unit/ec2/test_connection.py
+++ b/tests/unit/ec2/test_connection.py
@@ -491,6 +491,7 @@ class TestDescribeSpotInstanceRequests(TestEC2ConnectionBase):
         self.assertEqual(launch_spec.block_device_mapping, None)
         self.assertEqual(launch_spec.instance_profile, None)
         self.assertEqual(launch_spec.ebs_optimized, False)
+        self.assertEqual(launch_spec.associate_public_ip, False)
         status = spotrequest.status
         self.assertEqual(status.code, 'fulfilled')
         self.assertEqual(status.update_time, '2012-10-19T18:09:26.000Z')


### PR DESCRIPTION
As per http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_CreateLaunchConfiguration.html
added a possibility to create launchconfiguration which allocates EIP automatically for new instances.

Comment for improvements welcome. (perhaps this should go into 'development' branch?
