### PR TITLE
Quick solution to issue 1874. 

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -1836,7 +1836,7 @@ class EC2Connection(AWSQueryConnection):
         if dry_run:
             params['DryRun'] = 'true'
 
-        return self.get_status('AssociateAddress', params, verb='POST')
+        return self.get_object('AssociateAddress', params, Address, verb='POST')
 
     def disassociate_address(self, public_ip=None, association_id=None,
                              dry_run=False):


### PR DESCRIPTION
Make AssociateAddress return an object with the Association ID instead of a boolean status.

I'm not sure how intrusive a change this would be for the regular/supported use cases of Boto.  Anyone who depends on the boolean response will need to change their expected return values.  
