### PR TITLE
Fix BlockDeviceType deserialization in `get_all_launch_configurations`

### DIFF
--- a/boto/__init__.py
+++ b/boto/__init__.py
@@ -196,6 +196,11 @@ def connect_autoscale(aws_access_key_id=None, aws_secret_access_key=None,
 
     :rtype: :class:`boto.ec2.autoscale.AutoScaleConnection`
     :return: A connection to Amazon's Auto Scaling Service
+
+    :type use_block_device_types bool
+    :param use_block_device_types: Specifies whether to return described Launch Configs with block device mappings containing
+        block device types, or a list of old style block device mappings (deprecated).  This defaults to false for compatability
+        with the old incorrect style.
     """
     from boto.ec2.autoscale import AutoScaleConnection
     return AutoScaleConnection(aws_access_key_id, aws_secret_access_key,

--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -87,18 +87,22 @@ class AutoScaleConnection(AWSQueryConnection):
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, debug=0,
                  https_connection_factory=None, region=None, path='/',
-                 security_token=None, validate_certs=True, profile_name=None):
+                 security_token=None, validate_certs=True, profile_name=None,
+                 use_block_device_types=False):
         """
         Init method to create a new connection to the AutoScaling service.
 
         B{Note:} The host argument is overridden by the host specified in the
                  boto configuration file.
+
+
         """
         if not region:
             region = RegionInfo(self, self.DefaultRegionName,
                                 self.DefaultRegionEndpoint,
                                 AutoScaleConnection)
         self.region = region
+        self.use_block_device_types = use_block_device_types
         super(AutoScaleConnection, self).__init__(aws_access_key_id,
                                     aws_secret_access_key,
                                     is_secure, port, proxy, proxy_port,

--- a/boto/ec2/autoscale/launchconfig.py
+++ b/boto/ec2/autoscale/launchconfig.py
@@ -21,14 +21,16 @@
 # IN THE SOFTWARE.
 
 from datetime import datetime
-from boto.resultset import ResultSet
 from boto.ec2.elb.listelement import ListElement
+# Namespacing issue with deprecated local class
+from boto.ec2.blockdevicemapping import BlockDeviceMapping as BDM
+from boto.resultset import ResultSet
 import boto.utils
 import base64
 
+
 # this should use the corresponding object from boto.ec2
-
-
+# Currently in use by deprecated local BlockDeviceMapping class
 class Ebs(object):
     def __init__(self, connection=None, snapshot_id=None, volume_size=None):
         self.connection = connection
@@ -65,6 +67,8 @@ class InstanceMonitoring(object):
 
 
 # this should use the BlockDeviceMapping from boto.ec2.blockdevicemapping
+# Currently in use by deprecated code for backwards compatability
+# Removing this class can also remove the Ebs class in this same file
 class BlockDeviceMapping(object):
     def __init__(self, connection=None, device_name=None, virtual_name=None,
                  ebs=None, no_device=None):
@@ -100,7 +104,7 @@ class LaunchConfiguration(object):
                  instance_monitoring=False, spot_price=None,
                  instance_profile_name=None, ebs_optimized=False,
                  associate_public_ip_address=None, volume_type=None,
-                 delete_on_termination=True, iops=None):
+                 delete_on_termination=True, iops=None, use_block_device_types=False):
         """
         A launch configuration.
 
@@ -152,6 +156,7 @@ class LaunchConfiguration(object):
         :param ebs_optimized: Specifies whether the instance is optimized
             for EBS I/O (true) or not (false).
 
+
         :type associate_public_ip_address: bool
         :param associate_public_ip_address: Used for Auto Scaling groups that launch instances into an Amazon Virtual Private Cloud.
             Specifies whether to assign a public IP address to each instance launched in a Amazon VPC.
@@ -178,6 +183,7 @@ class LaunchConfiguration(object):
         self.volume_type = volume_type
         self.delete_on_termination = delete_on_termination
         self.iops = iops
+        self.use_block_device_types = connection.use_block_device_types
 
     def __repr__(self):
         return 'LaunchConfiguration:%s' % self.name
@@ -186,8 +192,10 @@ class LaunchConfiguration(object):
         if name == 'SecurityGroups':
             return self.security_groups
         elif name == 'BlockDeviceMappings':
-            self.block_device_mappings = ResultSet([('member',
-                                                     BlockDeviceMapping)])
+            if self.use_block_device_types:
+                self.block_device_mappings = BDM()
+            else:
+                self.block_device_mappings = ResultSet([('member', BlockDeviceMapping)])
             return self.block_device_mappings
         elif name == 'InstanceMonitoring':
             self.instance_monitoring = InstanceMonitoring(self)

--- a/boto/ec2/blockdevicemapping.py
+++ b/boto/ec2/blockdevicemapping.py
@@ -55,25 +55,26 @@ class BlockDeviceType(object):
         pass
 
     def endElement(self, name, value, connection):
+        lname = name.lower()
         if name == 'volumeId':
             self.volume_id = value
-        elif name == 'virtualName':
+        elif lname == 'virtualname':
             self.ephemeral_name = value
-        elif name == 'NoDevice':
+        elif lname == 'nodevice':
             self.no_device = (value == 'true')
-        elif name == 'snapshotId':
+        elif lname == 'snapshotid':
             self.snapshot_id = value
-        elif name == 'volumeSize':
+        elif lname == 'volumesize':
             self.size = int(value)
-        elif name == 'status':
+        elif lname == 'status':
             self.status = value
-        elif name == 'attachTime':
+        elif lname == 'attachtime':
             self.attach_time = value
-        elif name == 'deleteOnTermination':
+        elif lname == 'deleteontermination':
             self.delete_on_termination = (value == 'true')
-        elif name == 'volumeType':
+        elif lname == 'volumetype':
             self.volume_type = value
-        elif name == 'iops':
+        elif lname == 'iops':
             self.iops = int(value)
         else:
             setattr(self, name, value)
@@ -105,14 +106,16 @@ class BlockDeviceMapping(dict):
         self.current_value = None
 
     def startElement(self, name, attrs, connection):
-        if name == 'ebs' or name == 'virtualName':
+        lname = name.lower()
+        if lname in ['ebs', 'virtualname']:
             self.current_value = BlockDeviceType(self)
             return self.current_value
 
     def endElement(self, name, value, connection):
-        if name == 'device' or name == 'deviceName':
+        lname = name.lower()
+        if lname in ['device', 'devicename']:
             self.current_name = value
-        elif name == 'item':
+        elif lname in ['item', 'member']:
             self[self.current_name] = self.current_value
 
     def ec2_build_list_params(self, params, prefix=''):

--- a/docs/source/ec2_tut.rst
+++ b/docs/source/ec2_tut.rst
@@ -176,3 +176,40 @@ If you no longer need a snapshot, you can also easily delete it::
    True
 
 
+Working With Launch Configurations
+----------------------------------
+
+Launch Configurations allow you to create a re-usable set of properties for an
+instance.  These are used with AutoScaling groups to produce consistent repeatable
+instances sets.
+
+Creating a Launch Configuration is easy:
+
+   >>> conn = boto.connect_autoscale()
+   >>> config = LaunchConfig(name='foo', image_id='ami-abcd1234', key_name='foo.pem')
+   >>> conn.create_launch_configuration(config)
+
+Once you have a launch configuration, you can list you current configurations:
+
+   >>> conn = boto.connect_autoscale()
+   >>> config = conn.get_all_launch_configurations(names=['foo'])
+
+If you no longer need a launch configuration, you can delete it:
+
+   >>> conn = boto.connect_autoscale()
+   >>> conn.delete_launch_configuration('foo')
+
+.. versionchanged:: 2.27.0
+.. Note::
+
+    If ``use_block_device_types=True`` is passed to the connection it will deserialize
+    Launch Configurations with Block Device Mappings into a re-usable format with
+    BlockDeviceType objects, similar to how AMIs are deserialized currently.  Legacy
+    behavior is to put them into a format that is incompatabile with creating new Launch
+    Configurations. This switch is in place to preserve backwards compatability, but
+    its usage is the preferred format going forward.
+
+    If you would like to use the new format, you should use something like:
+
+      >>> conn = boto.connect_autoscale(use_block_device_types=True)
+      >>> config = conn.get_all_launch_configurations(names=['foo'])

--- a/tests/unit/ec2/autoscale/test_group.py
+++ b/tests/unit/ec2/autoscale/test_group.py
@@ -300,7 +300,7 @@ class TestLaunchConfigurationDescribe(AWSMockServiceTestCase):
 
     def test_get_all_launch_configurations(self):
         self.set_http_response(status_code=200)
-        
+
         response = self.service_connection.get_all_launch_configurations()
         self.assertTrue(isinstance(response, list))
         self.assertEqual(len(response), 1)
@@ -314,6 +314,7 @@ class TestLaunchConfigurationDescribe(AWSMockServiceTestCase):
         self.assertTrue(isinstance(response[0].instance_monitoring, launchconfig.InstanceMonitoring))
         self.assertEqual(response[0].instance_monitoring.enabled, 'true')
         self.assertEqual(response[0].ebs_optimized, False)
+        self.assertEqual(response[0].block_device_mappings, [])
 
         self.assert_request_parameters({
             'Action': 'DescribeLaunchConfigurations',
@@ -685,6 +686,119 @@ class TestGetAdjustmentTypes(AWSMockServiceTestCase):
         self.assertEqual(response[0].adjustment_type, "ChangeInCapacity")
         self.assertEqual(response[1].adjustment_type, "ExactCapacity")
         self.assertEqual(response[2].adjustment_type, "PercentChangeInCapacity")
+
+
+class TestLaunchConfigurationDescribeWithBlockDeviceTypes(AWSMockServiceTestCase):
+    connection_class = AutoScaleConnection
+
+    def default_body(self):
+        # This is a dummy response
+        return """
+        <DescribeLaunchConfigurationsResponse>
+          <DescribeLaunchConfigurationsResult>
+            <LaunchConfigurations>
+              <member>
+                <AssociatePublicIpAddress>true</AssociatePublicIpAddress>
+                <SecurityGroups/>
+                <CreatedTime>2013-01-21T23:04:42.200Z</CreatedTime>
+                <KernelId/>
+                <LaunchConfigurationName>my-test-lc</LaunchConfigurationName>
+                <UserData/>
+                <InstanceType>m1.small</InstanceType>
+                <LaunchConfigurationARN>arn:aws:autoscaling:us-east-1:803981987763:launchConfiguration:9dbbbf87-6141-428a-a409-0752edbe6cad:launchConfigurationName/my-test-lc</LaunchConfigurationARN>
+                <BlockDeviceMappings>
+                  <member>
+                    <DeviceName>/dev/xvdp</DeviceName>
+                    <Ebs>
+                      <SnapshotId>snap-1234abcd</SnapshotId>
+                      <Iops>1000</Iops>
+                      <DeleteOnTermination>true</DeleteOnTermination>
+                      <VolumeType>io1</VolumeType>
+                      <VolumeSize>100</VolumeSize>
+                    </Ebs>
+                  </member>
+                  <member>
+                    <VirtualName>ephemeral1</VirtualName>
+                    <DeviceName>/dev/xvdc</DeviceName>
+                  </member>
+                  <member>
+                    <VirtualName>ephemeral0</VirtualName>
+                    <DeviceName>/dev/xvdb</DeviceName>
+                  </member>
+                  <member>
+                    <DeviceName>/dev/xvdh</DeviceName>
+                    <Ebs>
+                      <Iops>2000</Iops>
+                      <DeleteOnTermination>false</DeleteOnTermination>
+                      <VolumeType>io1</VolumeType>
+                      <VolumeSize>200</VolumeSize>
+                    </Ebs>
+                  </member>
+                </BlockDeviceMappings>
+                <ImageId>ami-514ac838</ImageId>
+                <KeyName/>
+                <RamdiskId/>
+                <InstanceMonitoring>
+                  <Enabled>true</Enabled>
+                </InstanceMonitoring>
+                <EbsOptimized>false</EbsOptimized>
+              </member>
+            </LaunchConfigurations>
+          </DescribeLaunchConfigurationsResult>
+          <ResponseMetadata>
+            <RequestId>d05a22f8-b690-11e2-bf8e-2113fEXAMPLE</RequestId>
+          </ResponseMetadata>
+        </DescribeLaunchConfigurationsResponse>
+        """
+
+    def test_get_all_launch_configurations_with_block_device_types(self):
+        self.set_http_response(status_code=200)
+        self.service_connection.use_block_device_types = True
+
+        response = self.service_connection.get_all_launch_configurations()
+        self.assertTrue(isinstance(response, list))
+        self.assertEqual(len(response), 1)
+        self.assertTrue(isinstance(response[0], LaunchConfiguration))
+
+        self.assertEqual(response[0].associate_public_ip_address, True)
+        self.assertEqual(response[0].name, "my-test-lc")
+        self.assertEqual(response[0].instance_type, "m1.small")
+        self.assertEqual(response[0].launch_configuration_arn, "arn:aws:autoscaling:us-east-1:803981987763:launchConfiguration:9dbbbf87-6141-428a-a409-0752edbe6cad:launchConfigurationName/my-test-lc")
+        self.assertEqual(response[0].image_id, "ami-514ac838")
+        self.assertTrue(isinstance(response[0].instance_monitoring, launchconfig.InstanceMonitoring))
+        self.assertEqual(response[0].instance_monitoring.enabled, 'true')
+        self.assertEqual(response[0].ebs_optimized, False)
+
+        self.assertEqual(response[0].block_device_mappings['/dev/xvdb'].ephemeral_name, 'ephemeral0')
+
+        self.assertEqual(response[0].block_device_mappings['/dev/xvdc'].ephemeral_name, 'ephemeral1')
+
+        self.assertEqual(response[0].block_device_mappings['/dev/xvdp'].snapshot_id, 'snap-1234abcd')
+        self.assertEqual(response[0].block_device_mappings['/dev/xvdp'].delete_on_termination, True)
+        self.assertEqual(response[0].block_device_mappings['/dev/xvdp'].iops, 1000)
+        self.assertEqual(response[0].block_device_mappings['/dev/xvdp'].size, 100)
+        self.assertEqual(response[0].block_device_mappings['/dev/xvdp'].volume_type, 'io1')
+
+        self.assertEqual(response[0].block_device_mappings['/dev/xvdh'].delete_on_termination, False)
+        self.assertEqual(response[0].block_device_mappings['/dev/xvdh'].iops, 2000)
+        self.assertEqual(response[0].block_device_mappings['/dev/xvdh'].size, 200)
+        self.assertEqual(response[0].block_device_mappings['/dev/xvdh'].volume_type, 'io1')
+
+        self.assert_request_parameters({
+            'Action': 'DescribeLaunchConfigurations',
+        }, ignore_params_values=['Version'])
+
+    def test_get_all_configuration_limited(self):
+        self.set_http_response(status_code=200)
+
+        response = self.service_connection.get_all_launch_configurations(max_records=10, names=["my-test1", "my-test2"])
+        self.assert_request_parameters({
+            'Action': 'DescribeLaunchConfigurations',
+            'MaxRecords': 10,
+            'LaunchConfigurationNames.member.1': 'my-test1',
+            'LaunchConfigurationNames.member.2': 'my-test2'
+        }, ignore_params_values=['Version'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Add switch to remove deserialize API response to proper objects
- Preserve backwards compatible behavior
- Add test for new behavior
- Add documentation of new switch

Note: This is a consolidation of PR #2133 on a different branch with @toastdriven 's comments included.
