### PR TITLE
Introduce the vital / to find security-credentials

### DIFF
--- a/boto/provider.py
+++ b/boto/provider.py
@@ -290,7 +290,7 @@ class Provider(object):
         # clear to users.
         metadata = get_instance_metadata(
             timeout=timeout, num_retries=attempts,
-            data='meta-data/iam/security-credentials')
+            data='meta-data/iam/security-credentials/')
         if metadata:
             # I'm assuming there's only one role on the instance profile.
             security = metadata.values()[0]


### PR DESCRIPTION
We can't get meta-data/iam/security-credentials, we need to get
meta-data/iam/security-credentials/ to actually get the roles
