### PR TITLE
sqs.message: Raising an exception in decode() should not abort parsing

### DIFF
--- a/boto/handler.py
+++ b/boto/handler.py
@@ -38,6 +38,8 @@ class XmlHandler(xml.sax.ContentHandler):
     def endElement(self, name):
         self.nodes[-1][1].endElement(name, self.current_text, self.connection)
         if self.nodes[-1][0] == name:
+            if hasattr(self.nodes[-1][1], 'endNode'):
+                self.nodes[-1][1].endNode(self.connection)
             self.nodes.pop()
         self.current_text = ''
 

--- a/boto/sqs/message.py
+++ b/boto/sqs/message.py
@@ -95,7 +95,7 @@ class RawMessage:
 
     def endElement(self, name, value, connection):
         if name == 'Body':
-            self.set_body(self.decode(value))
+            self.set_body(value)
         elif name == 'MessageId':
             self.id = value
         elif name == 'ReceiptHandle':
@@ -104,6 +104,9 @@ class RawMessage:
             self.md5 = value
         else:
             setattr(self, name, value)
+
+    def endNode(self, connection):
+        self.set_body(self.decode(self.get_body()))
 
     def encode(self, value):
         """Transform body object into serialized byte array format."""


### PR DESCRIPTION
Since SQS seems to return Body before ReceiptHandle, raising an exception in e.g. boto.sqs.jsonmessage.JsonMessage.decode() will abort processing before the receipt handle is read.

This is a problem, because there's no way to dequeue the malformed message without the handle.

Instead, we should wait to invoke decode() until parsing is finished. This PR provides an additional callback to an entity when it's popped from the stack during parsing.
