### PR TITLE
test_refresh_credentials(): use UTC instead of local time.

### DIFF
--- a/tests/unit/provider/test_provider.py
+++ b/tests/unit/provider/test_provider.py
@@ -196,7 +196,7 @@ class TestProvider(unittest.TestCase):
             'meta-data/iam/security-credentials/')
 
     def test_refresh_credentials(self):
-        now = datetime.now()
+        now = datetime.utcnow()
         first_expiration = (now + timedelta(seconds=10)).strftime(
             "%Y-%m-%dT%H:%M:%SZ")
         credentials = {


### PR DESCRIPTION
In test_refresh_credentials(), datetime.now() is used to set the
_credential_expiry_time field of a provider. This value is later compared to
the result of datetime.utcnow() in _credentials_need_refresh(). This comparison
is meaningless. Use datetime.utcnow() in test_refresh_credentials() to fix
this.
