### PR TITLE
Avoid confusing cloudstack user data servers

### DIFF
--- a/boto/utils.py
+++ b/boto/utils.py
@@ -323,7 +323,7 @@ def _build_instance_metadata_url(url, version, path):
         http://169.254.169.254/latest/meta-data/
 
     """
-    return '%s/%s/%s/' % (url, version, path)
+    return '%s/%s/%s' % (url, version, path)
 
 
 def get_instance_metadata(version='latest', url='http://169.254.169.254',


### PR DESCRIPTION
Cloudstack does not cope well with trailing slashes. If other userdata servers can handle a lack of trailing slash, this would be useful and unbreak amongst others cloud-init for Ubuntu 13.10 at least.

I don't have means to test if EC2 handles trailing slashes well, maybe you guys can ?
