### PR TITLE
fix #2235

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -258,7 +258,7 @@ class EC2Connection(AWSQueryConnection):
         """
         try:
             return self.get_all_images(image_ids=[image_id], dry_run=dry_run)[0]
-        except IndexError:  # None of those images available
+        except (IndexError,EC2ResponseError):  # None of those images available
             return None
 
     def register_image(self, name=None, description=None, image_location=None,

--- a/tests/integration/ec2/test_connection.py
+++ b/tests/integration/ec2/test_connection.py
@@ -239,3 +239,15 @@ class EC2ConnectionTest(unittest.TestCase):
 
         # And kill it.
         rs.instances[0].terminate()
+            
+    def test_get_image(self):
+        c = EC2Connection()
+        image = c.get_image('ami-fb8e9292')
+        assert image
+        assert image.id == 'ami-fb8e9292'
+        image = c.get_image('ami-c2492bf3')
+        assert image == None
+
+
+
+


### PR DESCRIPTION
#2235 boto.ec2.connection.get_image throws exception when AMI ID is invalid.
1.Catch EC2ResponseError
2.Add test_get_image test case