### PR TITLE
(EMR) Fix bug where StepStatus was parsed as ClusterStatus, breaking step timelines

### DIFF
--- a/boto/emr/emrobject.py
+++ b/boto/emr/emrobject.py
@@ -338,7 +338,7 @@ class HadoopStep(EmrObject):
             self.config = StepConfig()
             return self.config
         elif name == 'Status':
-            self.status = ClusterStatus()
+            self.status = StepStatus()
             return self.status
         else:
             return None
@@ -425,6 +425,31 @@ class InstanceList(EmrObject):
             return None
 
 
+class StepTimeline(EmrObject):
+    Fields = set([
+        'CreationDateTime',
+        'StartDateTime',
+        'EndDateTime'
+    ])
+
+class StepStatus(EmrObject):
+    Fields = set([
+        'State',
+        'StateChangeReason',
+        'Timeline'
+    ])
+
+    def __init__(self, connection=None):
+        self.connection = connection
+        self.timeline = None
+
+    def startElement(self, name, attrs, connection):
+        if name == 'Timeline':
+            self.timeline = StepTimeline()
+            return self.timeline
+        else:
+            return None
+
 class StepSummary(EmrObject):
     Fields = set([
         'Id',
@@ -437,7 +462,7 @@ class StepSummary(EmrObject):
 
     def startElement(self, name, attrs, connection):
         if name == 'Status':
-            self.status = ClusterStatus()
+            self.status = StepStatus()
             return self.status
         else:
             return None

--- a/tests/unit/emr/test_emr_responses.py
+++ b/tests/unit/emr/test_emr_responses.py
@@ -447,7 +447,7 @@ class TestEMRResponses(unittest.TestCase):
         self.assertEquals("2014-04-10T08:08:41Z",
                           step.status.timeline.enddatetime)
 
-    def test_list_step_response(self):
+    def test_list_steps_response(self):
         [steps] = self._parse_xml(LIST_STEPS,
                                   [('ListStepsResult', emrobject.StepSummaryList)])
         summary = steps.steps[0]

--- a/tests/unit/emr/test_emr_responses.py
+++ b/tests/unit/emr/test_emr_responses.py
@@ -320,6 +320,66 @@ JOB_FLOW_COMPLETED = """
 </DescribeJobFlowsResponse>
 """
 
+DESCRIBE_STEP = """
+<DescribeStepResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
+  <DescribeStepResult>
+    <Step>
+      <Id>s-3NI20LLUAX13D</Id>
+      <Status>
+        <StateChangeReason/>
+        <State>COMPLETED</State>
+        <Timeline>
+          <CreationDateTime>2014-04-10T08:02:01Z</CreationDateTime>
+          <StartDateTime>2014-04-10T08:08:16Z</StartDateTime>
+          <EndDateTime>2014-04-10T08:08:41Z</EndDateTime>
+        </Timeline>
+      </Status>
+      <Name>Install Pig</Name>
+      <Config>
+        <Jar>s3n://us-east-1.elasticmapreduce/libs/script-runner/script-runner.jar</Jar>
+        <Args>
+          <member>s3n://us-east-1.elasticmapreduce/libs/pig/pig-script</member>
+          <member>--base-path</member>
+          <member>s3n://us-east-1.elasticmapreduce/libs/pig/</member>
+          <member>--install-pig</member>
+          <member>--pig-versions</member>
+          <member>latest</member>
+        </Args>
+        <Properties/>
+      </Config>
+      <ActionOnFailure>TERMINATE_CLUSTER</ActionOnFailure>
+    </Step>
+  </DescribeStepResult>
+  <ResponseMetadata>
+    <RequestId>a560e959-c564-11e3-be57-270e2b702778</RequestId>
+  </ResponseMetadata>
+</DescribeStepResponse>
+"""
+
+LIST_STEPS = """
+<ListStepsResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
+  <ListStepsResult>
+    <Steps>
+      <member>
+        <Id>s-3NI20LLUAX13D</Id>
+        <Status>
+          <StateChangeReason/>
+          <State>COMPLETED</State>
+          <Timeline>
+            <CreationDateTime>2014-04-10T08:02:01Z</CreationDateTime>
+            <StartDateTime>2014-04-10T08:08:16Z</StartDateTime>
+            <EndDateTime>2014-04-10T08:08:41Z</EndDateTime>
+          </Timeline>
+        </Status>
+        <Name>Install Pig</Name>
+      </member>
+    </Steps>
+  </ListStepsResult>
+  <ResponseMetadata>
+    <RequestId>e38d0c33-c564-11e3-acdb-1f4611226308</RequestId>
+  </ResponseMetadata>
+</ListStepsResponse>
+"""
 
 class TestEMRResponses(unittest.TestCase):
     def _parse_xml(self, body, markers):
@@ -371,3 +431,34 @@ class TestEMRResponses(unittest.TestCase):
         self.assertEquals(6, len(jobflow.steps))
         self.assertEquals(2, len(jobflow.instancegroups))
 
+    def test_describe_step_response(self):
+        [step] = self._parse_xml(DESCRIBE_STEP,
+                                 [('Step', emrobject.HadoopStep)])
+
+        self._assert_fields(step,
+                            id="s-3NI20LLUAX13D",
+                            actiononfailure="TERMINATE_CLUSTER",
+                            name="Install Pig")
+
+        self.assertEquals("2014-04-10T08:02:01Z",
+                          step.status.timeline.creationdatetime)
+        self.assertEquals("2014-04-10T08:08:16Z",
+                          step.status.timeline.startdatetime)
+        self.assertEquals("2014-04-10T08:08:41Z",
+                          step.status.timeline.enddatetime)
+
+    def test_list_step_response(self):
+        [steps] = self._parse_xml(LIST_STEPS,
+                                  [('ListStepsResult', emrobject.StepSummaryList)])
+        summary = steps.steps[0]
+
+        self._assert_fields(summary,
+                            id="s-3NI20LLUAX13D",
+                            name="Install Pig")
+
+        self.assertEquals("2014-04-10T08:02:01Z",
+                          summary.status.timeline.creationdatetime)
+        self.assertEquals("2014-04-10T08:08:16Z",
+                          summary.status.timeline.startdatetime)
+        self.assertEquals("2014-04-10T08:08:41Z",
+                          summary.status.timeline.enddatetime)


### PR DESCRIPTION
This bug caused step timelines to lack the startdatetime attribute. (Cluster timelines have a different attribute; readydatetime).

Relevant docs:
http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_DescribeStep.html
http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_ListSteps.html
http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_StepStatus.html
