### PR TITLE
Add credential profiles to config

### DIFF
--- a/boto/beanstalk/layer1.py
+++ b/boto/beanstalk/layer1.py
@@ -40,7 +40,7 @@ class Layer1(AWSQueryConnection):
                  proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
-                 api_version=None, security_token=None):
+                 api_version=None, security_token=None, profile_name=None):
         if not region:
             region = RegionInfo(self, self.DefaultRegionName,
                                 self.DefaultRegionEndpoint)
@@ -51,7 +51,7 @@ class Layer1(AWSQueryConnection):
                                     proxy_user, proxy_pass,
                                     self.region.endpoint, debug,
                                     https_connection_factory, path,
-                                    security_token)
+                                    security_token, profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['hmac-v4']

--- a/boto/cloudformation/connection.py
+++ b/boto/cloudformation/connection.py
@@ -52,7 +52,8 @@ class CloudFormationConnection(AWSQueryConnection):
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
-                 converter=None, security_token=None, validate_certs=True):
+                 converter=None, security_token=None, validate_certs=True,
+                 profile_name=None):
         if not region:
             region = RegionInfo(self, self.DefaultRegionName,
                 self.DefaultRegionEndpoint, CloudFormationConnection)
@@ -64,7 +65,8 @@ class CloudFormationConnection(AWSQueryConnection):
                                     self.region.endpoint, debug,
                                     https_connection_factory, path,
                                     security_token,
-                                    validate_certs=validate_certs)
+                                    validate_certs=validate_certs,
+                                    profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['hmac-v4']

--- a/boto/cloudfront/__init__.py
+++ b/boto/cloudfront/__init__.py
@@ -43,12 +43,13 @@ class CloudFrontConnection(AWSAuthConnection):
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  port=None, proxy=None, proxy_port=None,
                  host=DefaultHost, debug=0, security_token=None,
-                 validate_certs=True):
+                 validate_certs=True, profile_name=None):
         super(CloudFrontConnection, self).__init__(host,
                                    aws_access_key_id, aws_secret_access_key,
                                    True, port, proxy, proxy_port, debug=debug,
                                    security_token=security_token,
-                                   validate_certs=validate_certs)
+                                   validate_certs=validate_certs, 
+                                   profile_name=profile_name)
 
     def get_etag(self, response):
         response_headers = response.msg

--- a/boto/cloudsearch/layer1.py
+++ b/boto/cloudsearch/layer1.py
@@ -46,7 +46,7 @@ class Layer1(AWSQueryConnection):
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
                  api_version=None, security_token=None,
-                 validate_certs=True):
+                 validate_certs=True, profile_name=None):
         if not region:
             region = RegionInfo(self, self.DefaultRegionName,
                                 self.DefaultRegionEndpoint)
@@ -66,7 +66,8 @@ class Layer1(AWSQueryConnection):
             https_connection_factory=https_connection_factory,
             path=path,
             security_token=security_token,
-            validate_certs=validate_certs)
+            validate_certs=validate_certs,
+            profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['hmac-v4']

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -423,7 +423,7 @@ class AWSAuthConnection(object):
                  https_connection_factory=None, path='/',
                  provider='aws', security_token=None,
                  suppress_consec_slashes=True,
-                 validate_certs=True):
+                 validate_certs=True, profile_name=None):
         """
         :type host: str
         :param host: The host to make the connection to
@@ -464,6 +464,10 @@ class AWSAuthConnection(object):
         :type validate_certs: bool
         :param validate_certs: Controls whether SSL certificates
             will be validated or not.  Defaults to True.
+
+        :type profile_name: str
+        :param profile_name: Override usual Credentials section in config
+            file to use a named set of keys instead.
         """
         self.suppress_consec_slashes = suppress_consec_slashes
         self.num_retries = 6
@@ -542,7 +546,8 @@ class AWSAuthConnection(object):
             self.provider = Provider(self._provider_type,
                                      aws_access_key_id,
                                      aws_secret_access_key,
-                                     security_token)
+                                     security_token,
+                                     profile_name)
 
         # Allow config file to override default host, port, and host header.
         if self.provider.host:
@@ -598,6 +603,10 @@ class AWSAuthConnection(object):
     aws_secret_access_key = property(aws_secret_access_key)
     gs_secret_access_key = aws_secret_access_key
     secret_key = aws_secret_access_key
+
+    def profile_name(self):
+        return self.provider.profile_name
+    profile_name = property(profile_name)
 
     def get_path(self, path='/'):
         # The default behavior is to suppress consecutive slashes for reasons
@@ -1033,14 +1042,15 @@ class AWSQueryConnection(AWSAuthConnection):
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, host=None, debug=0,
                  https_connection_factory=None, path='/', security_token=None,
-                 validate_certs=True):
+                 validate_certs=True, profile_name=None):
         super(AWSQueryConnection, self).__init__(host, aws_access_key_id,
                                    aws_secret_access_key,
                                    is_secure, port, proxy,
                                    proxy_port, proxy_user, proxy_pass,
                                    debug, https_connection_factory, path,
                                    security_token=security_token,
-                                   validate_certs=validate_certs)
+                                   validate_certs=validate_certs,
+                                   profile_name=profile_name)
 
     def _required_auth_capability(self):
         return []

--- a/boto/dynamodb/layer1.py
+++ b/boto/dynamodb/layer1.py
@@ -74,7 +74,7 @@ class Layer1(AWSAuthConnection):
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  debug=0, security_token=None, region=None,
-                 validate_certs=True, validate_checksums=True):
+                 validate_certs=True, validate_checksums=True, profile_name=None):
         if not region:
             region_name = boto.config.get('DynamoDB', 'region',
                                           self.DefaultRegionName)
@@ -89,7 +89,8 @@ class Layer1(AWSAuthConnection):
                                    aws_secret_access_key,
                                    is_secure, port, proxy, proxy_port,
                                    debug=debug, security_token=security_token,
-                                   validate_certs=validate_certs)
+                                   validate_certs=validate_certs,
+                                   profile_name=profile_name)
         self.throughput_exceeded_events = 0
         self._validate_checksums = boto.config.getbool(
             'DynamoDB', 'validate_checksums', validate_checksums)

--- a/boto/dynamodb/layer2.py
+++ b/boto/dynamodb/layer2.py
@@ -145,11 +145,13 @@ class Layer2(object):
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  debug=0, security_token=None, region=None,
-                 validate_certs=True, dynamizer=LossyFloatDynamizer):
+                 validate_certs=True, dynamizer=LossyFloatDynamizer,
+                 profile_name=None):
         self.layer1 = Layer1(aws_access_key_id, aws_secret_access_key,
                              is_secure, port, proxy, proxy_port,
                              debug, security_token, region,
-                             validate_certs=validate_certs)
+                             validate_certs=validate_certs,
+                             profile_name=profile_name)
         self.dynamizer = dynamizer()
 
     def use_decimals(self):

--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -104,7 +104,7 @@ class AutoScaleConnection(AWSQueryConnection):
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
-                 security_token=None, validate_certs=True):
+                 security_token=None, validate_certs=True, profile_name=None):
         """
         Init method to create a new connection to the AutoScaling service.
 
@@ -123,7 +123,8 @@ class AutoScaleConnection(AWSQueryConnection):
                                     self.region.endpoint, debug,
                                     https_connection_factory, path=path,
                                     security_token=security_token,
-                                    validate_certs=validate_certs)
+                                    validate_certs=validate_certs,
+                                    profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['hmac-v4']

--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -91,7 +91,7 @@ class CloudWatchConnection(AWSQueryConnection):
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
-                 security_token=None, validate_certs=True):
+                 security_token=None, validate_certs=True, profile_name=None):
         """
         Init method to create a new connection to EC2 Monitoring Service.
 
@@ -115,7 +115,8 @@ class CloudWatchConnection(AWSQueryConnection):
                                     self.region.endpoint, debug,
                                     https_connection_factory, path,
                                     security_token,
-                                    validate_certs=validate_certs)
+                                    validate_certs=validate_certs,
+                                    profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['hmac-v4']

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -83,7 +83,7 @@ class EC2Connection(AWSQueryConnection):
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
                  api_version=None, security_token=None,
-                 validate_certs=True):
+                 validate_certs=True, profile_name=None):
         """
         Init method to create a new connection to EC2.
         """
@@ -98,7 +98,8 @@ class EC2Connection(AWSQueryConnection):
                                     self.region.endpoint, debug,
                                     https_connection_factory, path,
                                     security_token,
-                                    validate_certs=validate_certs)
+                                    validate_certs=validate_certs,
+                                    profile_name=profile_name)
         if api_version:
             self.APIVersion = api_version
 

--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -92,7 +92,7 @@ class ELBConnection(AWSQueryConnection):
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
-                 security_token=None, validate_certs=True):
+                 security_token=None, validate_certs=True, profile_name=None):
         """
         Init method to create a new connection to EC2 Load Balancing Service.
 
@@ -110,7 +110,8 @@ class ELBConnection(AWSQueryConnection):
                                     self.region.endpoint, debug,
                                     https_connection_factory, path,
                                     security_token,
-                                    validate_certs=validate_certs)
+                                    validate_certs=validate_certs,
+                                    profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['ec2']

--- a/boto/ecs/__init__.py
+++ b/boto/ecs/__init__.py
@@ -41,10 +41,11 @@ class ECSConnection(AWSQueryConnection):
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, host='ecs.amazonaws.com',
-                 debug=0, https_connection_factory=None, path='/'):
+                 debug=0, https_connection_factory=None, path='/', profile_name=None):
         super(ECSConnection, self).__init__(aws_access_key_id, aws_secret_access_key,
                                     is_secure, port, proxy, proxy_port, proxy_user, proxy_pass,
-                                    host, debug, https_connection_factory, path)
+                                    host, debug, https_connection_factory, path,
+                                    profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['ecs']

--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -55,7 +55,7 @@ class EmrConnection(AWSQueryConnection):
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
-                 security_token=None, validate_certs=True):
+                 security_token=None, validate_certs=True, profile_name=None):
         if not region:
             region = RegionInfo(self, self.DefaultRegionName,
                                 self.DefaultRegionEndpoint)
@@ -67,7 +67,8 @@ class EmrConnection(AWSQueryConnection):
                                     self.region.endpoint, debug,
                                     https_connection_factory, path,
                                     security_token,
-                                    validate_certs=validate_certs)
+                                    validate_certs=validate_certs,
+                                    profile_name=profile_name)
         # Many of the EMR hostnames are of the form:
         #     <region>.<service_name>.amazonaws.com
         # rather than the more common:

--- a/boto/glacier/layer1.py
+++ b/boto/glacier/layer1.py
@@ -44,7 +44,8 @@ class Layer1(AWSAuthConnection):
                  https_connection_factory=None, path='/',
                  provider='aws', security_token=None,
                  suppress_consec_slashes=True,
-                 region=None, region_name='us-east-1'):
+                 region=None, region_name='us-east-1',
+                 profile_name=None):
 
         if not region:
             for reg in boto.glacier.regions():
@@ -60,7 +61,7 @@ class Layer1(AWSAuthConnection):
                                    proxy_user, proxy_pass, debug,
                                    https_connection_factory,
                                    path, provider, security_token,
-                                   suppress_consec_slashes)
+                                   suppress_consec_slashes, profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['hmac-v4']

--- a/boto/iam/connection.py
+++ b/boto/iam/connection.py
@@ -40,15 +40,16 @@ class IAMConnection(AWSQueryConnection):
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, host='iam.amazonaws.com',
-                 debug=0, https_connection_factory=None,
-                 path='/', security_token=None, validate_certs=True):
+                 debug=0, https_connection_factory=None, path='/', 
+                 security_token=None, validate_certs=True, profile_name=None):
         super(IAMConnection, self).__init__(aws_access_key_id,
                                     aws_secret_access_key,
                                     is_secure, port, proxy,
                                     proxy_port, proxy_user, proxy_pass,
                                     host, debug, https_connection_factory,
                                     path, security_token,
-                                    validate_certs=validate_certs)
+                                    validate_certs=validate_certs,
+                                    profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['hmac-v4']

--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -46,7 +46,7 @@ class MTurkConnection(AWSQueryConnection):
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None,
                  host=None, debug=0,
-                 https_connection_factory=None):
+                 https_connection_factory=None, profile_name=None):
         if not host:
             if config.has_option('MTurk', 'sandbox') and config.get('MTurk', 'sandbox') == 'True':
                 host = 'mechanicalturk.sandbox.amazonaws.com'
@@ -58,7 +58,7 @@ class MTurkConnection(AWSQueryConnection):
                                     aws_secret_access_key,
                                     is_secure, port, proxy, proxy_port,
                                     proxy_user, proxy_pass, host, debug,
-                                    https_connection_factory)
+                                    https_connection_factory, profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['mturk']

--- a/boto/provider.py
+++ b/boto/provider.py
@@ -165,18 +165,19 @@ class Provider(object):
     }
 
     def __init__(self, name, access_key=None, secret_key=None,
-                 security_token=None):
+                 security_token=None, profile_name=None):
         self.host = None
         self.port = None
         self.host_header = None
         self.access_key = access_key
         self.secret_key = secret_key
         self.security_token = security_token
+        self.profile_name = profile_name
         self.name = name
         self.acl_class = self.AclClassMap[self.name]
         self.canned_acls = self.CannedAclsMap[self.name]
         self._credential_expiry_time = None
-        self.get_credentials(access_key, secret_key)
+        self.get_credentials(access_key, secret_key, profile_name)
         self.configure_headers()
         self.configure_errors()
         # Allow config file to override default host and port.
@@ -239,7 +240,7 @@ class Provider(object):
             else:
                 return False
 
-    def get_credentials(self, access_key=None, secret_key=None):
+    def get_credentials(self, access_key=None, secret_key=None, profile_name=None):
         access_key_name, secret_key_name = self.CredentialMap[self.name]
         if access_key is not None:
             self.access_key = access_key
@@ -247,6 +248,9 @@ class Provider(object):
         elif access_key_name.upper() in os.environ:
             self.access_key = os.environ[access_key_name.upper()]
             boto.log.debug("Using access key found in environment variable.")
+        elif config.has_option("profile %s" % profile_name, access_key_name):
+            self.access_key = config.get("profile %s" % profile_name, access_key_name)
+            boto.log.debug("Using access key found in config file: profile %s." % profile_name)
         elif config.has_option('Credentials', access_key_name):
             self.access_key = config.get('Credentials', access_key_name)
             boto.log.debug("Using access key found in config file.")
@@ -257,6 +261,9 @@ class Provider(object):
         elif secret_key_name.upper() in os.environ:
             self.secret_key = os.environ[secret_key_name.upper()]
             boto.log.debug("Using secret key found in environment variable.")
+        elif config.has_option("profile %s" % profile_name, secret_key_name):
+            self.secret_key = config.get("profile %s" % profile_name, secret_key_name)
+            boto.log.debug("Using secret key found in config file: profile %s." % profile_name)
         elif config.has_option('Credentials', secret_key_name):
             self.secret_key = config.get('Credentials', secret_key_name)
             boto.log.debug("Using secret key found in config file.")

--- a/boto/rds/__init__.py
+++ b/boto/rds/__init__.py
@@ -94,7 +94,8 @@ class RDSConnection(AWSQueryConnection):
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
-                 security_token=None, validate_certs=True):
+                 security_token=None, validate_certs=True,
+                 profile_name=None):
         if not region:
             region = RDSRegionInfo(self, self.DefaultRegionName,
                                    self.DefaultRegionEndpoint)
@@ -106,7 +107,8 @@ class RDSConnection(AWSQueryConnection):
                                     self.region.endpoint, debug,
                                     https_connection_factory, path,
                                     security_token,
-                                    validate_certs=validate_certs)
+                                    validate_certs=validate_certs,
+                                    profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['hmac-v4']

--- a/boto/route53/connection.py
+++ b/boto/route53/connection.py
@@ -63,13 +63,15 @@ class Route53Connection(AWSAuthConnection):
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  port=None, proxy=None, proxy_port=None,
                  host=DefaultHost, debug=0, security_token=None,
-                 validate_certs=True, https_connection_factory=None):
+                 validate_certs=True, https_connection_factory=None,
+                 profile_name=None):
         super(Route53Connection, self).__init__(host,
                                    aws_access_key_id, aws_secret_access_key,
                                    True, port, proxy, proxy_port, debug=debug,
                                    security_token=security_token,
                                    validate_certs=validate_certs,
-                                   https_connection_factory=https_connection_factory)
+                                   https_connection_factory=https_connection_factory,
+                                   profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['route53']

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -161,7 +161,7 @@ class S3Connection(AWSAuthConnection):
                  calling_format=DefaultCallingFormat, path='/',
                  provider='aws', bucket_class=Bucket, security_token=None,
                  suppress_consec_slashes=True, anon=False,
-                 validate_certs=None):
+                 validate_certs=None, profile_name=None):
         if isinstance(calling_format, basestring):
             calling_format=boto.utils.find_class(calling_format)()
         self.calling_format = calling_format
@@ -173,7 +173,7 @@ class S3Connection(AWSAuthConnection):
                 debug=debug, https_connection_factory=https_connection_factory,
                 path=path, provider=provider, security_token=security_token,
                 suppress_consec_slashes=suppress_consec_slashes,
-                validate_certs=validate_certs)
+                validate_certs=validate_certs, profile_name=profile_name)
 
     @detect_potential_s3sigv4
     def _required_auth_capability(self):

--- a/boto/sdb/connection.py
+++ b/boto/sdb/connection.py
@@ -86,7 +86,8 @@ class SDBConnection(AWSQueryConnection):
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
-                 converter=None, security_token=None, validate_certs=True):
+                 converter=None, security_token=None, validate_certs=True,
+                 profile_name=None):
         """
         For any keywords that aren't documented, refer to the parent class,
         :py:class:`boto.connection.AWSAuthConnection`. You can avoid having
@@ -118,7 +119,8 @@ class SDBConnection(AWSQueryConnection):
                                     self.region.endpoint, debug,
                                     https_connection_factory, path,
                                     security_token=security_token,
-                                    validate_certs=validate_certs)
+                                    validate_certs=validate_certs,
+                                    profile_name=profile_name)
         self.box_usage = 0.0
         self.converter = converter
         self.item_cls = Item

--- a/boto/ses/connection.py
+++ b/boto/ses/connection.py
@@ -42,7 +42,7 @@ class SESConnection(AWSAuthConnection):
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
-                 security_token=None, validate_certs=True):
+                 security_token=None, validate_certs=True, profile_name=None):
         if not region:
             region = RegionInfo(self, self.DefaultRegionName,
                                 self.DefaultRegionEndpoint)
@@ -53,7 +53,8 @@ class SESConnection(AWSAuthConnection):
                                    proxy_user, proxy_pass, debug,
                                    https_connection_factory, path,
                                    security_token=security_token,
-                                   validate_certs=validate_certs)
+                                   validate_certs=validate_certs,
+                                   profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['ses']

--- a/boto/sns/connection.py
+++ b/boto/sns/connection.py
@@ -56,7 +56,8 @@ class SNSConnection(AWSQueryConnection):
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
-                 security_token=None, validate_certs=True):
+                 security_token=None, validate_certs=True,
+                 profile_name=None):
         if not region:
             region = RegionInfo(self, self.DefaultRegionName,
                                 self.DefaultRegionEndpoint,
@@ -69,7 +70,8 @@ class SNSConnection(AWSQueryConnection):
                                     self.region.endpoint, debug,
                                     https_connection_factory, path,
                                     security_token=security_token,
-                                    validate_certs=validate_certs)
+                                    validate_certs=validate_certs,
+                                    profile_name=profile_name)
 
     def _build_dict_as_list_params(self, params, dictionary, name):
       """

--- a/boto/sts/connection.py
+++ b/boto/sts/connection.py
@@ -70,7 +70,7 @@ class STSConnection(AWSQueryConnection):
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
                  converter=None, validate_certs=True, anon=False,
-                 security_token=None):
+                 security_token=None, profile_name=None):
         if not region:
             region = RegionInfo(self, self.DefaultRegionName,
                                 self.DefaultRegionEndpoint,
@@ -85,7 +85,8 @@ class STSConnection(AWSQueryConnection):
                                     self.region.endpoint, debug,
                                     https_connection_factory, path,
                                     validate_certs=validate_certs,
-                                    security_token=security_token)
+                                    security_token=security_token,
+                                    profile_name=profile_name)
 
     def _required_auth_capability(self):
         if self.anon:

--- a/boto/swf/layer1.py
+++ b/boto/swf/layer1.py
@@ -69,7 +69,7 @@ class Layer1(AWSAuthConnection):
 
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,
-                 debug=0, session_token=None, region=None):
+                 debug=0, session_token=None, region=None, profile_name=None):
         if not region:
             region_name = boto.config.get('SWF', 'region',
                                           self.DefaultRegionName)
@@ -82,7 +82,7 @@ class Layer1(AWSAuthConnection):
         super(Layer1, self).__init__(self.region.endpoint,
                                    aws_access_key_id, aws_secret_access_key,
                                    is_secure, port, proxy, proxy_port,
-                                   debug, session_token)
+                                   debug, session_token, profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['hmac-v4']

--- a/docs/source/boto_config_tut.rst
+++ b/docs/source/boto_config_tut.rst
@@ -52,9 +52,10 @@ Credentials
 The Credentials section is used to specify the AWS credentials used for all
 boto requests. The order of precedence for authentication credentials is:
 
-* Credentials passed into Connection class constructor.
+* Credentials passed into the Connection class constructor.
 * Credentials specified by environment variables
-* Credentials specified as options in the config file.
+* Credentials specified as named profiles in the config file.
+* Credentials specified by default in the config file.
 
 This section defines the following options: ``aws_access_key_id`` and
 ``aws_secret_access_key``. The former being your AWS key id and the latter
@@ -62,12 +63,23 @@ being the secret key.
 
 For example::
 
+    [profile name_goes_here]
+    aws_access_key_id = <access key for this profile>
+    aws_secret_access_key = <secret key for this profile>
+
     [Credentials]
-    aws_access_key_id = <your access key>
-    aws_secret_access_key = <your secret key>
+    aws_access_key_id = <your default access key>
+    aws_secret_access_key = <your default secret key>
 
 Please notice that quote characters are not used to either side of the '='
-operator even when both your AWS access key id and secret key are strings.
+operator even when both your AWS access key ID and secret key are strings.
+
+If you have multiple AWS keypairs that you use for different purposes,
+use the ``profile`` style shown above. You can set an arbitrary number
+of profiles within your configuration files and then reference them by name
+when you instantiate your connection. If you specify a profile that does not
+exist in the configuration, the keys used under the ``[Credentials]`` heading
+will be applied by default.
 
 For greater security, the secret key can be stored in a keyring and
 retrieved via the keyring package.  To use a keyring, use ``keyring``,

--- a/tests/unit/provider/test_provider.py
+++ b/tests/unit/provider/test_provider.py
@@ -71,6 +71,29 @@ class TestProvider(unittest.TestCase):
         self.assertEqual(p.secret_key, 'env_secret_key')
         self.assertIsNone(p.security_token)
 
+    def test_config_profile_values_are_used(self):
+        self.config = {
+            'profile dev': {
+                'aws_access_key_id': 'dev_access_key',
+                'aws_secret_access_key': 'dev_secret_key',
+            }, 'profile prod': {
+                'aws_access_key_id': 'prod_access_key',
+                'aws_secret_access_key': 'prod_secret_key',
+            }, 'Credentials': {
+                'aws_access_key_id': 'default_access_key',
+                'aws_secret_access_key': 'default_secret_key'
+            }
+        }
+        p = provider.Provider('aws', profile_name='prod')
+        self.assertEqual(p.access_key, 'prod_access_key')
+        self.assertEqual(p.secret_key, 'prod_secret_key')
+        q = provider.Provider('aws', profile_name='dev')
+        self.assertEqual(q.access_key, 'dev_access_key')
+        self.assertEqual(q.secret_key, 'dev_secret_key')
+        r = provider.Provider('aws', profile_name='doesntexist')
+        self.assertEqual(r.access_key, 'default_access_key')
+        self.assertEqual(r.secret_key, 'default_secret_key')
+
     def test_config_values_are_used(self):
         self.config = {
             'Credentials': {

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -82,7 +82,7 @@ class MockAWSService(AWSQueryConnection):
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
                  api_version=None, security_token=None,
-                 validate_certs=True):
+                 validate_certs=True, profile_name=None):
         self.region = region
         if host is None:
             host = self.region.endpoint
@@ -93,7 +93,8 @@ class MockAWSService(AWSQueryConnection):
                                     host, debug,
                                     https_connection_factory, path,
                                     security_token,
-                                    validate_certs=validate_certs)
+                                    validate_certs=validate_certs,
+                                    profile_name=profile_name)
 
 class TestAWSAuthConnection(unittest.TestCase):
     def test_get_path(self):


### PR DESCRIPTION
This expands upon the existing configuration options in ~/.boto and /etc/boto.cfg. Instead of allowing a single set of keys under the [Credentials] heading, we allow an arbitrary amount of keypairs via headers like [profile name_of_credentials].

These can be accessed through any of the classes that use AWSAuthConnection or AWSQueryConnection - I think I've found them all. There's now a parameter passed to the instantiator called profile_name.

If the user specifies a profile name that doesn't exist at present, or does not specify one, we default to the [Credentials] section as before. This renders the change backward compatible.

This request is on a new branch, but it is in follow-up to #1903 which I have now closed.
