### PR TITLE
GS should ignore restore_headers as they are never set.

### DIFF
--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -109,6 +109,9 @@ class Key(S3Key):
         self.metageneration = resp.getheader('x-goog-metageneration', None)
         self.generation = resp.getheader('x-goog-generation', None)
 
+    def handle_restore_headers(self, response):
+        return
+
     def handle_addl_headers(self, headers):
         for key, value in headers:
             if key == 'x-goog-hash':


### PR DESCRIPTION
Override the handle_restore_headers() method in gs.key to
do nothing instead of using the base method.
