### PR TITLE
Add support for configuring SNS and SQS endpoints through boto.cfg

### DIFF
--- a/boto/sns/connection.py
+++ b/boto/sns/connection.py
@@ -48,9 +48,11 @@ class SNSConnection(AWSQueryConnection):
     requests, and handling error responses. For a list of available
     SDKs, go to `Tools for Amazon Web Services`_.
     """
-    DefaultRegionName = 'us-east-1'
-    DefaultRegionEndpoint = 'sns.us-east-1.amazonaws.com'
-    APIVersion = '2010-03-31'
+    DefaultRegionName = boto.config.get('Boto', 'sns_region_name', 'us-east-1')
+    DefaultRegionEndpoint = boto.config.get('Boto', 'sns_region_endpoint', 
+                                            'sns.us-east-1.amazonaws.com')
+    APIVersion = boto.config.get('Boto', 'sns_version', '2010-03-31')
+
 
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,

--- a/boto/sqs/connection.py
+++ b/boto/sqs/connection.py
@@ -32,9 +32,10 @@ class SQSConnection(AWSQueryConnection):
     """
     A Connection to the SQS Service.
     """
-    DefaultRegionName = 'us-east-1'
-    DefaultRegionEndpoint = 'queue.amazonaws.com'
-    APIVersion = '2012-11-05'
+    DefaultRegionName = boto.config.get('Boto', 'sqs_region_name', 'us-east-1')
+    DefaultRegionEndpoint = boto.config.get('Boto', 'sqs_region_endpoint', 
+                                            'queue.amazonaws.com')
+    APIVersion = boto.config.get('Boto', 'sqs_version', '2012-11-05')
     DefaultContentType = 'text/plain'
     ResponseError = SQSError
     AuthServiceName = 'sqs'


### PR DESCRIPTION
This change adds calls to boto.config.get in sns/connection.py and sqs/connection.py to set DefaultRegionName, DefaultRegionEndpoint, and APIVersion in those modules.  It follows the pattern in ec2/connection.py and uses same defaults that were hardcoded prior to this change.
