### PR TITLE
use auth_handler to specify host header value if possible

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -839,6 +839,13 @@ class AWSAuthConnection(object):
         auth = base64.encodestring(self.proxy_user + ':' + self.proxy_pass)
         return {'Proxy-Authorization': 'Basic %s' % auth}
 
+    def set_host_header(self, request):
+        try:
+            request.headers['Host'] = \
+                self._auth_handler.host_header(self.host, request)
+        except AttributeError:
+            request.headers['Host'] = self.host.split(':', 1)[0]
+
     def _mexe(self, request, sender=None, override_num_retries=None,
               retry_handler=None):
         """
@@ -879,11 +886,7 @@ class AWSAuthConnection(object):
                 # the port info. All others should be now be up to date and
                 # not include the port.
                 if 's3' not in self._required_auth_capability():
-                    try:
-                        request.headers['Host'] = \
-                            self._auth_handler.host_header(self.host, request)
-                    except AttributeError:
-                        request.headers['Host'] = self.host.split(':', 1)[0]
+                    self.set_host_header(request)
                     
                 if callable(sender):
                     response = sender(connection, request.method, request.path,


### PR DESCRIPTION
Here's an example request from boto 2.13.3
......`.GET /services/AutoScaling/?Action=DescribeAutoScalingGroups&Version=2011-01-01 HTTP/1.1
Host: 10.111.1.16:8773
Accept-Encoding: identity
Content-Length: 0
Authorization: AWS4-HMAC-SHA256 Credential=AKIFBFNSN71IQ2EI5WZL/20131118/Eucalyptus/10/aws4_request,SignedHeaders=host;x-amz-date,Signature=8a279475589c5fe29e4ac50a1232a934d8bcafefb3d59675f788270de557df7e
X-Amz-Date: 20131118T162926Z
User-Agent: Boto/v2.13.2 Python/2.7.1 Darwin/11.4.2

This is the same request in boto 2.14.0
..M@...#GET /services/AutoScaling/?Action=DescribeAutoScalingGroups&Version=2011-01-01 HTTP/1.1
Accept-Encoding: identity
Content-Length: 0
Host: 10.111.1.16
Authorization: AWS4-HMAC-SHA256 Credential=AKIFBFNSN71IQ2EI5WZL/20131118/Eucalyptus/10/aws4_request,SignedHeaders=host;x-amz-date,Signature=a73c58078ac4caa086456da44c7801f369deec3725f9d938ff06665174c36d34
X-Amz-Date: 20131118T162847Z
User-Agent: Boto/2.14.0 Python/2.7.1 Darwin/11.4.2

The problem is that when a non-standard port is used, the Host header should contain the port number since that was used to sign the request (if you look at StringToSign). The problem didn't show up against AWS since they use standard ports, but eucalyptus runs on a non-standard port by default.
This problem affects v4 signing only, so I simply added a conditional to check to see if the auth_handler had the host_header method and call it in that case.
I've tested with AWS and Eucalyptus using both http and https.
