### PR TITLE
Fix boto import for elbadmin invocations without a region

### DIFF
--- a/bin/elbadmin
+++ b/bin/elbadmin
@@ -108,10 +108,10 @@ def get(elb, name):
         print
 
         # Make map of all instance Id's to Name tags
+        import boto
         if not options.region:
             ec2 = boto.connect_ec2()
         else:
-            import boto.ec2.elb
             ec2 = boto.ec2.connect_to_region(options.region)
 
         instance_health = b.get_instance_health()


### PR DESCRIPTION
I have no idea how invocations of `elbadmin` are working when `-r` is not passed after the merge of 2ffbc602ddc4ed97bc7939375af0984a526ceba8.  There must be some change in boto itself I have not tracked down.  Perhaps I am just mistaken.
