### PR TITLE
check whether query_auth is true before adding x-amz-security-token when run using an IAM role

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -347,8 +347,9 @@ class S3Connection(AWSAuthConnection):
         if response_headers:
             for k, v in response_headers.items():
                 extra_qp.append("%s=%s" % (k, urllib.quote(v)))
-        if self.provider.security_token:
-            headers['x-amz-security-token'] = self.provider.security_token
+        if query_auth:
+            if self.provider.security_token:
+                headers['x-amz-security-token'] = self.provider.security_token
         if extra_qp:
             delimiter = '?' if '?' not in auth_path else '&'
             auth_path += delimiter + '&'.join(extra_qp)


### PR DESCRIPTION
Raised in ticket:
https://github.com/boto/boto/issues/2043
