### PR TITLE
Prevent implicit string decode in hmac-v4 handlers.

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -329,7 +329,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         parameter_names = sorted(http_request.params.keys())
         pairs = []
         for pname in parameter_names:
-            pval = str(http_request.params[pname]).encode('utf-8')
+            pval = boto.utils.get_utf8_value(http_request.params[pname])
             pairs.append(urllib.quote(pname, safe='') + '=' +
                          urllib.quote(pval, safe='-_~'))
         return '&'.join(pairs)
@@ -341,7 +341,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
             return ""
         l = []
         for param in sorted(http_request.params):
-            value = str(http_request.params[param])
+            value = boto.utils.get_utf8_value(http_request.params[param])
             l.append('%s=%s' % (urllib.quote(param, safe='-_.~'),
                                 urllib.quote(value, safe='-_.~')))
         return '&'.join(l)

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -64,6 +64,18 @@ class TestSigV4Handler(unittest.TestCase):
         query_string = auth.canonical_query_string(request)
         self.assertEqual(query_string, 'Foo.1=aaa&Foo.10=zzz')
 
+    def test_query_string(self):
+        auth = HmacAuthV4Handler('sns.us-east-1.amazonaws.com',
+                                 Mock(), self.provider)
+        params = {
+            'Message': u'We \u2665 utf-8'.encode('utf-8'),
+        }
+        request = HTTPRequest(
+            'POST', 'https', 'sns.us-east-1.amazonaws.com', 443,
+            '/', None, params, {}, '')
+        query_string = auth.query_string(request)
+        self.assertEqual(query_string, 'Message=We%20%E2%99%A5%20utf-8')
+
     def test_canonical_uri(self):
         auth = HmacAuthV4Handler('glacier.us-east-1.amazonaws.com',
                                  Mock(), self.provider)

--- a/tests/unit/sns/test_connection.py
+++ b/tests/unit/sns/test_connection.py
@@ -225,6 +225,17 @@ class TestSNSConnection(AWSMockServiceTestCase):
             'MessageStructure': 'json',
         }, ignore_params_values=['Version', 'ContentType'])
 
+    def test_publish_with_utf8_message(self):
+        self.set_http_response(status_code=200)
+        subject = message = u'We \u2665 utf-8'.encode('utf-8')
+        self.service_connection.publish('topic', message, subject)
+        self.assert_request_parameters({
+            'Action': 'Publish',
+            'TopicArn': 'topic',
+            'Subject': subject,
+            'Message': message,
+        }, ignore_params_values=['Version', 'ContentType'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is an attempt to fix #2033, but also fixes an important bug in hmac-v4 auth handler that prevents using it with non-ascii values.

the premise is that doing the following is a mistake, as the result of str() is already an encoded string (in python 2)

``` pycon
>>> str(u'\xf1'.encode('utf-8')).encode('utf8')
---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
<ipython-input-8-1b7de61b9d5b> in <module>()
----> 1 str(u'\xf1'.encode('utf-8')).encode('utf8')

UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
```
