### PR TITLE
Fix specification of elasticbeanstalk tier

### DIFF
--- a/boto/beanstalk/layer1.py
+++ b/boto/beanstalk/layer1.py
@@ -351,9 +351,9 @@ class Layer1(AWSQueryConnection):
             self.build_list_params(params, options_to_remove,
                                    'OptionsToRemove.member')
         if tier_name and tier_type and tier_version:
-            params['Tier.member.Name'] = tier_name
-            params['Tier.member.Type'] = tier_type
-            params['Tier.member.Version'] = tier_version
+            params['Tier.Name'] = tier_name
+            params['Tier.Type'] = tier_type
+            params['Tier.Version'] = tier_version
         return self._get_response('CreateEnvironment', params)
 
     def create_storage_location(self):
@@ -1138,9 +1138,9 @@ class Layer1(AWSQueryConnection):
             self.build_list_params(params, options_to_remove,
                                    'OptionsToRemove.member')
         if tier_name and tier_type and tier_version:
-            params['Tier.member.Name'] = tier_name
-            params['Tier.member.Type'] = tier_type
-            params['Tier.member.Version'] = tier_version
+            params['Tier.Name'] = tier_name
+            params['Tier.Type'] = tier_type
+            params['Tier.Version'] = tier_version
         return self._get_response('UpdateEnvironment', params)
 
     def validate_configuration_settings(self, application_name,

--- a/tests/unit/beanstalk/test_layer1.py
+++ b/tests/unit/beanstalk/test_layer1.py
@@ -143,7 +143,7 @@ class TestCreateEnvironment(AWSMockServiceTestCase):
             'OptionSettings.member.2.Namespace': 'aws:elasticbeanstalk:application:environment',
             'OptionSettings.member.2.OptionName': 'ENVVAR',
             'OptionSettings.member.2.Value': 'VALUE1',
-            'Tier.member.Name': 'Worker',
-            'Tier.member.Type': 'SQS/HTTP',
-            'Tier.member.Version': '1.0',
+            'Tier.Name': 'Worker',
+            'Tier.Type': 'SQS/HTTP',
+            'Tier.Version': '1.0',
         })


### PR DESCRIPTION
According to the API: http://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_CreateEnvironment.html
The `member` part of the Tier key names is not valid.
I was always getting:

``` js
{"Error":
    {"Code":"InvalidParameterValue",
     "Message":"Environment tier definition not found",
     "Type":"Sender"},
"RequestId":"xxxxx"}
```

This allows an environment to be created and to specify the tier_name and tier_type.

``` py
tier_name = 'Worker'
tier_type = 'SQS/HTTP'
environment = beanstalk.create_environment(application_name, environment_name, version_label=label,
                                            template_name=template_name, description=None,
                                            option_settings=None, options_to_remove=None,
                                            tier_name=tier_name, tier_type=tier_type, tier_version='1.0')
```
