### PR TITLE
Explicitly catch storage response errors for buckets that don't exist, r...

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -538,7 +538,9 @@ class S3Connection(AWSAuthConnection):
         """
         try:
             bucket = self.get_bucket(bucket_name, validate, headers=headers)
-        except:
+        except self.provider.storage_response_error, e:
+            if e.status != 404:
+                raise
             bucket = None
         return bucket
 


### PR DESCRIPTION
...e-raise other exceptions.

The documentation for the S3 connection lookup method states that an exception will not be raised if a bucket that's looked up does not exist. While this is fine and works as advertised, other code paths triggered by this method may instead raise an exception that is not tied to the existence of the bucket; the example that I've encountered was with a boto auth plugin that was used behind the scenes to authenticate the lookup request.

In this scenario the current code suppresses any and all exceptions without discriminating on type, and returns the same None type that is returned when the request succeeds but the bucket looked up does not exist. Client code in this situation is likely to get confused on the outcome of the operation. This pull request attempts a change to silence only storage response errors with a status code of 404 (bucket does not exist), and re-raise all others so they can be properly handled.

Three unit tests are provided to test four scenarios: successful request of an existing bucket, successful request of a non-existing bucket, request that triggers a storage response error exception with a status code != 404, and request that triggers another type of exception.
