### PR TITLE
Import with_statement for old Python versions

### DIFF
--- a/boto/glacier/concurrent.py
+++ b/boto/glacier/concurrent.py
@@ -19,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
+from __future__ import with_statement
+
 import os
 import math
 import threading


### PR DESCRIPTION
boto.glacier.concurrent doesn't work with older versions of Python lacking the with statement. Added an import from **future**.
