### PR TITLE
Add EC2 associate_address_object method

### DIFF
--- a/tests/unit/ec2/test_connection.py
+++ b/tests/unit/ec2/test_connection.py
@@ -1378,5 +1378,27 @@ class TestAssociateAddress(TestEC2ConnectionBase):
         self.assertEqual('eipassoc-fc5ca095', result.association_id)
 
 
+class TestAssociateAddressFail(TestEC2ConnectionBase):
+    def default_body(self):
+        return """
+            <Response>
+                <Errors>
+                     <Error>
+                       <Code>InvalidInstanceID.NotFound</Code>
+                       <Message>The instance ID 'i-4cbc822a' does not exist</Message>
+                     </Error>
+                </Errors>
+                <RequestID>ea966190-f9aa-478e-9ede-cb5432daacc0</RequestID>
+                <StatusCode>Failure</StatusCode>
+            </Response>
+        """
+
+    def test_associate_address(self):
+        self.set_http_response(status_code=200)
+        result = self.ec2.associate_address(instance_id='i-1234',
+                                            public_ip='192.0.2.1')
+        self.assertEqual(False, result)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #1874, #1893. Adds a test to make sure both methods work as expected.

@toastdriven, @msilvey please review.
