### PR TITLE
Fixes #2028: LaunchConfiguration does not retrieve AssociatePublicIpAddress properly

### DIFF
--- a/boto/ec2/autoscale/launchconfig.py
+++ b/boto/ec2/autoscale/launchconfig.py
@@ -223,6 +223,8 @@ class LaunchConfiguration(object):
             self.instance_profile_name = value
         elif name == 'EbsOptimized':
             self.ebs_optimized = True if value.lower() == 'true' else False
+        elif name == 'AssociatePublicIpAddress':
+            self.associate_public_ip_address = True if value.lower() == 'true' else False
         elif name == 'VolumeType':
             self.volume_type = value
         elif name == 'DeleteOnTermination':


### PR DESCRIPTION
Pull request #1799 added support to AssociatePublicIpAddress, but it added only support for sending that parameter. Retrieval was not fully supported yet.

This pull request is a ripoff of pull request #1832: https://github.com/boto/boto/pull/1832/files#diff-8c9af36969b22e4d4bb34924adc35399R105

I didn't add tests because I couldn't find an example and I am not familiar with boto's codebase.
