### PR TITLE
Replace correct ACL association

### DIFF
--- a/boto/vpc/__init__.py
+++ b/boto/vpc/__init__.py
@@ -497,10 +497,10 @@ class VPCConnection(EC2Connection):
         """
 
         acl = self.get_all_network_acls(filters=[('association.subnet-id', subnet_id)])[0]
-        association_id = acl.associations[0].id
+        association = [ association for association in acl.associations if association.subnet_id == subnet_id ][0]
 
         params = {
-            'AssociationId': association_id,
+            'AssociationId': association.id,
             'NetworkAclId': network_acl_id
         }
 

--- a/tests/unit/vpc/test_vpc.py
+++ b/tests/unit/vpc/test_vpc.py
@@ -381,14 +381,14 @@ class TestReplaceNetworkAclAssociation(AWSMockServiceTestCase):
               </entrySet>
               <associationSet>
                 <item>
-                  <networkAclAssociationId>aclassoc-5c659635</networkAclAssociationId>
-                  <networkAclId>acl-5d659634</networkAclId>
-                  <subnetId>subnet-ff669596</subnetId>
-                </item>
-                <item>
                   <networkAclAssociationId>aclassoc-c26596ab</networkAclAssociationId>
                   <networkAclId>acl-5d659634</networkAclId>
                   <subnetId>subnet-f0669599</subnetId>
+                </item>
+                <item>
+                  <networkAclAssociationId>aclassoc-5c659635</networkAclAssociationId>
+                  <networkAclId>acl-5d659634</networkAclId>
+                  <subnetId>subnet-ff669596</subnetId>
                 </item>
               </associationSet>
               <tagSet/>


### PR DESCRIPTION
Addresses #1843 . Only the _specified_ subnet's ACL association is replaced, not the _first_ one. 
