### PR TITLE
Fix multiple inheritance in `FormattedContent`

### DIFF
--- a/boto/mturk/question.py
+++ b/boto/mturk/question.py
@@ -179,7 +179,7 @@ class Flash(Application):
         super(Flash, self).get_inner_content(content)
 
 
-class FormattedContent(object, XMLTemplate):
+class FormattedContent(XMLTemplate):
     schema_url = 'http://mechanicalturk.amazonaws.com/AWSMechanicalTurkDataSchemas/2006-07-14/FormattedContentXHTMLSubset.xsd'
     template = '<FormattedContent><![CDATA[%(content)s]]></FormattedContent>'
 


### PR DESCRIPTION
See https://github.com/boto/boto/issues/1936

`XMLTemplate` already inherits from `object`, which leads to a `TypeError`:

```
>>> from boto.mturk.connection import MTurkConnection
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/vagrant/debug-boto/local/lib/python2.7/site-packages/boto/mturk/connection.py", line 33, in <module>
    from boto.mturk.question import QuestionForm, ExternalQuestion, HTMLQuestion
  File "/home/vagrant/debug-boto/local/lib/python2.7/site-packages/boto/mturk/question.py", line 182, in <module>
    class FormattedContent(object, XMLTemplate):
TypeError: Error when calling the metaclass bases
    Cannot create a consistent method resolution
order (MRO) for bases object, XMLTemplate
```
