### PR TITLE
Don't pull the security token from the environment or config when a caller supplies the access key and secret

### DIFF
--- a/boto/provider.py
+++ b/boto/provider.py
@@ -289,7 +289,12 @@ class Provider(object):
         if security_token is not None:
             self.security_token = security_token
             boto.log.debug("Using security token provided by client.")
-        elif security_token_name is not None:
+        elif ((security_token_name is not None) and
+              (access_key is None) and (secret_key is None)):
+            # Only provide a token from the environment/config if the
+            # caller did not specify a key and secret.  Otherwise an
+            # environment/config token could be paired with a
+            # different set of credentials provided by the caller
             if security_token_name.upper() in os.environ:
                 self.security_token = os.environ[security_token_name.upper()]
                 boto.log.debug("Using security token found in environment"

--- a/tests/unit/provider/test_provider.py
+++ b/tests/unit/provider/test_provider.py
@@ -155,6 +155,15 @@ class TestProvider(unittest.TestCase):
             if not imported:
                 del sys.modules['keyring']
 
+    def test_passed_in_values_beat_env_vars(self):
+        self.environ['AWS_ACCESS_KEY_ID'] = 'env_access_key'
+        self.environ['AWS_SECRET_ACCESS_KEY'] = 'env_secret_key'
+        self.environ['AWS_SECURITY_TOKEN'] = 'env_security_token'
+        p = provider.Provider('aws', 'access_key', 'secret_key')
+        self.assertEqual(p.access_key, 'access_key')
+        self.assertEqual(p.secret_key, 'secret_key')
+        self.assertEqual(p.security_token, None)
+
     def test_env_vars_beat_config_values(self):
         self.environ['AWS_ACCESS_KEY_ID'] = 'env_access_key'
         self.environ['AWS_SECRET_ACCESS_KEY'] = 'env_secret_key'


### PR DESCRIPTION
The recently added support for pulling a security token from the environment or a config file allows tokens to be incorrectly associated with other credentials if a caller supplies an access key and secret.
