### PR TITLE
Fix string parameter handling in S3Connection.

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -162,7 +162,7 @@ class S3Connection(AWSAuthConnection):
                  provider='aws', bucket_class=Bucket, security_token=None,
                  suppress_consec_slashes=True, anon=False,
                  validate_certs=None):
-        if isinstance(calling_format, str):
+        if isinstance(calling_format, basestring):
             calling_format=boto.utils.find_class(calling_format)()
         self.calling_format = calling_format
         self.bucket_class = bucket_class


### PR DESCRIPTION
I was initializing an S3 connection with the following parameter:

``` python
calling_format = u'boto.s3.connection.OrdinaryCallingFormat'
```

Which produced this error:

``` python
Traceback (most recent call last):
(...)
  File "/lib/python2.7/site-packages/boto-2.19.0-py2.7.egg/boto/s3/connection.py", line 495, in create_bucket
  File "/lib/python2.7/site-packages/boto-2.19.0-py2.7.egg/boto/s3/connection.py", line 533, in make_request
AttributeError: 'unicode' object has no attribute 'build_path_base'
```

To fix this issue, I had to replace my `calling_format` parameter by a pure string:

``` python
calling_format = 'boto.s3.connection.OrdinaryCallingFormat'
```

This patch fix string parameter comparison to always get the proper calling format class.
