### PR TITLE
Clarify that MTurkConnection.get_assignments attributes are actually strings

### DIFF
--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -388,15 +388,15 @@ class MTurkConnection(AWSQueryConnection):
                 The number of assignments on the page in the filtered results
                 list, equivalent to the number of assignments being returned
                 by this call.
-                A non-negative integer
+                A non-negative integer, as a string.
         PageNumber
                 The number of the page in the filtered results list being
                 returned.
-                A positive integer
+                A positive integer, as a string.
         TotalNumResults
                 The total number of HITs in the filtered results list based
                 on this call.
-                A non-negative integer
+                A non-negative integer, as a string.
 
         The ResultSet will contain zero or more Assignment objects
 

--- a/tests/mturk/reviewable_hits.doctest
+++ b/tests/mturk/reviewable_hits.doctest
@@ -84,10 +84,10 @@ True
 >>> len(assignments_rs) == int(assignments_rs.NumResults)
 True
 
->>> assignments_rs.PageNumber
-u'1'
+>>> int(assignments_rs.PageNumber)
+1
 
->>> assignments_rs.TotalNumResults >= 1
+>>> int(assignments_rs.TotalNumResults) >= 1
 True
 
 # should contain at least one Assignment object


### PR DESCRIPTION
Fixes #2176.

I also edited a doctest accordingly.
