### PR TITLE
Fix use of STS generated auth key + tokens with SWF

### DIFF
--- a/boto/swf/layer1.py
+++ b/boto/swf/layer1.py
@@ -69,7 +69,7 @@ class Layer1(AWSAuthConnection):
 
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,
-                 debug=0, session_token=None, region=None):
+                 debug=0, security_token=None, region=None):
         if not region:
             region_name = boto.config.get('SWF', 'region',
                                           self.DefaultRegionName)
@@ -82,7 +82,7 @@ class Layer1(AWSAuthConnection):
         AWSAuthConnection.__init__(self, self.region.endpoint,
                                    aws_access_key_id, aws_secret_access_key,
                                    is_secure, port, proxy, proxy_port,
-                                   debug, session_token)
+                                   debug, security_token=security_token)
 
     def _required_auth_capability(self):
         return ['hmac-v4']


### PR DESCRIPTION
Be explicit about what the security token is.  Note that this does change the parameter name but it couldn't ever have worked before since passing the token as an unnamed parameter meant it was being used as https_connection_factory.

I can make both parameter names work but it felt like cruft since it couldn't have worked before.
