### PR TITLE
[dynamodb2] Implement nonzero for Item to consider empty items falsey

### DIFF
--- a/boto/dynamodb2/items.py
+++ b/boto/dynamodb2/items.py
@@ -19,6 +19,9 @@ class Item(object):
     This object presents a dictionary-like interface for accessing/storing
     data. It also tries to intelligently track how data has changed throughout
     the life of the instance, to be as efficient as possible about updates.
+
+    Empty items, or items that have no data, are considered falsey.
+
     """
     def __init__(self, table, data=None, loaded=False):
         """
@@ -104,6 +107,9 @@ class Item(object):
 
     def __contains__(self, key):
         return key in self._data
+
+    def __nonzero__(self):
+        return bool(self._data)
 
     def _determine_alterations(self):
         """

--- a/tests/unit/dynamodb2/test_table.py
+++ b/tests/unit/dynamodb2/test_table.py
@@ -653,6 +653,10 @@ class ItemTestCase(unittest.TestCase):
             date_joined=12345
         )
 
+    def test_nonzero(self):
+        self.assertTrue(self.johndoe)
+        self.assertFalse(self.create_item({}))
+
 
 def fake_results(name, greeting='hello', exclusive_start_key=None, limit=None):
     if exclusive_start_key is None:


### PR DESCRIPTION
Doing `table.get_item(foo='a')` where no item exists matching `foo='a'` returns an empty item. The returned empty item when passed to `bool`  evaluates as `True`:

```
In [23]: i =  comments_table.get_item(item_id='not_in_there')

In [24]: bool(i)
Out[24]: True
```

This is surprising, and it'd be nice to have `i` show up falsey.
