### PR TITLE
Updated signing v4 canonical headers to preserve quoted strings

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -358,9 +358,11 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         for header in headers_to_sign:
             c_name = header.lower().strip()
             raw_value = headers_to_sign[header]
-            c_value = ' '.join(raw_value.strip().split())
+            if '"' in raw_value:
+                c_value = raw_value.strip()
+            else:
+                c_value = ' '.join(raw_value.strip().split())
             canonical.append('%s:%s' % (c_name, c_value))
-
         return '\n'.join(sorted(canonical))
 
     def signed_headers(self, headers_to_sign):

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -65,7 +65,7 @@ class TestSigV4Handler(unittest.TestCase):
                          'host:glacier.us-east-1.amazonaws.com\n'
                          'x-amz-archive-description:two spaces\n'
                          'x-amz-glacier-version:2012-06-01\n'
-                         'x-amz-quoted-string:"a  b  c"')
+                         'x-amz-quoted-string:"a   b   c"')
 
     def test_canonical_query_string(self):
         auth = HmacAuthV4Handler('glacier.us-east-1.amazonaws.com',


### PR DESCRIPTION
This is way out in left field but I was working through the v4 signing instructions and noticed quoted strings were not handled correctly.

From http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html

Original

```
host:iam.amazonaws.com\n
Content-type:application/x-www-form-urlencoded; charset=utf-8\n
My-header1:    a   b   c \n
x-amz-date:20120228T030031Z\n
My-Header2:    "a   b   c"\n 
```

Canonical

```
content-type:application/x-www-form-urlencoded; charset=utf-8\n
host:iam.amazonaws.com\n
my-header1:a b c\n
my-header2:"a   b   c"\n
x-amz-date:20120228T024136Z\n
```

So I fixed a dupe line bug, updated tests, and added very simple logic to detect a quoted string.

Tests are green https://travis-ci.org/leetrout/boto/builds/20065380

Again, minutia, but thought it was worth fixing :weary: 
