### PR TITLE
Reintroduced the ``reverse`` fix for DDB.

### DIFF
--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -816,6 +816,20 @@ class Table(object):
     def query(self, limit=None, index=None, reverse=False, consistent=False,
               attributes=None, max_page_size=None, **filter_kwargs):
         """
+        **WARNING:** This method is provided **strictly** for
+        backward-compatibility. It returns results in an incorrect order.
+
+        If you are writing new code, please use ``Table.query_2``.
+        """
+        reverse = not reverse
+        return self.query_2(limit=limit, index=index, reverse=reverse,
+                            consistent=consistent, attributes=attributes,
+                            max_page_size=max_page_size, **filter_kwargs)
+
+    def query_2(self, limit=None, index=None, reverse=False,
+                consistent=False, attributes=None, max_page_size=None,
+                **filter_kwargs):
+        """
         Queries for a set of matching items in a DynamoDB table.
 
         Queries can be performed against a hash key, a hash+range key or
@@ -837,7 +851,7 @@ class Table(object):
         (Default: ``None``)
 
         Optionally accepts a ``reverse`` parameter, which will present the
-        results in reverse order. (Default: ``None`` - normal order)
+        results in reverse order. (Default: ``False`` - normal order)
 
         Optionally accepts a ``consistent`` parameter, which should be a
         boolean. If you provide ``True``, it will force a consistent read of
@@ -988,11 +1002,13 @@ class Table(object):
         kwargs = {
             'limit': limit,
             'index_name': index,
-            'scan_index_forward': reverse,
             'consistent_read': consistent,
             'select': select,
-            'attributes_to_get': attributes_to_get
+            'attributes_to_get': attributes_to_get,
         }
+
+        if reverse:
+            kwargs['scan_index_forward'] = False
 
         if exclusive_start_key:
             kwargs['exclusive_start_key'] = {}

--- a/docs/source/dynamodb2_tut.rst
+++ b/docs/source/dynamodb2_tut.rst
@@ -310,6 +310,13 @@ manager.
 Querying
 --------
 
+.. warning::
+
+    The ``Table`` object has both a ``query`` & a ``query_2`` method. If you
+    are writing new code, **DO NOT** use ``Table.query``. It presents results
+    in an incorrect order than expected & is strictly present for
+    backward-compatibility.
+
 Manually fetching out each item by itself isn't tenable for large datasets.
 To cope with fetching many records, you can either perform a standard query,
 query via a local secondary index or scan the entire table.
@@ -338,7 +345,7 @@ request.
 
 To run a query for last names starting with the letter "D"::
 
-    >>> names_with_d = users.query(
+    >>> names_with_d = users.query_2(
     ...     account_type__eq='standard_user',
     ...     last_name__beginswith='D'
     ... )
@@ -352,7 +359,7 @@ To run a query for last names starting with the letter "D"::
 You can also reverse results (``reverse=True``) as well as limiting them
 (``limit=2``)::
 
-    >>> rev_with_d = users.query(
+    >>> rev_with_d = users.query_2(
     ...     account_type__eq='standard_user',
     ...     last_name__beginswith='D',
     ...     reverse=True,
@@ -369,7 +376,7 @@ the index name (``index='FirstNameIndex'``) & filter parameters against its
 fields::
 
     # Users within the last hour.
-    >>> recent = users.query(
+    >>> recent = users.query_2(
     ...     account_type__eq='standard_user',
     ...     date_joined__gte=time.time() - (60 * 60),
     ...     index='DateJoinedIndex'
@@ -383,11 +390,11 @@ fields::
 By default, DynamoDB can return a large amount of data per-request (up to 1Mb
 of data). To prevent these requests from drowning other smaller gets, you can
 specify a smaller page size via the ``max_page_size`` argument to
-``Table.query`` & ``Table.scan``. Doing so looks like::
+``Table.query_2`` & ``Table.scan``. Doing so looks like::
 
     # Small pages yield faster responses & less potential of drowning other
     # requests.
-    >>> all_users = users.query(
+    >>> all_users = users.query_2(
     ...     account_type__eq='standard_user',
     ...     date_joined__gte=0,
     ...     max_page_size=10
@@ -429,7 +436,7 @@ Filtering a scan looks like::
 The ``ResultSet``
 ~~~~~~~~~~~~~~~~~
 
-Both ``Table.query`` & ``Table.scan`` return an object called ``ResultSet``.
+Both ``Table.query_2`` & ``Table.scan`` return an object called ``ResultSet``.
 It's a lazily-evaluated object that uses the `Iterator protocol`_. It delays
 your queries until you request the next item in the result set.
 
@@ -460,7 +467,7 @@ a call to ``list()``. Ex.::
     Wrapping calls like the above in ``list(...)`` **WILL** cause it to evaluate
     the **ENTIRE** potentially large data set.
 
-    Appropriate use of the ``limit=...`` kwarg to ``Table.query`` &
+    Appropriate use of the ``limit=...`` kwarg to ``Table.query_2`` &
     ``Table.scan`` calls are **VERY** important should you chose to do this.
 
     Alternatively, you can build your own list, using ``for`` on the

--- a/docs/source/migrations/dynamodb_v1_to_v2.rst
+++ b/docs/source/migrations/dynamodb_v1_to_v2.rst
@@ -231,7 +231,7 @@ DynamoDB v2::
 
     >>> from boto.dynamodb2.table import Table
     >>> table = Table('messages')
-    >>> items = table.query(
+    >>> items = table.query_2(
     ...     forum_name__eq='Amazon DynamoDB',
     ...     subject__beginswith='DynamoDB',
     ...     limit=1

--- a/tests/integration/dynamodb2/test_highlevel.py
+++ b/tests/integration/dynamodb2/test_highlevel.py
@@ -219,7 +219,7 @@ class DynamoDBv2Test(unittest.TestCase):
         self.assertEqual(serverside_sadie['first_name'], 'Sadie')
 
         # Test the eventually consistent query.
-        results = users.query(
+        results = users.query_2(
             username__eq='johndoe',
             last_name__eq='Doe',
             index='LastNameIndex',
@@ -232,7 +232,7 @@ class DynamoDBv2Test(unittest.TestCase):
             self.assertEqual(res.keys(), ['username'])
 
         # Ensure that queries with attributes don't return the hash key.
-        results = users.query(
+        results = users.query_2(
             username__eq='johndoe',
             friend_count__eq=4,
             attributes=('first_name',)
@@ -243,7 +243,7 @@ class DynamoDBv2Test(unittest.TestCase):
             self.assertEqual(res.keys(), ['first_name'])
 
         # Test the strongly consistent query.
-        c_results = users.query(
+        c_results = users.query_2(
             username__eq='johndoe',
             last_name__eq='Doe',
             index='LastNameIndex',
@@ -322,7 +322,7 @@ class DynamoDBv2Test(unittest.TestCase):
             username__eq='johndoe'
         )
         # But it shouldn't break on more complex tables.
-        res = users.query(username__eq='johndoe')
+        res = users.query_2(username__eq='johndoe')
 
         # Test putting with/without sets.
         mau5_created = users.put_item(data={
@@ -458,14 +458,14 @@ class DynamoDBv2Test(unittest.TestCase):
         })
 
         # Try the main key. Should be fine.
-        rs = users.query(
+        rs = users.query_2(
             user_id__eq='24'
         )
         results = sorted([user['username'] for user in rs])
         self.assertEqual(results, ['alice'])
 
         # Now try the GSI. Also should work.
-        rs = users.query(
+        rs = users.query_2(
             username__eq='johndoe',
             index='UsernameIndex'
         )
@@ -504,7 +504,7 @@ class DynamoDBv2Test(unittest.TestCase):
         time.sleep(5)
 
         # Test the reduced page size.
-        results = posts.query(
+        results = posts.query_2(
             thread__eq='Favorite chiptune band?',
             posted_on__gte='2013-12-24T00:00:00',
             max_page_size=2
@@ -515,4 +515,117 @@ class DynamoDBv2Test(unittest.TestCase):
             [post['posted_by'] for post in all_posts],
             ['joe', 'jane', 'joe', 'joe', 'jane', 'joe']
         )
-        self.assertEqual(results._fetches, 3)
+        self.assertTrue(results._fetches >= 3)
+
+    def test_query_with_reverse(self):
+        posts = Table.create('more-posts', schema=[
+            HashKey('thread'),
+            RangeKey('posted_on')
+        ], throughput={
+            'read': 5,
+            'write': 5,
+        })
+        self.addCleanup(posts.delete)
+
+        # Wait for it.
+        time.sleep(60)
+
+        # Add some data.
+        test_data_path = os.path.join(
+            os.path.dirname(__file__),
+            'forum_test_data.json'
+        )
+        with open(test_data_path, 'r') as test_data:
+            data = json.load(test_data)
+
+            with posts.batch_write() as batch:
+                for post in data:
+                    batch.put_item(post)
+
+        time.sleep(5)
+
+        # Test the default order (ascending).
+        results = posts.query_2(
+            thread__eq='Favorite chiptune band?',
+            posted_on__gte='2013-12-24T00:00:00'
+        )
+        self.assertEqual(
+            [post['posted_on'] for post in results],
+            [
+                '2013-12-24T12:30:54',
+                '2013-12-24T12:35:40',
+                '2013-12-24T13:45:30',
+                '2013-12-24T14:15:14',
+                '2013-12-24T14:25:33',
+                '2013-12-24T15:22:22',
+            ]
+        )
+
+        # Test the explicit ascending order.
+        results = posts.query_2(
+            thread__eq='Favorite chiptune band?',
+            posted_on__gte='2013-12-24T00:00:00',
+            reverse=False
+        )
+        self.assertEqual(
+            [post['posted_on'] for post in results],
+            [
+                '2013-12-24T12:30:54',
+                '2013-12-24T12:35:40',
+                '2013-12-24T13:45:30',
+                '2013-12-24T14:15:14',
+                '2013-12-24T14:25:33',
+                '2013-12-24T15:22:22',
+            ]
+        )
+
+        # Test the explicit descending order.
+        results = posts.query_2(
+            thread__eq='Favorite chiptune band?',
+            posted_on__gte='2013-12-24T00:00:00',
+            reverse=True
+        )
+        self.assertEqual(
+            [post['posted_on'] for post in results],
+            [
+                '2013-12-24T15:22:22',
+                '2013-12-24T14:25:33',
+                '2013-12-24T14:15:14',
+                '2013-12-24T13:45:30',
+                '2013-12-24T12:35:40',
+                '2013-12-24T12:30:54',
+            ]
+        )
+
+        # Test the old, broken style.
+        results = posts.query(
+            thread__eq='Favorite chiptune band?',
+            posted_on__gte='2013-12-24T00:00:00'
+        )
+        self.assertEqual(
+            [post['posted_on'] for post in results],
+            [
+                '2013-12-24T15:22:22',
+                '2013-12-24T14:25:33',
+                '2013-12-24T14:15:14',
+                '2013-12-24T13:45:30',
+                '2013-12-24T12:35:40',
+                '2013-12-24T12:30:54',
+            ]
+        )
+        results = posts.query(
+            thread__eq='Favorite chiptune band?',
+            posted_on__gte='2013-12-24T00:00:00',
+            reverse=True
+        )
+        self.assertEqual(
+            [post['posted_on'] for post in results],
+            [
+                '2013-12-24T12:30:54',
+                '2013-12-24T12:35:40',
+                '2013-12-24T13:45:30',
+                '2013-12-24T14:15:14',
+                '2013-12-24T14:25:33',
+                '2013-12-24T15:22:22',
+            ]
+        )

--- a/tests/unit/dynamodb2/test_table.py
+++ b/tests/unit/dynamodb2/test_table.py
@@ -883,7 +883,7 @@ class ResultSetTestCase(unittest.TestCase):
         self.results.fetch_more()
         self.result_function.assert_called_with('john', greeting='Hello', limit=10)
         self.result_function.reset_mock()
-    
+
     def test_fetch_more(self):
         # First "page".
         self.results.fetch_more()
@@ -2196,7 +2196,7 @@ class TableTestCase(unittest.TestCase):
 
         mock_query.assert_called_once_with('users',
             consistent_read=False,
-            scan_index_forward=True,
+            scan_index_forward=False,
             index_name=None,
             attributes_to_get=None,
             limit=4,
@@ -2243,7 +2243,7 @@ class TableTestCase(unittest.TestCase):
             },
             index_name=None,
             attributes_to_get=None,
-            scan_index_forward=True,
+            scan_index_forward=False,
             limit=4,
             exclusive_start_key={
                 'username': {
@@ -2376,7 +2376,7 @@ class TableTestCase(unittest.TestCase):
             'last_key': 'jane',
         }
 
-        results = self.users.query(last_name__eq='Doe')
+        results = self.users.query_2(last_name__eq='Doe')
         self.assertTrue(isinstance(results, ResultSet))
         self.assertEqual(len(results._results), 0)
         self.assertEqual(results.the_callable, self.users._query)
@@ -2430,7 +2430,7 @@ class TableTestCase(unittest.TestCase):
             'last_key': 'jane',
         }
 
-        results = self.users.query(last_name__eq='Doe',
+        results = self.users.query_2(last_name__eq='Doe',
                                    attributes=['username'])
         self.assertTrue(isinstance(results, ResultSet))
         self.assertEqual(len(results._results), 0)


### PR DESCRIPTION
This is more backward-compatible than the previous attempt. Mostly the same as #2160, but introduces it as a new method & recommends the user chose `query_2`.

Fixes #2160 & all previous.

Review please? @danielgtaylor
