### PR TITLE
Fix honor cooldown AutoScaling parameter serialization

### DIFF
--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -785,7 +785,7 @@ class AutoScaleConnection(AWSQueryConnection):
         params = {'AutoScalingGroupName': group_name,
                   'DesiredCapacity': desired_capacity}
         if honor_cooldown:
-            params['HonorCooldown'] = json.dumps('True')
+            params['HonorCooldown'] = 'true'
 
         return self.get_status('SetDesiredCapacity', params)
 

--- a/tests/unit/ec2/autoscale/test_group.py
+++ b/tests/unit/ec2/autoscale/test_group.py
@@ -67,6 +67,29 @@ class TestAutoScaleGroup(AWSMockServiceTestCase):
             'TerminationPolicies.member.2': 'OldestLaunchConfiguration',
         }, ignore_params_values=['Version'])
 
+
+class TestAutoScaleGroupHonorCooldown(AWSMockServiceTestCase):
+    connection_class = AutoScaleConnection
+
+    def default_body(self):
+        return """
+            <SetDesiredCapacityResponse>
+              <ResponseMetadata>
+                <RequestId>9fb7e2db-6998-11e2-a985-57c82EXAMPLE</RequestId>
+              </ResponseMetadata>
+            </SetDesiredCapacityResponse>
+        """
+
+    def test_honor_cooldown(self):
+        self.set_http_response(status_code=200)
+        self.service_connection.set_desired_capacity('foo', 10, True)
+        self.assert_request_parameters({
+            'Action': 'SetDesiredCapacity',
+            'AutoScalingGroupName': 'foo',
+            'DesiredCapacity': 10,
+            'HonorCooldown': 'true',
+        }, ignore_params_values=['Version'])
+
 class TestScheduledGroup(AWSMockServiceTestCase):
     connection_class = AutoScaleConnection
 


### PR DESCRIPTION
Fix honor cooldown AutoScaling parameter serialization to prevent an exception and bad request. Fixes #1892.

@toastdriven please review :smile:
