### PR TITLE
Add security_token parameter to STSConnection

### DIFF
--- a/boto/sts/connection.py
+++ b/boto/sts/connection.py
@@ -69,7 +69,8 @@ class STSConnection(AWSQueryConnection):
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
-                 converter=None, validate_certs=True, anon=False):
+                 converter=None, validate_certs=True, anon=False,
+                 security_token=None):
         if not region:
             region = RegionInfo(self, self.DefaultRegionName,
                                 self.DefaultRegionEndpoint,
@@ -83,7 +84,8 @@ class STSConnection(AWSQueryConnection):
                                     proxy_user, proxy_pass,
                                     self.region.endpoint, debug,
                                     https_connection_factory, path,
-                                    validate_certs=validate_certs)
+                                    validate_certs=validate_certs,
+                                    security_token=security_token)
 
     def _required_auth_capability(self):
         if self.anon:


### PR DESCRIPTION
Add the security_token parameter to STS so one can use temporary credentials to make STS calls.
