### PR TITLE
Populate both next_token and nextToken.

### DIFF
--- a/boto/resultset.py
+++ b/boto/resultset.py
@@ -119,6 +119,9 @@ class ResultSet(list):
             self.next_token = value
         elif name == 'nextToken':
             self.next_token = value
+            # Code exists which expects nextToken to be available, so we
+            # set it here to remain backwards-compatibile.
+            self.nextToken = value
         elif name == 'BoxUsage':
             try:
                 connection.box_usage += float(value)

--- a/tests/unit/ec2/test_spotinstance.py
+++ b/tests/unit/ec2/test_spotinstance.py
@@ -83,6 +83,8 @@ class TestGetSpotPriceHistory(AWSMockServiceTestCase):
         self.assertEqual(len(response), 2)
         self.assertEqual(response.next_token,
                          'q5GwEl5bMGjKq6YmhpDLJ7hEwyWU54jJC2GQ93n61vZV4s1+fzZ674xzvUlTihrl')
+        self.assertEqual(response.nextToken,
+                         'q5GwEl5bMGjKq6YmhpDLJ7hEwyWU54jJC2GQ93n61vZV4s1+fzZ674xzvUlTihrl')
         self.assertEqual(response[0].instance_type, 'c3.large')
         self.assertEqual(response[0].availability_zone, 'us-west-2c')
         self.assertEqual(response[1].instance_type, 'c3.large')
@@ -106,4 +108,3 @@ class TestGetSpotPriceHistory(AWSMockServiceTestCase):
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])
-        


### PR DESCRIPTION
Fixes #1968.

This bug was introduced due to an issue with how boto handled the nextToken
field in responses, which meant that it was exposed with the incorrect
name. The fix caused existing code to break, so now both versions are made
available. New code should use next_token.

@toastdriven, please review.
