### PR TITLE
Updated conn params for security_token.

### DIFF
--- a/boto/ecs/__init__.py
+++ b/boto/ecs/__init__.py
@@ -41,10 +41,12 @@ class ECSConnection(AWSQueryConnection):
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, host='ecs.amazonaws.com',
-                 debug=0, https_connection_factory=None, path='/', profile_name=None):
+                 debug=0, https_connection_factory=None, path='/',
+                 security_token=None, profile_name=None):
         super(ECSConnection, self).__init__(aws_access_key_id, aws_secret_access_key,
                                     is_secure, port, proxy, proxy_port, proxy_user, proxy_pass,
                                     host, debug, https_connection_factory, path,
+                                    security_token=security_token,
                                     profile_name=profile_name)
 
     def _required_auth_capability(self):

--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -46,7 +46,8 @@ class MTurkConnection(AWSQueryConnection):
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None,
                  host=None, debug=0,
-                 https_connection_factory=None, profile_name=None):
+                 https_connection_factory=None, security_token=None,
+                 profile_name=None):
         if not host:
             if config.has_option('MTurk', 'sandbox') and config.get('MTurk', 'sandbox') == 'True':
                 host = 'mechanicalturk.sandbox.amazonaws.com'
@@ -58,7 +59,9 @@ class MTurkConnection(AWSQueryConnection):
                                     aws_secret_access_key,
                                     is_secure, port, proxy, proxy_port,
                                     proxy_user, proxy_pass, host, debug,
-                                    https_connection_factory, profile_name=profile_name)
+                                    https_connection_factory,
+                                    security_token=security_token,
+                                    profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['mturk']


### PR DESCRIPTION
Fills in the only places `security_token` wasn't previously being passed. Finishes #1942.

Review please (no rush)? @danielgtaylor
