### PR TITLE
Fixed a date bug in the trim_snapshots tests.

### DIFF
--- a/tests/unit/ec2/test_connection.py
+++ b/tests/unit/ec2/test_connection.py
@@ -968,7 +968,9 @@ class TestTrimSnapshots(TestEC2ConnectionBase):
         """
         snaps = []
 
-        # Generate some dates offset by days, weeks, months
+        # Generate some dates offset by days, weeks, months.
+        # This is to validate the various types of snapshot logic handled by
+        # ``trim_snapshots``.
         now = datetime.now()
         dates = [
             now,
@@ -977,7 +979,10 @@ class TestTrimSnapshots(TestEC2ConnectionBase):
             now - timedelta(days=7),
             now - timedelta(days=14),
             # We want to simulate 30/60/90-day snapshots, but February is
-            # short, so decrease by 2 days apiece.
+            # short (only 28 days), so we decrease the delta by 2 days apiece.
+            # This prevents the ``delete_snapshot`` code below from being
+            # called, since they don't fall outside the allowed timeframes
+            # for the snapshots.
             datetime(now.year, now.month, 1) - timedelta(days=28),
             datetime(now.year, now.month, 1) - timedelta(days=58),
             datetime(now.year, now.month, 1) - timedelta(days=88)


### PR DESCRIPTION
This should put Travis back to green. We didn't encounter this until now because February is short (only 28 days) & these tests were added more than 90 days after February last year.

Review/sanity-check please? @danielgtaylor
