### PR TITLE
Fix Flash and JavaApplet object XML rendering.

### DIFF
--- a/boto/mturk/question.py
+++ b/boto/mturk/question.py
@@ -162,7 +162,6 @@ class JavaApplet(Application):
         super(JavaApplet, self).__init__(*args, **kwargs)
 
     def get_inner_content(self, content):
-        content = OrderedContent()
         content.append_field('AppletPath', self.path)
         content.append_field('AppletFilename', self.filename)
         super(JavaApplet, self).get_inner_content(content)
@@ -174,7 +173,6 @@ class Flash(Application):
         super(Flash, self).__init__(*args, **kwargs)
 
     def get_inner_content(self, content):
-        content = OrderedContent()
         content.append_field('FlashMovieURL', self.url)
         super(Flash, self).get_inner_content(content)
 


### PR DESCRIPTION
Hi y'all, thanks for the fantastic library.

This is regarding the issue here:
https://github.com/boto/boto/issues/203

The Flash and JavaApplet objects fail to render XML properly because the `content` variable is reinitialized when `get_inner_content()` is called. This is just @haltil's fix implemented. I needed to be able to pip install a fixed version from a repo, and thought I'd send this upstream. Tested and working for Flash objects.

Cheers,
Yuri
