### PR TITLE
Fixes layer1 modify_db_parameter_group

### DIFF
--- a/boto/rds2/layer1.py
+++ b/boto/rds2/layer1.py
@@ -2890,7 +2890,7 @@ class RDSConnection(AWSQueryConnection):
         self.build_complex_list_params(
             params, parameters,
             'Parameters.member',
-            ('ParameterName', 'ParameterValue', 'Description', 'Source', 'ApplyType', 'DataType', 'AllowedValues', 'IsModifiable', 'MinimumEngineVersion', 'ApplyMethod'))
+            ('ParameterName', 'ParameterValue', 'ApplyMethod'))
         return self._make_request(
             action='ModifyDBParameterGroup',
             verb='POST',


### PR DESCRIPTION
modify_db_parameter_group is currently broken, suggesting no one has ever tried to use the method before. Now I'm very curious how much of Boto has actually been tested against AWS...this greatly reduces my confidence in Boto :(

As stated in the documentation, the function should only expect values
for ParameterName, ParameterValue, and ApplyMethod instead of all the
fields supplied when reading parameters from RDS.
