### PR TITLE
Clarifying documentation for CloudWatchConnection.list_metrics().

### DIFF
--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -273,9 +273,13 @@ class CloudWatchConnection(AWSQueryConnection):
             pairs that will be used to filter the results.  The key in
             the dictionary is the name of a Dimension.  The value in
             the dictionary is either a scalar value of that Dimension
-            name that you want to filter on, a list of values to
-            filter on or None if you want all metrics with that
-            Dimension name.
+            name that you want to filter on or None if you want all
+            metrics with that Dimension name.  To be included in the
+            result a metric must contain all specified dimensions,
+            although the metric may contain additional dimensions beyond
+            the requested metrics.  The Dimension names, and values must
+            be strings between 1 and 250 characters long. A maximum of
+            10 dimensions are allowed.
 
         :type metric_name: str
         :param metric_name: The name of the Metric to filter against.  If None,


### PR DESCRIPTION
As far as I can tell, the CloudWatch API doesn't actually support the ability to specify multiple values for the same dimension.  In my experience, I only ever get results for one of the values listed.  For example, with:

``` python
conn=cloudwatch.connect_to_region("...")
conn.list_metrics(dimensions={"InstanceId": ["i-xxxxxxxx", "i-yyyyyyyy", "i-zzzzzzzz"]})
```

I only every get results for i-zzzzzzzz.

This brings documentation for CloudWatchConnection.list_metrics() in line with http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cli-mon-list-metrics.html, which demonstrates the same behavior.  i.e. `mon-list-metrics --namespace AWS/EC2 --dimensions "InstanceId=i-xxxxxxxx,InstanceId=i-yyyyyyyy,InstanceId=i-zzzzzzzz"` only returns results for i-zzzzzzzz.
