### PR TITLE
elbadmin dies if terminated, non-extant instances are present in an ELB

### DIFF
--- a/bin/elbadmin
+++ b/bin/elbadmin
@@ -117,9 +117,10 @@ def get(elb, name):
         instance_health = b.get_instance_health()
         instances = [state.instance_id for state in instance_health]
 
-        names = {}
-        for i in ec2.get_only_instances(instances):
-            names[i.id] = i.tags.get('Name', '')
+        names = dict((k,'') for k in instances)
+        for i in ec2.get_only_instances():
+            if i.id in instances:
+                names[i.id] = i.tags.get('Name', '')
 
         name_column_width = max([4] + [len(v) for k,v in names.iteritems()]) + 2
 


### PR DESCRIPTION
43c9d71ab241a47cd8a5d2caebc368fcbeff7b65 added printing of the `Name` tag for instances in an ELB.  7de7ca16a5e672bdf5251eb7204caa0bf9a39e2c changed that new feature to only pull `Name` tags for instances in the ELB.  However, terminated instances can remain in an ELB.  Terminated instances can be queried for a time, but querying them eventually returns a 400 error of `Client.InvalidInstanceID.NotFound`.

This patch reverts to enumerating all instances, but only requests the Name tag for extant instances.  This is likely more reliable than, say, relying on the `Instance is in terminated state.` message.

`elbadmin` has no tests, so no test is added for this change.
