### PR TITLE
Fixed typo in Table.create example

### DIFF
--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -170,7 +170,7 @@ class Table(object):
             ...     ],
             ...     throughput={
             ...       'read':10,
-            ...       'write":10,
+            ...       'write':10,
             ...     }),
             ... ])
 


### PR DESCRIPTION
This is a teeny tiny typo, but it's in an annoying place...
