### PR TITLE
Documentation fix.

### DIFF
--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -410,19 +410,20 @@ class Key(S3Key):
         contents.
 
         :type fp: file
-        :param fp: the file whose contents are to be uploaded
+        :param fp: The file whose contents are to be uploaded.
 
         :type headers: dict
-        :param headers: additional HTTP headers to be sent with the PUT request.
+        :param headers: (optional) Additional HTTP headers to be sent with the
+            PUT request.
 
         :type replace: bool
-        :param replace: If this parameter is False, the method will first check
-            to see if an object exists in the bucket with the same key. If it
-            does, it won't overwrite it. The default value is True which will
-            overwrite the object.
+        :param replace: (optional) If this parameter is False, the method will
+            first check to see if an object exists in the bucket with the same
+            key. If it does, it won't overwrite it. The default value is True
+            which will overwrite the object.
 
         :type cb: function
-        :param cb: a callback function that will be called to report
+        :param cb: (optional) Callback function that will be called to report
             progress on the upload. The callback should accept two integer
             parameters, the first representing the number of bytes that have
             been successfully transmitted to GS and the second representing the
@@ -435,43 +436,44 @@ class Key(S3Key):
             during the file transfer.
 
         :type policy: :class:`boto.gs.acl.CannedACLStrings`
-        :param policy: A canned ACL policy that will be applied to the new key
-            in GS.
+        :param policy: (optional) A canned ACL policy that will be applied to
+            the new key in GS.
 
-        :type md5: A tuple containing the hexdigest version of the MD5 checksum
-            of the file as the first element and the Base64-encoded version of
-            the plain checksum as the second element. This is the same format
-            returned by the compute_md5 method.
-        :param md5: If you need to compute the MD5 for any reason prior to
-            upload, it's silly to have to do it twice so this param, if present,
-            will be used as the MD5 values of the file. Otherwise, the checksum
-            will be computed.
+        :type md5: tuple
+        :param md5: (optional) A tuple containing the hexdigest version of the
+            MD5 checksum of the file as the first element and the
+            Base64-encoded version of the plain checksum as the second element.
+            This is the same format returned by the compute_md5 method.
 
-        :type res_upload_handler: ResumableUploadHandler
-        :param res_upload_handler: If provided, this handler will perform the
-            upload.
+            If you need to compute the MD5 for any reason prior to upload, it's
+            silly to have to do it twice so this param, if present, will be
+            used as the MD5 values of the file. Otherwise, the checksum will be
+            computed.
+
+        :type res_upload_handler: :py:class:`boto.gs.resumable_upload_handler.ResumableUploadHandler`
+        :param res_upload_handler: (optional) If provided, this handler will
+            perform the upload.
 
         :type size: int
-        :param size: (optional) The Maximum number of bytes to read from
-            the file pointer (fp). This is useful when uploading
-            a file in multiple parts where you are splitting the
-            file up into different ranges to be uploaded. If not
-            specified, the default behaviour is to read all bytes
-            from the file pointer. Less bytes may be available.
+        :param size: (optional) The Maximum number of bytes to read from the
+            file pointer (fp). This is useful when uploading a file in multiple
+            parts where you are splitting the file up into different ranges to
+            be uploaded. If not specified, the default behaviour is to read all
+            bytes from the file pointer. Less bytes may be available.
+
             Notes:
 
-                1. The "size" parameter currently cannot be used when
-                   a resumable upload handler is given but is still
-                   useful for uploading part of a file as implemented
-                   by the parent class.
-                2. At present Google Cloud Storage does not support
-                   multipart uploads.
+                1. The "size" parameter currently cannot be used when a
+                   resumable upload handler is given but is still useful for
+                   uploading part of a file as implemented by the parent class.
+                2. At present Google Cloud Storage does not support multipart
+                   uploads.
 
         :type rewind: bool
-        :param rewind: (optional) If True, the file pointer (fp) will be 
-                       rewound to the start before any bytes are read from
-                       it. The default behaviour is False which reads from
-                       the current position of the file pointer (fp).
+        :param rewind: (optional) If True, the file pointer (fp) will be
+            rewound to the start before any bytes are read from it. The default
+            behaviour is False which reads from the current position of the
+            file pointer (fp).
 
         :type if_generation: int
         :param if_generation: (optional) If set to a generation number, the
@@ -588,44 +590,47 @@ class Key(S3Key):
         parameters.
 
         :type filename: string
-        :param filename: The name of the file that you want to put onto GS
+        :param filename: The name of the file that you want to put onto GS.
 
         :type headers: dict
-        :param headers: Additional headers to pass along with the request to GS.
+        :param headers: (optional) Additional headers to pass along with the
+            request to GS.
 
         :type replace: bool
-        :param replace: If True, replaces the contents of the file if it
-            already exists.
+        :param replace: (optional) If True, replaces the contents of the file
+            if it already exists.
 
         :type cb: function
-        :param cb: (optional) a callback function that will be called to report
-            progress on the download. The callback should accept two integer
+        :param cb: (optional) Callback function that will be called to report
+            progress on the upload. The callback should accept two integer
             parameters, the first representing the number of bytes that have
-            been successfully transmitted from GS and the second representing
-            the total number of bytes that need to be transmitted.
+            been successfully transmitted to GS and the second representing the
+            total number of bytes that need to be transmitted.
 
-        :type cb: int
+        :type num_cb: int
         :param num_cb: (optional) If a callback is specified with the cb
             parameter this parameter determines the granularity of the callback
             by defining the maximum number of times the callback will be called
             during the file transfer.
 
-        :type policy: :class:`boto.gs.acl.CannedACLStrings`
-        :param policy: A canned ACL policy that will be applied to the new key
-            in GS.
+        :type policy: :py:attribute:`boto.gs.acl.CannedACLStrings`
+        :param policy: (optional) A canned ACL policy that will be applied to
+            the new key in GS.
 
-        :type md5: A tuple containing the hexdigest version of the MD5 checksum
-            of the file as the first element and the Base64-encoded version of
-            the plain checksum as the second element. This is the same format
-            returned by the compute_md5 method.
-        :param md5: If you need to compute the MD5 for any reason prior to
-            upload, it's silly to have to do it twice so this param, if present,
-            will be used as the MD5 values of the file. Otherwise, the checksum
-            will be computed.
+        :type md5: tuple
+        :param md5: (optional) A tuple containing the hexdigest version of the
+            MD5 checksum of the file as the first element and the
+            Base64-encoded version of the plain checksum as the second element.
+            This is the same format returned by the compute_md5 method.
 
-        :type res_upload_handler: ResumableUploadHandler
-        :param res_upload_handler: If provided, this handler will perform the
-            upload.
+            If you need to compute the MD5 for any reason prior to upload, it's
+            silly to have to do it twice so this param, if present, will be
+            used as the MD5 values of the file. Otherwise, the checksum will be
+            computed.
+
+        :type res_upload_handler: :py:class:`boto.gs.resumable_upload_handler.ResumableUploadHandler`
+        :param res_upload_handler: (optional) If provided, this handler will
+            perform the upload.
 
         :type if_generation: int
         :param if_generation: (optional) If set to a generation number, the


### PR DESCRIPTION
Noticed misnamed arguments in the documentation, and then went on to completely fix the documentation formatting, as well.
