### PR TITLE
Finished implementation of RDS's DescribeDBLogFiles

### DIFF
--- a/boto/rds/__init__.py
+++ b/boto/rds/__init__.py
@@ -1076,23 +1076,47 @@ class RDSConnection(AWSQueryConnection):
         return self.get_list('DescribeDBSnapshots', params,
                              [('DBSnapshot', DBSnapshot)])
 
-    def get_all_logs(self, dbinstance_id=None):
+    def get_all_logs(self, dbinstance_id, max_records=None, marker=None, file_size=None, filename_contains=None, file_last_written=None):
         """
         Get all log files
 
         :type instance_id: str
-        :param instance_id: The identifier of a DBInstance.  If provided,
-                            only the :class:`boto.rds.logfile.LogFile` related
-                            to that instance will be returned.  If not
-                            provided, all logfiles will be returned.
+        :param instance_id: The identifier of a DBInstance.
+
+        :type max_records: int
+        :param max_records: Number of log file names to return.
+
+        :type marker: str
+        :param marker: The marker provided by a previous request.
+
+        :file_size: int
+        :param file_size: Filter results to files large than this size in bytes.
+
+        :filename_contains: str
+        :param filename_contains: Filter results to files with filename containing this string
+
+        :file_last_written: int
+        :param file_last_written: Filter results to files written after this time (POSIX timestamp)
 
         :rtype: list
         :return: A list of :class:`boto.rds.logfile.LogFile`
         """
-        params = {}
-        if dbinstance_id:
-           params['DBInstanceIdentifier'] = dbinstance_id
-        params['MaxRecords'] = 26
+        params = {'DBInstanceIdentifier': dbinstance_id}
+
+        if file_size:
+            params['FileSize'] = file_size
+
+        if filename_contains:
+            params['FilenameContains'] = filename_contains
+
+        if file_last_written:
+            params['FileLastWritten'] = file_last_written
+
+        if marker:
+            params['Marker'] = marker
+
+        if max_records:
+            params['MaxRecords'] = max_records
 
         return self.get_list('DescribeDBLogFiles', params,
                              [('DescribeDBLogFilesDetails',LogFile)])

--- a/tests/unit/rds/test_connection.py
+++ b/tests/unit/rds/test_connection.py
@@ -599,13 +599,13 @@ class TestRDSLogFile(AWSMockServiceTestCase):
         </DescribeDBLogFilesResponse>
         """
 
-    def test_get_all_logs(self):
+    def test_get_all_logs_simple(self):
         self.set_http_response(status_code=200)
-        response = self.service_connection.get_all_logs()
+        response = self.service_connection.get_all_logs('db1')
 
         self.assert_request_parameters({
             'Action': 'DescribeDBLogFiles',
-            'MaxRecords': 26,
+            'DBInstanceIdentifier': 'db1',
         }, ignore_params_values=['Version'])
 
         self.assertEqual(len(response), 6)
@@ -614,14 +614,18 @@ class TestRDSLogFile(AWSMockServiceTestCase):
         self.assertEqual(response[0].last_written, '1364403600000')
         self.assertEqual(response[0].size, '0')
 
-    def test_get_all_logs_single(self):
+    def test_get_all_logs_filtered(self):
         self.set_http_response(status_code=200)
-        response = self.service_connection.get_all_logs('db_instance_1')
+        response = self.service_connection.get_all_logs('db_instance_1', max_records=100, marker='error/mysql-error.log', file_size=2000000, filename_contains='error', file_last_written=12345678)
 
         self.assert_request_parameters({
             'Action': 'DescribeDBLogFiles',
             'DBInstanceIdentifier': 'db_instance_1',
-            'MaxRecords': 26,
+            'MaxRecords': 100,
+            'Marker': 'error/mysql-error.log',
+            'FileSize': 2000000,
+            'FilenameContains': 'error',
+            'FileLastWritten': 12345678,
         }, ignore_params_values=['Version'])
 
         self.assertEqual(len(response), 6)


### PR DESCRIPTION
This commit implements the missing arguments for get_all_logs.

It introduces two slight API changes. They're the right thing to do, but I can revert those parts if needed. 

a) dbinstance_id is no longer optional. It's a required field in the docs, so there's no reason for it to be optional.

b) max_records was previously hardcoded to 26. It's actually an optional field, so I've changed to be so. 
