### PR TITLE
Update auth.py

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -330,7 +330,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         parameter_names = sorted(http_request.params.keys())
         pairs = []
         for pname in parameter_names:
-            pval = str(http_request.params[pname]).encode('utf-8')
+            pval = unicode(http_request.params[pname]).encode('utf-8')
             pairs.append(urllib.quote(pname, safe='') + '=' +
                          urllib.quote(pval, safe='-_~'))
         return '&'.join(pairs)


### PR DESCRIPTION
In case the string contains unicode characters (e.g. emoji text=u'monkey \U0001F435'.encode('utf-8')), str() operation fails.
