### PR TITLE
Changed variable to be a logical name

### DIFF
--- a/boto/vpc/networkacl.py
+++ b/boto/vpc/networkacl.py
@@ -135,7 +135,7 @@ class NetworkAclAssociation(object):
         if name == 'networkAclAssociationId':
             self.id = value
         elif name == 'networkAclId':
-            self.route_table_id = value
+            self.network_acl_id = value
         elif name == 'subnetId':
             self.subnet_id = value
 


### PR DESCRIPTION
Changed the route_table_id variable to network_acl_id due to the returned value being the network_acl_id.
