### PR TITLE
Fix DynamoDBv2 tutorial sentence with missing verb.

### DIFF
--- a/docs/source/dynamodb2_tut.rst
+++ b/docs/source/dynamodb2_tut.rst
@@ -204,8 +204,8 @@ three choices.
 
 The first is sending all the data with the expectation nothing has changed
 since you read the data. DynamoDB will verify the data is in the original state
-and, if so, will all of the item's data. If that expectation fails, the call
-will fail::
+and, if so, will send all of the item's data. If that expectation fails, the
+call will fail::
 
     >>> johndoe = users.get_item(username='johndoe')
     >>> johndoe['first_name'] = 'Johann'


### PR DESCRIPTION
Fixes #1825. @toastdriven, please sanity check.
