### PR TITLE
Add missing Content-MD5 header to the POST Object Restore request

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1910,9 +1910,13 @@ class Key(object):
             respect to the completion time of the request.
 
         """
+        data = self.RestoreBody % days
+        md5 = compute_md5(StringIO.StringIO(data))
+        headers = headers or {}
+        headers['Content-MD5'] = md5[1]
         response = self.bucket.connection.make_request(
             'POST', self.bucket.name, self.name,
-            data=self.RestoreBody % days,
+            data=data,
             headers=headers, query_args='restore')
         if response.status not in (200, 202):
             provider = self.bucket.connection.provider


### PR DESCRIPTION
I tried to write a unit test for this change but unfortunately AWS takes an indefinite amount of time to transition objects to glacier even when you set 0 days which makes automating a restore test case difficult.

I tested this manually though and sniffed the request/response to show its setting the header now and that AWS accepted the request. Note: I modified the Authorization header when I pasted it below.

```
POST /meta?restore HTTP/1.1.
Host: ozaintbucket.s3.amazonaws.com.
Accept-Encoding: identity.
Date: Mon, 03 Feb 2014 02:29:34 GMT.
Content-Length: 155.
User-Agent: Boto/2.23.0 Python/2.7.3 Linux/3.9.10-100.fc17.x86_64.
Authorization: AWS BLAH:BLAH.
Content-MD5: 52ovPBx7I1yaJo86KXcVdQ==.
.
<?xml version="1.0" encoding="UTF-8"?>
      <RestoreRequest xmlns="http://s3.amazonaws.com/doc/2006-03-01">
        <Days>1</Days>
      </RestoreRequest>
#
T 205.251.242.184:80 -> 10.181.164.198:49398 [A]
......
#
T 205.251.242.184:80 -> 10.181.164.198:49398 [AP]
HTTP/1.1 202 Accepted.
x-amz-id-2: Tr0my0QQoMKf3Ru7pym0b+8mtHQIBR5ZqOuiugYh+5dEl4SzQriEIlRKk1N+JGEc.
x-amz-request-id: 9460B322F2BFCF8C.
Date: Mon, 03 Feb 2014 02:29:35 GMT.
Content-Length: 0.
Server: AmazonS3.
.
```
