### PR TITLE
Properly handle getopt long options in s3put

### DIFF
--- a/bin/s3put
+++ b/bin/s3put
@@ -298,18 +298,18 @@ def main():
             aws_secret_access_key = a
         if o in ('-r', '--reduced'):
             reduced = True
-        if o in ('--header'):
+        if o == '--header':
             (k, v) = a.split("=", 1)
             headers[k] = v
-        if o in ('--host'):
+        if o == '--host':
             host = a
-        if o in ('--multipart'):
+        if o == '--multipart':
             if multipart_capable:
                 multipart_requested = True
             else:
                 print "multipart upload requested but not capable"
                 sys.exit(4)
-        if o in ('--region'):
+        if o == '--region':
             regions = boto.s3.regions()
             for region_info in regions:
                 if region_info.name == a:


### PR DESCRIPTION
Fixes #1946, where `-r` was mistakenly processed as if `--region` had been
passed because of incorrectly initialized tuples.

I checked all the other scripts in `bin` and this was the only one affected by this bug. @toastdriven please sanity check.
