### PR TITLE
Fixed the DDBv2 `has_item` support.

### DIFF
--- a/boto/dynamodb2/exceptions.py
+++ b/boto/dynamodb2/exceptions.py
@@ -72,3 +72,7 @@ class UnknownFilterTypeError(DynamoDBError):
 
 class QueryError(DynamoDBError):
     pass
+
+
+class ItemNotFound(DynamoDBError):
+    pass

--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -488,6 +488,8 @@ class Table(object):
             attributes_to_get=attributes,
             consistent_read=consistent
         )
+        if 'Item' not in item_data:
+            raise exceptions.ItemNotFound("Item %s couldn't be found." % kwargs)
         item = Item(self)
         item.load(item_data)
         return item
@@ -526,7 +528,7 @@ class Table(object):
         """
         try:
             self.get_item(**kwargs)
-        except JSONResponseError:
+        except (JSONResponseError, exceptions.ItemNotFound):
             return False
 
         return True

--- a/tests/integration/dynamodb2/test_highlevel.py
+++ b/tests/integration/dynamodb2/test_highlevel.py
@@ -109,6 +109,14 @@ class DynamoDBv2Test(unittest.TestCase):
 
         time.sleep(5)
 
+        # Does it exist? It should?
+        self.assertTrue(users.has_item(username='jane', friend_count=3))
+        # But this shouldn't be there...
+        self.assertFalse(users.has_item(
+            username='mrcarmichaeljones',
+            friend_count=72948
+        ))
+
         # Test getting an item & updating it.
         # This is the "safe" variant (only write if there have been no
         # changes).


### PR DESCRIPTION
This corrects the failure seen at https://forums.aws.amazon.com/thread.jspa?messageID=522703. Previously, we were leaning on a `JSONResponseError`, but that's not what DynamoDB returns when there's no data.

Review please? @danielgtaylor @jamesls 
