### PR TITLE
Fixing the dynamo 'scan in' filter

### DIFF
--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -424,7 +424,7 @@ class Table(object):
         with boto.dynamodb. Unlike get_item, it takes hash_key and range_key first,
         although you may still specify keyword arguments instead.
 
-        Also unlike the get_item command, if the returned item has no keys 
+        Also unlike the get_item command, if the returned item has no keys
         (i.e., it does not exist in DynamoDB), a None result is returned, instead
         of an empty key object.
 
@@ -668,6 +668,10 @@ class Table(object):
                     lookup['AttributeValueList'].append(
                         self._dynamizer.encode(value[1])
                     )
+            # Special-case the ``IN`` case
+            elif field_bits[-1] == 'in':
+                for val in value:
+                    lookup['AttributeValueList'].append(self._dynamizer.encode(val))
             else:
                 # Fix up the value for encoding, because it was built to only work
                 # with ``set``s.

--- a/tests/unit/dynamodb2/test_table.py
+++ b/tests/unit/dynamodb2/test_table.py
@@ -1698,7 +1698,12 @@ class TableTestCase(unittest.TestCase):
                 'ComparisonOperator': 'GE',
             },
             'age': {
-                'AttributeValueList': [{'NS': ['32', '33', '30', '31']}],
+                'AttributeValueList': [
+                    {'N': '30'},
+                    {'N': '31'},
+                    {'N': '32'},
+                    {'N': '33'},
+                ],
                 'ComparisonOperator': 'IN',
             },
             'last_name': {


### PR DESCRIPTION
The "IN" filter was not working for DynamoDB `scan` calls. It requires multiple values be sent up in the AttributeValueList. Boto was instead sending up a single value with one of the "set" datatypes.

The API documentation can be found here: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html
