### PR TITLE
S3 meta data  handle plus sign

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -374,7 +374,7 @@ class HTTPRequest(object):
             val = self.headers[key]
             if isinstance(val, unicode):
                 safe = '!"#$%&\'()*+,/:;<=>?@[\\]^`{|}~'
-                self.headers[key] = urllib.quote_plus(val.encode('utf-8'), safe)
+                self.headers[key] = urllib.quote(val.encode('utf-8'), safe)
 
         connection._auth_handler.add_auth(self, **kwargs)
 

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -195,7 +195,7 @@ def get_aws_metadata(headers, provider=None):
     metadata = {}
     for hkey in headers.keys():
         if hkey.lower().startswith(metadata_prefix):
-            val = urllib.unquote_plus(headers[hkey])
+            val = urllib.unquote(headers[hkey])
             try:
                 metadata[hkey[len(metadata_prefix):]] = unicode(val, 'utf-8')
             except UnicodeDecodeError:

--- a/tests/integration/s3/test_key.py
+++ b/tests/integration/s3/test_key.py
@@ -409,8 +409,8 @@ class S3KeyTest(unittest.TestCase):
 
         self.assertEqual(check.cache_control, 'public, max-age=500')
         self.assertEqual(check.get_metadata('test-plus'), 'A plus (+)')
-        self.assertEqual(check.content_disposition, 'filename=Sch%C3%B6ne+Zeit.txt')
+        self.assertEqual(check.content_disposition, 'filename=Sch%C3%B6ne%20Zeit.txt')
         self.assertEqual(
-            urllib.unquote_plus(check.content_disposition).decode('utf-8'),
+            urllib.unquote(check.content_disposition).decode('utf-8'),
             'filename=Schöne Zeit.txt'.decode('utf-8')
         )


### PR DESCRIPTION
Previously, there was no way to reliably store and then retrieve
metadata values that contained plus signs. `quote_plus` left existing
pluses as they were while encoding spaces as "+". This would turn a
value like "x+ +x" into "x+++x" which upon retrieval from S3 using boto
would be decoded into "x   x".

This change allows storage of plus characters "+" in s3 key metadata
values.
