### PR TITLE
Converting policy to bytes to do a valid b64encode

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -303,7 +303,7 @@ class S3Connection(AWSAuthConnection):
                            'value': server_side_encryption})
             conditions.append('{"x-amz-server-side-encryption": "%s"}' % server_side_encryption)
 
-        policy = self.build_post_policy(expiration, conditions)
+        policy = self.build_post_policy(expiration, conditions).encode()
 
         # Add the base64-encoded policy document as the 'policy' field
         policy_b64 = base64.b64encode(policy)


### PR DESCRIPTION
S3Connection.build_post_policy returns a string and in order to do a
base64-encode, we need it to be in bytes.
