### PR TITLE
documentation of launch config in Autoscaling Group was wrong

### DIFF
--- a/boto/ec2/autoscale/group.py
+++ b/boto/ec2/autoscale/group.py
@@ -129,8 +129,8 @@ class AutoScalingGroup(object):
         :param health_check_type: The service you want the health status from,
             Amazon EC2 or Elastic Load Balancer.
 
-        :type launch_config_name: str or LaunchConfiguration
-        :param launch_config_name: Name of launch configuration (required).
+        :type launch_config: str or LaunchConfiguration
+        :param launch_config: Name of launch configuration (required).
 
         :type load_balancers: list
         :param load_balancers: List of load balancers.


### PR DESCRIPTION
The documentation mentioned a parameter called launch_config_name, but it's really called launch_config.
