### PR TITLE
Remove unnecessary '?' from req.path on POST

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -498,7 +498,10 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
             # Safe to modify req.path here since
             # the signature will use req.auth_path.
             req.path = req.path.split('?')[0]
-            req.path = req.path + '?' + qs
+            
+            if qs:
+                # Don't insert the '?' unless there's actually a query string
+                req.path = req.path + '?' + qs
         canonical_request = self.canonical_request(req)
         boto.log.debug('CanonicalRequest:\n%s' % canonical_request)
         string_to_sign = self.string_to_sign(req, canonical_request)


### PR DESCRIPTION
The if/else logic in add_auth on line 491 only handles if qs and POST.

But if you're POSTing with no query string, execution falls into the else condition on line 497 and an unnecessary '?' is added with a blank query string.

My elastictranscoder.create_job calls were failing due to the unnecessary '?' in the path. It would return:

JSONResponseError: 403 Forbidden
{u'message': u"When Content-Type:application/x-www-form-urlencoded, URL cannot include query-string parameters (after '?'): '/2012-09-25/jobs?'"}

I'm not sure why, but the bug only happens when running on Google App Engine. My local dev_appserver was able to make the create_job request just fine.
