### PR TITLE
Add parameter to control auto tag from create_snapshot

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -2420,7 +2420,7 @@ class EC2Connection(AWSQueryConnection):
         return self.get_list('DescribeSnapshots', params,
                              [('item', Snapshot)], verb='POST')
 
-    def create_snapshot(self, volume_id, description=None, dry_run=False):
+    def create_snapshot(self, volume_id, description=None, dry_run=False, add_tag=True):
         """
         Create a snapshot of an existing EBS Volume.
 
@@ -2444,6 +2444,11 @@ class EC2Connection(AWSQueryConnection):
             params['DryRun'] = 'true'
         snapshot = self.get_object('CreateSnapshot', params,
                                    Snapshot, verb='POST')
+        if add_tag:
+            volume = self.get_all_volumes([volume_id], dry_run=dry_run)[0]
+            volume_name = volume.tags.get('Name')
+            if volume_name:
+                snapshot.add_tag('Name', volume_name)
         return snapshot
 
     def delete_snapshot(self, snapshot_id, dry_run=False):


### PR DESCRIPTION
Snapshotting does not imply tagging rights. This regression causes UnauthorizedOperation's to be thrown when tagging fails, which imply a failure of the snapshot when a failure of the snapshot did not occur. This tagging feature should be implemented as a new method that does both, or new parameter that is opt-in, not a backward-incompatible change of the existing behavior of the method.
