### PR TITLE
Generate docs for route53/zone, remove docs for route53/hostedzone, route53/exceptions

### DIFF
--- a/docs/source/ref/route53.rst
+++ b/docs/source/ref/route53.rst
@@ -12,6 +12,13 @@ boto.route53.connection
    :members:   
    :undoc-members:
 
+boto.route53.exception
+-------------------
+
+.. automodule:: boto.route53.exception
+   :members:   
+   :undoc-members:
+
 boto.route53.record
 -------------------
 


### PR DESCRIPTION
Add generated documentation for route53/zone
Remove generated documentation for implementation classes route53/exception and route53/hostedzone
