### PR TITLE
CloudFrontConnection.create_distribution accepts default_root_object key...

### DIFF
--- a/boto/cloudfront/__init__.py
+++ b/boto/cloudfront/__init__.py
@@ -163,11 +163,13 @@ class CloudFrontConnection(AWSAuthConnection):
         return self._set_config(distribution_id, etag, config)
 
     def create_distribution(self, origin, enabled, caller_reference='',
-                            cnames=None, comment='', trusted_signers=None):
+                            cnames=None, comment='', trusted_signers=None,
+                            default_root_object=None):
         config = DistributionConfig(origin=origin, enabled=enabled,
                                     caller_reference=caller_reference,
                                     cnames=cnames, comment=comment,
-                                    trusted_signers=trusted_signers)
+                                    trusted_signers=trusted_signers,
+                                    default_root_object=default_root_object)
         return self._create_object(config, 'distribution', Distribution)
 
     def delete_distribution(self, distribution_id, etag):


### PR DESCRIPTION
Adds support for setting the default_root_object when creating a CloudFront distribution using CloudFrontConnection.create_distribution; CloudFrontConnection currently uses CloudFront API version 2010-11-01, which already supports the DefaultRootObject property, and default_root_object is already handled by the Distribution xml serializer method.
