### PR TITLE
Add CloudFormation template capabilities support.

### DIFF
--- a/boto/cloudformation/template.py
+++ b/boto/cloudformation/template.py
@@ -1,21 +1,29 @@
 from boto.resultset import ResultSet
+from boto.cloudformation.stack import Capability
 
 class Template(object):
     def __init__(self, connection=None):
         self.connection = connection
         self.description = None
         self.template_parameters = None
+        self.capabilities_reason = None
+        self.capabilities = None
 
     def startElement(self, name, attrs, connection):
         if name == "Parameters":
             self.template_parameters = ResultSet([('member', TemplateParameter)])
             return self.template_parameters
+        elif name == "Capabilities":
+            self.capabilities = ResultSet([('member', Capability)])
+            return self.capabilities
         else:
             return None
 
     def endElement(self, name, value, connection):
         if name == "Description":
             self.description = value
+        elif name == "CapabilitiesReason":
+            self.capabilities_reason = value
         else:
             setattr(self, name, value)
 

--- a/tests/unit/cloudformation/test_connection.py
+++ b/tests/unit/cloudformation/test_connection.py
@@ -569,6 +569,10 @@ class TestCloudFormationValidateTemplate(CloudFormationConnectionBase):
                     <Description>EC2 KeyPair</Description>
                   </member>
                 </Parameters>
+                <CapabilitiesReason>Reason</CapabilitiesReason>
+                <Capabilities>
+                  <member>CAPABILITY_IAM</member>
+                </Capabilities>
               </ValidateTemplateResult>
               <ResponseMetadata>
                 <RequestId>0be7b6e8-e4a0-11e0-a5bd-9f8d5a7dbc91</RequestId>
@@ -592,6 +596,11 @@ class TestCloudFormationValidateTemplate(CloudFormationConnectionBase):
         self.assertEqual(param2.description, 'EC2 KeyPair')
         self.assertEqual(param2.no_echo, True)
         self.assertEqual(param2.parameter_key, 'KeyName')
+
+        self.assertEqual(template.capabilities_reason, 'Reason')
+
+        self.assertEqual(len(template.capabilities), 1)
+        self.assertEqual(template.capabilities[0].value, 'CAPABILITY_IAM')
 
         self.assert_request_parameters({
             'Action': 'ValidateTemplate',


### PR DESCRIPTION
Adds support for Capabilities and CapabilitiesReason to the Template
object. Fixes #2075.

@toastdriven, please review.
