### PR TITLE
Retry on 408 Request timed out

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -924,7 +924,7 @@ class AWSAuthConnection(object):
                             boto.log.debug(msg)
                         time.sleep(next_sleep)
                         continue
-                if response.status in [500, 502, 503, 504]:
+                if response.status in [408, 500, 502, 503, 504]:
                     msg = 'Received %d response.  ' % response.status
                     msg += 'Retrying in %3.1f seconds' % next_sleep
                     boto.log.debug(msg)


### PR DESCRIPTION
This error is common when uploading files to Glacier---according to the spec its perfectly fine to retry and typically this works. This makes uploading large chunks more robust.

If we don't want to retry on all 408s we should at least do it for glacier as it seems necessary there. Its not clear to me what is happening on the Amazon side to cause this but the issue is well known.
