### PR TITLE
Fix date parsing (missing timezone)

### DIFF
--- a/boto/utils.py
+++ b/boto/utils.py
@@ -46,6 +46,9 @@ import imp
 import subprocess
 import StringIO
 import time
+import iso8601
+from iso8601 import ParseError
+import dateutil.parser
 import logging.handlers
 import boto
 import boto.provider
@@ -457,15 +460,11 @@ def get_ts(ts=None):
 def parse_ts(ts):
     ts = ts.strip()
     try:
-        dt = datetime.datetime.strptime(ts, ISO8601)
+        dt = iso8601.parse_date(ts)
         return dt
-    except ValueError:
-        try:
-            dt = datetime.datetime.strptime(ts, ISO8601_MS)
-            return dt
-        except ValueError:
-            dt = datetime.datetime.strptime(ts, RFC1123)
-            return dt
+    except ParseError:
+        dt = dateutil.parser.parse(ts)
+        return dt
 
 
 def find_class(module_name, class_name=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ unittest2==0.5.1
 httpretty>=0.7.0
 paramiko>=1.10.0
 PyYAML>=3.10
+iso8601==0.1.10
+python-dateutil==2.2

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -28,6 +28,7 @@ import hashlib
 import hmac
 import mock
 import thread
+import datetime
 import time
 
 import boto.utils
@@ -53,6 +54,47 @@ class TestThreadImport(unittest.TestCase):
             thread.start_new_thread(f, ())
 
         time.sleep(3)
+
+
+class TestTimestampParsing(unittest.TestCase):
+    def test_iso8601(self):
+        dt = boto.utils.parse_ts('2014-01-01T01:05:03Z')
+        self.assertEquals(dt.tzname(), 'UTC')
+
+        dt = boto.utils.parse_ts('2014-01-01T01:05:03+01')
+        self.assertEquals(dt.tzname(), '+01:00')
+
+    def test_iso8601_no_tz(self):
+        dt = boto.utils.parse_ts('2014-01-01T01:05:03')
+        self.assertEquals(dt.tzname(), 'UTC')
+
+    def test_iso8601_ms(self):
+        dt = boto.utils.parse_ts('2014-01-01T01:05:00.685000Z')
+        self.assertEquals(dt.tzname(), 'UTC')
+
+        dt = boto.utils.parse_ts('2014-01-01T01:05:00.685000+01')
+        self.assertEquals(dt.tzname(), '+01:00')
+
+    def test_iso8601_ms_no_tz(self):
+        dt = boto.utils.parse_ts('2014-01-01T01:05:00.685000')
+        self.assertEquals(dt.tzname(), 'UTC')
+
+    def test_rfc1123(self):
+        dt = boto.utils.parse_ts('Thu, 24 Apr 2014 11:44:31 UTC')
+        self.assertEquals(dt.tzname(), 'UTC')
+
+        dt = boto.utils.parse_ts('Thu, 24 Apr 2014 11:44:31 BST')
+        self.assertEquals(dt.tzname(), 'BST')
+
+        dt = boto.utils.parse_ts('Thu, 24 Apr 2014 11:44:31 +0100')
+        self.assertEquals(dt.strftime('%z'), '+0100')
+
+        dt = boto.utils.parse_ts('Thu, 24 Apr 2014 11:44:31 +0000')
+        self.assertEquals(dt.strftime('%z'), '+0000')
+
+    def test_invalid_date(self):
+        with self.assertRaises(ValueError):
+            dt = boto.utils.parse_ts('0')
 
 
 class TestPassword(unittest.TestCase):


### PR DESCRIPTION
When you parse any date (ISO8601 or RFC1123), the `boto.utils.parse_ts()` will always give you instance of `datetime.datetime` **without** `tzinfo` so you can only predict it's UTC, which is true in most cases, but it complicates any further conversions between timezones.

In simple terms the function can't reconstruct the same date passed as it relies on `datetime.strptime()` which ignores parsed timezones in the string too:

https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior

`datetime.strptime(date_string, format)`
is equivalent to
`datetime(*(time.strptime(date_string, format)[0:6]))`

This patch is fixing it.
See attached test suite.

This solves #875 
