### PR TITLE
Set security token via environment or config file

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -434,6 +434,10 @@ class AWSAuthConnection(object):
         :keyword str aws_secret_access_key: Your AWS Secret Access Key
             (provided by Amazon). If none is specified, the value in your
             ``AWS_SECRET_ACCESS_KEY`` environmental variable is used.
+        :keyword str security_token: The security token associated with
+            temporary credentials issued by STS.  Optional unless using
+            temporary credentials.  If none is specified, the environment
+            variable ``AWS_SECURITY_TOKEN`` is used if defined.
 
         :type is_secure: boolean
         :param is_secure: Whether the connection is over SSL

--- a/tests/unit/provider/test_provider.py
+++ b/tests/unit/provider/test_provider.py
@@ -71,6 +71,15 @@ class TestProvider(unittest.TestCase):
         self.assertEqual(p.secret_key, 'env_secret_key')
         self.assertIsNone(p.security_token)
 
+    def test_environment_variable_aws_security_token(self):
+        self.environ['AWS_ACCESS_KEY_ID'] = 'env_access_key'
+        self.environ['AWS_SECRET_ACCESS_KEY'] = 'env_secret_key'
+        self.environ['AWS_SECURITY_TOKEN'] = 'env_security_token'
+        p = provider.Provider('aws')
+        self.assertEqual(p.access_key, 'env_access_key')
+        self.assertEqual(p.secret_key, 'env_secret_key')
+        self.assertEqual(p.security_token, 'env_security_token')
+
     def test_config_values_are_used(self):
         self.config = {
             'Credentials': {
@@ -82,6 +91,19 @@ class TestProvider(unittest.TestCase):
         self.assertEqual(p.access_key, 'cfg_access_key')
         self.assertEqual(p.secret_key, 'cfg_secret_key')
         self.assertIsNone(p.security_token)
+
+    def test_config_value_security_token_is_used(self):
+        self.config = {
+            'Credentials': {
+                'aws_access_key_id': 'cfg_access_key',
+                'aws_secret_access_key': 'cfg_secret_key',
+                'aws_security_token': 'cfg_security_token',
+            }
+        }
+        p = provider.Provider('aws')
+        self.assertEqual(p.access_key, 'cfg_access_key')
+        self.assertEqual(p.secret_key, 'cfg_secret_key')
+        self.assertEqual(p.security_token, 'cfg_security_token')
 
     def test_keyring_is_used(self):
         self.config = {
@@ -123,6 +145,22 @@ class TestProvider(unittest.TestCase):
         self.assertEqual(p.access_key, 'env_access_key')
         self.assertEqual(p.secret_key, 'env_secret_key')
         self.assertIsNone(p.security_token)
+
+    def test_env_vars_security_token_beats_config_values(self):
+        self.environ['AWS_ACCESS_KEY_ID'] = 'env_access_key'
+        self.environ['AWS_SECRET_ACCESS_KEY'] = 'env_secret_key'
+        self.environ['AWS_SECURITY_TOKEN'] = 'env_security_token'
+        self.config = {
+            'Credentials': {
+                'aws_access_key_id': 'cfg_access_key',
+                'aws_secret_access_key': 'cfg_secret_key',
+                'aws_security_token': 'cfg_security_token',
+            }
+        }
+        p = provider.Provider('aws')
+        self.assertEqual(p.access_key, 'env_access_key')
+        self.assertEqual(p.secret_key, 'env_secret_key')
+        self.assertEqual(p.security_token, 'env_security_token')
 
     def test_metadata_server_credentials(self):
         self.get_instance_metadata.return_value = INSTANCE_CONFIG


### PR DESCRIPTION
Support AWS_SECURITY_TOKEN environment variable and
aws_security_token in the config file.  Unit tests and doc change
included.  Ignored updating core/ as I assume core is abandoned in
favor of the separate botocore project.
