### PR TITLE
Fixes a bug with TCP health check request generation where ResourcePath ...

### DIFF
--- a/boto/route53/healthcheck.py
+++ b/boto/route53/healthcheck.py
@@ -56,13 +56,15 @@ class HealthCheck(object):
             <IPAddress>%(ip_addr)s</IPAddress>
             <Port>%(port)s</Port>
             <Type>%(type)s</Type>
-            <ResourcePath>%(resource_path)s</ResourcePath>
+            %(resource_path)s
             %(fqdn_part)s
             %(string_match_part)s
             %(request_interval)s
             <FailureThreshold>%(failure_threshold)s</FailureThreshold>
         </HealthCheckConfig>
     """
+
+    XMLResourcePathPart = """<ResourcePath>%(resource_path)s</ResourcePath>"""
 
     XMLFQDNPart = """<FullyQualifiedDomainName>%(fqdn)s</FullyQualifiedDomainName>"""
 
@@ -125,7 +127,7 @@ class HealthCheck(object):
             'ip_addr': self.ip_addr,
             'port': self.port,
             'type': self.hc_type,
-            'resource_path': self.resource_path,
+            'resource_path': "",
             'fqdn_part': "",
             'string_match_part': "",
             'request_interval': (self.XMLRequestIntervalPart %
@@ -137,5 +139,8 @@ class HealthCheck(object):
 
         if self.string_match is not None:
             params['string_match_part'] = self.XMLStringMatchPart % {'string_match' : self.string_match}
+
+        if self.resource_path is not None:
+            params['resource_path'] = self.XMLResourcePathPart % {'resource_path' : self.resource_path}
 
         return self.POSTXMLBody % params


### PR DESCRIPTION
...should not be included in the request XML

There is an error when you try to create a TCP health check in route53 due to the fact that the tcp health check does not support ResourcePath

Invalid request:

```
<CallerReference>f239c81e-a761-49d6-b4f8-05d5ed8ec167</CallerReference>

    <HealthCheckConfig>
        <IPAddress>54.54.54.54</IPAddress>
        <Port>1024</Port>
        <Type>TCP</Type>
        <ResourcePath>None</ResourcePath>


        <RequestInterval>10</RequestInterval>
        <FailureThreshold>7</FailureThreshold>
    </HealthCheckConfig>

</CreateHealthCheckRequest>
```

Error:

```
<ErrorResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
    <Error><Type>Sender</Type><Code>InvalidInput</Code><Message>TCP health checks must not have a resource path specificed.</Message></Error><RequestId>4bf97687-c58c-11e3-9c4f-b18f7840909a</RequestId>
</ErrorResponse>
```

Valid request with this patch:

```
<CallerReference>f239c81e-a761-49d6-b4f8-05d5ed8ec167</CallerReference>

    <HealthCheckConfig>
        <IPAddress>54.54.54.54</IPAddress>
        <Port>1024</Port>
        <Type>TCP</Type>



        <RequestInterval>10</RequestInterval>
        <FailureThreshold>7</FailureThreshold>
    </HealthCheckConfig>

</CreateHealthCheckRequest>
```
