### PR TITLE
Add ability to define persona-type credentials file within boto.cfg

### DIFF
--- a/docs/source/boto_config_tut.rst
+++ b/docs/source/boto_config_tut.rst
@@ -69,6 +69,23 @@ For example::
 Please notice that quote characters are not used to either side of the '='
 operator even when both your AWS access key id and secret key are strings.
 
+If using multiple personae managed in a separate configuration file,
+specify ``aws_credential_file`` instead of a specific keypair.::
+
+    [Credentials]
+    aws_credential_file = /path/to/persona/creds
+
+The persona configuration file then looks like this::
+
+    [production]
+    access_key = <your production access key>
+    secret_key = <your production secret key>
+
+    [default]
+    access_key = <your default access key, if no persona is specified>
+    secret_key = <your default secret key, if no persona is specified>
+
+
 For greater security, the secret key can be stored in a keyring and
 retrieved via the keyring package.  To use a keyring, use ``keyring``,
 rather than ``aws_secret_access_key``::


### PR DESCRIPTION
This expands upon the existing feature to set the environmental variable AWS_CREDENTIAL_FILE to a user-defined file with multiple personae. In certain work environments that manage configuration files - but not environmental variables - centrally, it would be useful to set this within a place like boto.cfg.

In the [Credentials] section of a boto.cfg (or similar) we now support an option called aws_credential_file, which represents a path to a file containing at least one persona. This does NOT override the extant behavior of setting a keypair in [Credentials] - it only kicks in if aws_access_key_id and aws_secret_access_key are missing. 
