### PR TITLE
Update rsa to the latest version

### DIFF
--- a/py3kport/requirements.txt-3.3
+++ b/py3kport/requirements.txt-3.3
@@ -1,6 +1,6 @@
 nose==1.1.2
 requests>=1.1.0
-rsa==3.1.1
+rsa==3.1.2
 tox==1.4
 Sphinx==1.1.3
 httpretty==0.5.10


### PR DESCRIPTION
With the new setuptools, rsa fails to install with Python 3.
This issue is fixed in the latest version of rsa.

For more info, see: https://bitbucket.org/sybren/python-rsa/issue/17/pip-install-fails-on-python3-with-newer
