### PR TITLE
Use system supplied certs without a bundle file

### DIFF
--- a/boto/https_connection.py
+++ b/boto/https_connection.py
@@ -109,8 +109,12 @@ class CertValidatingHTTPSConnection(httplib.HTTPConnection):
     if hasattr(self, "timeout") and self.timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
         sock.settimeout(self.timeout)
     sock.connect((self.host, self.port))
-    boto.log.debug("wrapping ssl socket; CA certificate file=%s",
-                   self.ca_certs)
+    msg = "wrapping ssl socket; "
+    if self.ca_certs:
+        msg += "CA certificate file=%s" %self.ca_certs
+    else:
+        msg += "using system provided SSL certs"
+    boto.log.debug(msg)
     self.sock = ssl.wrap_socket(sock, keyfile=self.key_file,
                                 certfile=self.cert_file,
                                 cert_reqs=ssl.CERT_REQUIRED,

--- a/docs/source/boto_config_tut.rst
+++ b/docs/source/boto_config_tut.rst
@@ -147,7 +147,10 @@ For example::
 :is_secure: Is the connection over SSL. This setting will overide passed in
   values.
 :https_validate_certificates: Validate HTTPS certificates. This is on by default
-:ca_certificates_file: Location of CA certificates
+:ca_certificates_file: Location of CA certificates or the keyword "system".
+  Using the system keyword lets boto get out of the way and makes the
+  SSL certificate validation the responsibility the underlying SSL
+  implementation provided by the system.
 :http_socket_timeout: Timeout used to overwrite the system default socket
   timeout for httplib .
 :send_crlf_after_proxy_auth_headers: Change line ending behaviour with proxies.


### PR DESCRIPTION
- Allow the use of system provided certificate setup that may be incorporated
  
  into the SSL library used on the specific system
  - At present we either use the default certificate bundle we ship with the
    boto source, or we force a user/integrator to create a bundle file of their
    own. Linux distributors build the way certificates are used and validated
    into their SSL implementation. This change allows integrators to use their
    way of certificate handling by setting the configuration to the new
    "system" keyword.
