### PR TITLE
Read EvaluateTargetHealth from resource record set

### DIFF
--- a/boto/route53/record.py
+++ b/boto/route53/record.py
@@ -336,6 +336,8 @@ class Record(object):
             self.alias_dns_name = value
         elif name == 'SetIdentifier':
             self.identifier = value
+        elif name == 'EvaluateTargetHealth':
+            self.alias_evaluate_target_health = value
         elif name == 'Weight':
             self.weight = value
         elif name == 'Region':


### PR DESCRIPTION
This change will allow boto to read `<EvaluateTargetHealth>` tag from AWS response and set either `true` or `false` correctly.

Currently `alias_evaluate_target_health` is always `None`, even if the response from AWS contains:

```
"AliasTarget": {
    "HostedZoneId": "ABCDEFG12345",
    "EvaluateTargetHealth": true,
    "DNSName": "abcdefg-12345.us-west-2.elb.amazonaws.com."
}
```
