### PR TITLE
Fixed ``boto.connect_rds2()``.

### DIFF
--- a/boto/__init__.py
+++ b/boto/__init__.py
@@ -324,7 +324,11 @@ def connect_rds2(aws_access_key_id=None, aws_secret_access_key=None, **kwargs):
     :return: A connection to RDS
     """
     from boto.rds2.layer1 import RDSConnection
-    return RDSConnection(aws_access_key_id, aws_secret_access_key, **kwargs)
+    return RDSConnection(
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        **kwargs
+    )
 
 
 def connect_emr(aws_access_key_id=None, aws_secret_access_key=None, **kwargs):

--- a/tests/integration/rds2/test_connection.py
+++ b/tests/integration/rds2/test_connection.py
@@ -32,6 +32,12 @@ class TestRDS2Connection(unittest.TestCase):
         self.conn = RDSConnection()
         self.db_name = "test-db-%s" % str(int(time.time()))
 
+    def test_connect_rds(self):
+        # Upon release, this did not function correct. Ensure that
+        # args are passed correctly.
+        import boto
+        conn = boto.connect_rds2()
+
     def test_integration(self):
         resp = self.conn.create_db_instance(
             db_instance_identifier=self.db_name,


### PR DESCRIPTION
The rest of `rds2` should be fine, but I copy-pasted the wrong style `boto.connect_FOO` & without this, establishing a connection this way fails. Manually importing the `RDSConnection` or using `boto.rds2.connect_to_region` works as expected.

This was added in Boto 2.26.0. Is it worth a patch release?

Review please? @danielgtaylor
