### PR TITLE
Fixing user data url

### DIFF
--- a/boto/utils.py
+++ b/boto/utils.py
@@ -423,7 +423,7 @@ def get_instance_identity(version='latest', url='http://169.254.169.254',
 
 def get_instance_userdata(version='latest', sep=None,
                           url='http://169.254.169.254'):
-    ud_url = _build_instance_metadata_url(url, version, 'user-data')
+    ud_url = '%s/%s/user-data' % (url, version)
     user_data = retry_url(ud_url, retry_on_404=False)
     if user_data:
         if sep:


### PR DESCRIPTION
I'm working on instance initiation by CloudInit in CloudStack and have a problem when I use boto 2.9.0 later together. The problem is that I can't get "user-data" by boto.

This commit is for fixing access url to fetch user-data. I of course know a similar issue(https://github.com/boto/boto/pull/1856) and a pull request are already made.

However, this patch fixes it in a different way. I only changed get_instance_userdata and it makes no harm to fetching meta-data from meta-data service url. My suggestion is described in detail below.

CloudInit in CloudStack uses boto for retrieving meta-data and user-data, becuase CloudStack provides those data like Amazon EC2. So, CloudInit simply calls boto.utils.get_instance_metadata and boto.utils.get_instance_userdata to get them.

Access url composition routine in boto.utils.get_instance_userdata was changed at 2.9.0 and it is a reason of failing to get user-data. Difference is below.

<pre>
    (1) before 2.8.0  http://<ipaddr>/latest/user-data
    (2) after  2.9.0  http://<ipaddr>/latest/user-data/
</pre>


user-data service in CloudStack provides only user-data at (1) and an access to (2) leads to 404 Not Found error.

A document of Amazon EC2 also describes that the service url is (1).

http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html

I think url composition like (2) is not correct though the access to (2) actually works fine in Amazon EC2 because the url may be redirected or rewritten to (1).

So, this patch fixes backward compatibility and gives boto portability to CloudStack in fetching user-data.
