### PR TITLE
fix doc for dynamodb2.table.query

### DIFF
--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -824,7 +824,7 @@ class Table(object):
         (Default: ``None``)
 
         Optionally accepts a ``reverse`` parameter, which will present the
-        results in reverse order. (Default: ``None`` - normal order)
+        results in descending order. (Default: ``False`` - descending order)
 
         Optionally accepts a ``consistent`` parameter, which should be a
         boolean. If you provide ``True``, it will force a consistent read of


### PR DESCRIPTION
`reverse` parameter is by default `False` not `None`
also clarify that the results in `descending` order.
