### PR TITLE
Renamed test with duplicated name

### DIFF
--- a/tests/unit/ec2/test_blockdevicemapping.py
+++ b/tests/unit/ec2/test_blockdevicemapping.py
@@ -65,7 +65,7 @@ class BlockDeviceMappingTests(unittest.TestCase):
         retval = self.block_device_mapping.startElement("virtualName", None, None)
         assert self.block_device_type_eq(retval, BlockDeviceType(self.block_device_mapping))
 
-    def test_endElement_with_name_device_sets_current_name(self):
+    def test_endElement_with_name_device_sets_current_name_dev_null(self):
         self.block_device_mapping.endElement("device", "/dev/null", None)
         self.assertEqual(self.block_device_mapping.current_name, "/dev/null")
 


### PR DESCRIPTION
There's two unit tests with the same name in the same class so only one of them gets to run.

Renaming one of the unit tests means that both of them will run.
