### PR TITLE
Added ``validate`` kwarg to ``Bucket.get_key``.

### DIFF
--- a/docs/source/s3_tut.rst
+++ b/docs/source/s3_tut.rst
@@ -143,6 +143,24 @@ guessing.  The other thing to note is that boto does stream the content
 to and from S3 so you should be able to send and receive large files without
 any problem.
 
+When fetching a key that has already exists, you have two options. If you're
+uncertain whether a key exists (or if you need the metadata set on it, you can
+call ``Bucket.get_key(key_name_here)``. However, if you're sure a key already
+exists within a bucket, you can skip the check for a key on the server.
+
+::
+
+    >>> import boto
+    >>> c = boto.connect_s3()
+    >>> b = c.get_bucket('mybucket') # substitute your bucket name here
+
+    # Will hit the API to check if it exists.
+    >>> possible_key = b.get_key('mykey') # substitute your key name here
+
+    # Won't hit the API.
+    >>> key_we_know_is_there = b.get_key(validate=False)
+
+
 Accessing A Bucket
 ------------------
 

--- a/tests/unit/s3/test_bucket.py
+++ b/tests/unit/s3/test_bucket.py
@@ -4,6 +4,7 @@ from mock import patch
 from tests.unit import unittest
 from tests.unit import AWSMockServiceTestCase
 
+from boto.exception import BotoClientError
 from boto.s3.connection import S3Connection
 from boto.s3.bucket import Bucket
 from boto.s3.deletemarker import DeleteMarker
@@ -176,3 +177,21 @@ class TestS3Bucket(AWSMockServiceTestCase):
             ], 'uploads', None,
             encoding_type='url'
         )
+
+    @patch.object(Bucket, 'get_all_keys')
+    @patch.object(Bucket, '_get_key_internal')
+    def test_bucket_get_key_no_validate(self, mock_gki, mock_gak):
+        self.set_http_response(status_code=200)
+        bucket = self.service_connection.get_bucket('mybucket')
+        key = bucket.get_key('mykey', validate=False)
+
+        self.assertEqual(len(mock_gki.mock_calls), 0)
+        self.assertTrue(isinstance(key, Key))
+        self.assertEqual(key.name, 'mykey')
+
+        with self.assertRaises(BotoClientError):
+            bucket.get_key(
+                'mykey',
+                version_id='something',
+                validate=False
+            )


### PR DESCRIPTION
This allows the user to avoid hitting the service if they know a key already exists.
Fixes #1996.

Review please? @danielgtaylor
