### PR TITLE
Return the x-amz-restore header with GET KEY and fix provider prefix.

### DIFF
--- a/boto/provider.py
+++ b/boto/provider.py
@@ -57,6 +57,7 @@ STORAGE_CLASS_HEADER_KEY = 'storage-class'
 MFA_HEADER_KEY = 'mfa-header'
 SERVER_SIDE_ENCRYPTION_KEY = 'server-side-encryption-header'
 VERSION_ID_HEADER_KEY = 'version-id-header'
+RESTORE_HEADER_KEY = 'restore-header'
 
 STORAGE_COPY_ERROR = 'StorageCopyError'
 STORAGE_CREATE_ERROR = 'StorageCreateError'
@@ -124,6 +125,7 @@ class Provider(object):
             VERSION_ID_HEADER_KEY: AWS_HEADER_PREFIX + 'version-id',
             STORAGE_CLASS_HEADER_KEY: AWS_HEADER_PREFIX + 'storage-class',
             MFA_HEADER_KEY: AWS_HEADER_PREFIX + 'mfa',
+            RESTORE_HEADER_KEY: AWS_HEADER_PREFIX + 'restore',
         },
         'google': {
             HEADER_PREFIX_KEY: GOOG_HEADER_PREFIX,
@@ -146,6 +148,7 @@ class Provider(object):
             VERSION_ID_HEADER_KEY: GOOG_HEADER_PREFIX + 'version-id',
             STORAGE_CLASS_HEADER_KEY: None,
             MFA_HEADER_KEY: None,
+            RESTORE_HEADER_KEY: None,
         }
     }
 
@@ -355,6 +358,7 @@ class Provider(object):
         self.storage_class_header = header_info_map[STORAGE_CLASS_HEADER_KEY]
         self.version_id = header_info_map[VERSION_ID_HEADER_KEY]
         self.mfa_header = header_info_map[MFA_HEADER_KEY]
+        self.restore_header = header_info_map[RESTORE_HEADER_KEY]
 
     def configure_errors(self):
         error_map = self.ErrorMap[self.name]

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -217,7 +217,8 @@ class Key(object):
             self.delete_marker = False
 
     def handle_restore_headers(self, response):
-        header = response.getheader('x-amz-restore')
+        provider = self.bucket.connection.provider
+        header = response.getheader(provider.restore_header)
         if header is None:
             return
         parts = header.split(',', 1)
@@ -299,6 +300,7 @@ class Key(object):
                     self.content_disposition = value
             self.handle_version_headers(self.resp)
             self.handle_encryption_headers(self.resp)
+            self.handle_restore_headers(self.resp)
             self.handle_addl_headers(self.resp.getheaders())
 
     def open_write(self, headers=None, override_num_retries=None):


### PR DESCRIPTION
Currently x-amz-restore is only supported by HEAD KEY but GET KEY also
returns the header when it has been successfully restored and the
restored key is awaiting expiry. Fixed the provider 'x-amz-' prefix
part so that it's consistent with other standard headers. Previously,
it was hardcoded.

This patch is hard to automate a test for as transitioning to GLACIER
and restoring back from GLACIER both take time. This change has been
manually tested.
