### PR TITLE
Add AAAA Zone record functions and tests

### DIFF
--- a/boto/route53/zone.py
+++ b/boto/route53/zone.py
@@ -184,6 +184,20 @@ class Zone(object):
                                identifier=identifier,
                                comment=comment)
 
+    def add_aaaa(self, name, value, ttl=None, identifier=None, comment=""):
+        """
+        Add a new AAAA (IPv6) record to this Zone.  See _new_record for
+        parameter documentation.  Returns a Status object.
+        """
+        ttl = ttl or default_ttl
+        name = self.route53connection._make_qualified(name)
+        return self.add_record(resource_type='AAAA',
+                               name=name,
+                               value=value,
+                               ttl=ttl,
+                               identifier=identifier,
+                               comment=comment)
+
     def add_mx(self, name, records, ttl=None, identifier=None, comment=""):
         """
         Add a new MX record to this Zone.  See _new_record for
@@ -288,6 +302,18 @@ class Zone(object):
         """
         return self.find_records(name, 'A', all=all)
 
+    def get_aaaa(self, name, all=False):
+        """
+        Search this Zone for AAAA (IPv6) records that match name.
+
+        Returns a ResourceRecord.
+
+        If there is more than one match return all as a
+        ResourceRecordSets if all is True, otherwise throws
+        TooManyRecordsException.
+        """
+        return self.find_records(name, 'AAAA', all=all)
+
     def get_mx(self, name, all=False):
         """
         Search this Zone for MX records that match name.
@@ -328,6 +354,23 @@ class Zone(object):
         """
         name = self.route53connection._make_qualified(name)
         old_record = self.get_a(name)
+        ttl = ttl or old_record.ttl
+        return self.update_record(old_record,
+                                  new_value=value,
+                                  new_ttl=ttl,
+                                  new_identifier=identifier,
+                                  comment=comment)
+
+    def update_aaaa(self, name, value, ttl=None, identifier=None, comment=""):
+        """
+        Update the given AAAA (IPv6) record in this Zone to a new value, ttl,
+        and identifier.  Returns a Status object.
+
+        Will throw TooManyRecordsException is name, value does not match
+        a single record.
+        """
+        name = self.route53connection._make_qualified(name)
+        old_record = self.get_aaaa(name)
         ttl = ttl or old_record.ttl
         return self.update_record(old_record,
                                   new_value=value,
@@ -376,6 +419,19 @@ class Zone(object):
         """
         name = self.route53connection._make_qualified(name)
         record = self.find_records(name, 'A', identifier=identifier,
+                                   all=all)
+        return self.delete_record(record)
+
+    def delete_aaaa(self, name, identifier=None, all=False):
+        """
+        Delete an AAAA (IPv6) record matching name and identifier from this
+        Zone.  Returns a Status object.
+
+        If there is more than one match delete all matching records if
+        all is True, otherwise throws TooManyRecordsException.
+        """
+        name = self.route53connection._make_qualified(name)
+        record = self.find_records(name, 'AAAA', identifier=identifier,
                                    all=all)
         return self.delete_record(record)
 

--- a/tests/integration/route53/test_zone.py
+++ b/tests/integration/route53/test_zone.py
@@ -55,6 +55,19 @@ class TestRoute53Zone(unittest.TestCase):
         self.assertEquals(record.resource_records, [u'186.143.32.2'])
         self.assertEquals(record.ttl, u'800')
 
+    def test_aaaa(self):
+        self.zone.add_aaaa(self.base_domain, '3ffe::2', 80)
+        record = self.zone.get_aaaa(self.base_domain)
+        self.assertEquals(record.name, u'%s.' % self.base_domain)
+        self.assertEquals(record.resource_records, [u'3ffe::2'])
+        self.assertEquals(record.ttl, u'80')
+        self.zone.update_aaaa(self.base_domain, '3ffe:1000:1:2::1', '800')
+        record = self.zone.get_aaaa(self.base_domain)
+        self.assertEquals(record.name, u'%s.' % self.base_domain)
+        self.assertEquals(record.resource_records, [u'3ffe:1000:1:2::1'])
+        self.assertEquals(record.ttl, u'800')
+
+
     def test_cname(self):
         self.zone.add_cname(
             'www.%s' % self.base_domain,
@@ -158,6 +171,7 @@ class TestRoute53Zone(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         self.zone.delete_a(self.base_domain)
+        self.zone.delete_aaaa(self.base_domain)
         self.zone.delete_cname('www.%s' % self.base_domain)
         self.zone.delete_mx(self.base_domain)
         self.zone.delete()


### PR DESCRIPTION
Add the same abilities as 'A' records for 'AAAA' to support IPv6 in Route 53. All functions and tests are essentially copied from the existing 'A' functions, such as get_a -> get_aaaa, delete_a -> delete_aaaa.

Integration tests are also included and results shown below:

```
[ematthews@frederick route53]$ python test_zone.py
test_a (__main__.TestRoute53Zone) ... ok
test_aaaa (__main__.TestRoute53Zone) ... ok
test_cname (__main__.TestRoute53Zone) ... ok
test_get_nameservers (__main__.TestRoute53Zone) ... ok
test_get_records (__main__.TestRoute53Zone) ... ok
test_get_zones (__main__.TestRoute53Zone) ... ok
test_identifiers_lbrs (__main__.TestRoute53Zone) ... ok
test_identifiers_wrrs (__main__.TestRoute53Zone) ... ok
test_mx (__main__.TestRoute53Zone) ... ok
test_nameservers (__main__.TestRoute53Zone) ... ok
test_toomany_exception (__main__.TestRoute53Zone) ... ok

----------------------------------------------------------------------
Ran 11 tests in 4.216s

OK
```
