### PR TITLE
Fix #1898 by doing an initial call to `datetime.strptime`

### DIFF
--- a/boto/__init__.py
+++ b/boto/__init__.py
@@ -27,6 +27,7 @@
 from boto.pyami.config import Config, BotoConfigLocations
 from boto.storage_uri import BucketStorageUri, FileStorageUri
 import boto.plugin
+import datetime
 import os
 import platform
 import re
@@ -38,6 +39,9 @@ from boto.exception import InvalidUriError
 
 __version__ = '2.21.0'
 Version = __version__  # for backware compatibility
+
+# http://bugs.python.org/issue7980
+datetime.datetime.strptime('', '')
 
 UserAgent = 'Boto/%s Python/%s %s/%s' % (
     __version__,

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -26,8 +26,9 @@ except ImportError:
 
 import hashlib
 import hmac
-
 import mock
+import thread
+import time
 
 import boto.utils
 from boto.utils import Password
@@ -38,6 +39,21 @@ from boto.utils import retry_url
 from boto.utils import LazyLoadMetadata
 
 from boto.compat import json
+
+
+@unittest.skip("http://bugs.python.org/issue7980")
+class TestThreadImport(unittest.TestCase):
+    def test_strptime(self):
+        def f():
+            for m in xrange(1, 13):
+                for d in xrange(1,29):
+                    boto.utils.parse_ts('2013-01-01T00:00:00Z')
+
+        for _ in xrange(10):
+            thread.start_new_thread(f, ())
+
+        time.sleep(3)
+
 
 class TestPassword(unittest.TestCase):
     """Test basic password functionality"""


### PR DESCRIPTION
Fix #1898 by doing an initial call to `datetime.strptime`.

This commit works around an upstream threading bug
http://bugs.python.org/issue7980 which affects Mac OS X. It includes a
test which is skipped by default because it will not always fail.

@toastdriven please review.
