### PR TITLE
Align volume delete on terminate with AWS defaults

### DIFF
--- a/boto/ec2/blockdevicemapping.py
+++ b/boto/ec2/blockdevicemapping.py
@@ -35,7 +35,7 @@ class BlockDeviceType(object):
                  snapshot_id=None,
                  status=None,
                  attach_time=None,
-                 delete_on_termination=False,
+                 delete_on_termination=True,
                  size=None,
                  volume_type=None,
                  iops=None):

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -266,7 +266,8 @@ class EC2Connection(AWSQueryConnection):
                        root_device_name=None, block_device_map=None,
                        dry_run=False, virtualization_type=None,
                        sriov_net_support=None,
-                       snapshot_id=None):
+                       snapshot_id=None, 
+                       delete_root_volume_on_termination=True):
         """
         Register an image.
 
@@ -315,6 +316,11 @@ class EC2Connection(AWSQueryConnection):
             as root device for the image. Mutually exclusive with
             block_device_map, requires root_device_name
 
+        :type delete_root_volume_on_termination: bool
+        :param delete_root_volume_on_termination: Whether to delete the root
+            volume of the image after instance termination. Only applies when
+            creating image from snapshot_id.
+
         :rtype: string
         :return: The new image id
         """
@@ -334,7 +340,8 @@ class EC2Connection(AWSQueryConnection):
         if root_device_name:
             params['RootDeviceName'] = root_device_name
         if snapshot_id:
-            root_vol = BlockDeviceType(snapshot_id=snapshot_id)
+            root_vol = BlockDeviceType(snapshot_id=snapshot_id, 
+              delete_on_termination=delete_root_volume_on_termination)
             block_device_map = BlockDeviceMapping()
             block_device_map[root_device_name] = root_vol
         if block_device_map:

--- a/tests/unit/ec2/autoscale/test_group.py
+++ b/tests/unit/ec2/autoscale/test_group.py
@@ -370,10 +370,10 @@ class TestLaunchConfiguration(AWSMockServiceTestCase):
         self.assert_request_parameters({
             'Action': 'CreateLaunchConfiguration',
             'BlockDeviceMappings.member.1.DeviceName': '/dev/sdf',
-            'BlockDeviceMappings.member.1.Ebs.DeleteOnTermination': 'false',
+            'BlockDeviceMappings.member.1.Ebs.DeleteOnTermination': 'true',
             'BlockDeviceMappings.member.1.Ebs.SnapshotId': 'snap-12345',
             'BlockDeviceMappings.member.2.DeviceName': '/dev/sdg',
-            'BlockDeviceMappings.member.2.Ebs.DeleteOnTermination': 'false',
+            'BlockDeviceMappings.member.2.Ebs.DeleteOnTermination': 'true',
             'BlockDeviceMappings.member.2.Ebs.SnapshotId': 'snap-12346',
             'EbsOptimized': 'false',
             'LaunchConfigurationName': 'launch_config',

--- a/tests/unit/ec2/test_blockdevicemapping.py
+++ b/tests/unit/ec2/test_blockdevicemapping.py
@@ -96,7 +96,7 @@ class TestLaunchConfiguration(AWSMockServiceTestCase):
         # Autoscaling).
         self.set_http_response(status_code=200)
         dev_sdf = BlockDeviceType(snapshot_id='snap-12345')
-        dev_sdg = BlockDeviceType(snapshot_id='snap-12346')
+        dev_sdg = BlockDeviceType(snapshot_id='snap-12346', delete_on_termination=False)
 
         bdm = BlockDeviceMapping()
         bdm['/dev/sdf'] = dev_sdf
@@ -112,7 +112,7 @@ class TestLaunchConfiguration(AWSMockServiceTestCase):
         self.assert_request_parameters({
             'Action': 'RunInstances',
             'BlockDeviceMapping.1.DeviceName': '/dev/sdf',
-            'BlockDeviceMapping.1.Ebs.DeleteOnTermination': 'false',
+            'BlockDeviceMapping.1.Ebs.DeleteOnTermination': 'true',
             'BlockDeviceMapping.1.Ebs.SnapshotId': 'snap-12345',
             'BlockDeviceMapping.2.DeviceName': '/dev/sdg',
             'BlockDeviceMapping.2.Ebs.DeleteOnTermination': 'false',

--- a/tests/unit/ec2/test_connection.py
+++ b/tests/unit/ec2/test_connection.py
@@ -186,7 +186,7 @@ class TestCreateImage(TestEC2ConnectionBase):
             'InstanceId': 'instance_id',
             'Name': 'name',
             'BlockDeviceMapping.1.DeviceName': 'test',
-            'BlockDeviceMapping.1.Ebs.DeleteOnTermination': 'false'},
+            'BlockDeviceMapping.1.Ebs.DeleteOnTermination': 'true'},
              ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                    'SignatureVersion', 'Timestamp',
                                    'Version'])
@@ -1248,6 +1248,44 @@ class TestRegisterImage(TestEC2ConnectionBase):
             'Name': 'name',
             'Description': 'description',
             'SriovNetSupport': 'simple'
+        }, ignore_params_values=[
+            'AWSAccessKeyId', 'SignatureMethod',
+            'SignatureVersion', 'Timestamp',
+            'Version'
+        ])
+    
+    def test_volume_delete_on_termination_off(self):
+        self.set_http_response(status_code=200)
+        self.ec2.register_image('name', 'description',
+                                snapshot_id='snap-12345678',
+                                delete_root_volume_on_termination=False)
+        
+        self.assert_request_parameters({
+            'Action': 'RegisterImage',
+            'Name': 'name',
+            'Description': 'description',
+            'BlockDeviceMapping.1.DeviceName': None,
+            'BlockDeviceMapping.1.Ebs.DeleteOnTermination' : 'false',
+            'BlockDeviceMapping.1.Ebs.SnapshotId': 'snap-12345678',
+        }, ignore_params_values=[
+            'AWSAccessKeyId', 'SignatureMethod',
+            'SignatureVersion', 'Timestamp',
+            'Version'
+        ])
+        
+
+    def test_volume_delete_on_termination_default(self):
+        self.set_http_response(status_code=200)
+        self.ec2.register_image('name', 'description',
+                                snapshot_id='snap-12345678')
+        
+        self.assert_request_parameters({
+            'Action': 'RegisterImage',
+            'Name': 'name',
+            'Description': 'description',
+            'BlockDeviceMapping.1.DeviceName': None,
+            'BlockDeviceMapping.1.Ebs.DeleteOnTermination' : 'true',
+            'BlockDeviceMapping.1.Ebs.SnapshotId': 'snap-12345678',
         }, ignore_params_values=[
             'AWSAccessKeyId', 'SignatureMethod',
             'SignatureVersion', 'Timestamp',


### PR DESCRIPTION
This pull request changes the default delete_on_termination flag to True, as it is in AWS.  It also updates register_image to allow users to make an explicit choice of whether to delete on termination for images created with the snapshot_id arg.

I made this change after discovering that our new image creation process was leaving volumes behind.  When we discovered this, we had about 4.5TB of volumes that we had generated over the past few weeks from launching and terminating autoscaled instances.

This was unexpected for us, as the AWS default is to delete volumes on termination unless explicitly told not to.
