### PR TITLE
Fixed EMR's describe_cluster_command

### DIFF
--- a/boto/emr/emrobject.py
+++ b/boto/emr/emrobject.py
@@ -262,11 +262,12 @@ class Cluster(EmrObject):
         if name == 'Status':
             self.status = ClusterStatus()
             return self.status
-        elif name == 'EC2InstanceAttributes':
+        elif name == 'Ec2InstanceAttributes':
             self.ec2instanceattributes = Ec2InstanceAttributes()
             return self.ec2instanceattributes
         elif name == 'Applications':
             self.applications = ResultSet([('member', Application)])
+            return self.applications
         elif name == 'Tags':
             self.tags = ResultSet([('member', KeyValue)])
             return self.tags


### PR DESCRIPTION
There's two bugs being fixed in this command:
- It should be Ec2InstanceAttributes rather than EC2InstanceAttributes according to the docs and what's returned by the API (http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_Cluster.html)
- Parsed Applications weren't being returned which was confusing the parser, and causing some data to go missing.
