### PR TITLE
Add support for SQS message attributes

### DIFF
--- a/boto/sqs/connection.py
+++ b/boto/sqs/connection.py
@@ -144,7 +144,7 @@ class SQSConnection(AWSQueryConnection):
 
     def receive_message(self, queue, number_messages=1,
                         visibility_timeout=None, attributes=None,
-                        wait_time_seconds=None):
+                        wait_time_seconds=None, message_attributes=None):
         """
         Read messages from an SQS Queue.
 
@@ -177,6 +177,11 @@ class SQSConnection(AWSQueryConnection):
             If a message is available, the call will return sooner than
             wait_time_seconds.
 
+        :type message_attributes: list
+        :param message_attributes: The name(s) of additional message
+            attributes to return. The default is to return no additional
+            message attributes. Use ``['All']`` or ``['.*']`` to return all.
+
         :rtype: list
         :return: A list of :class:`boto.sqs.message.Message` objects.
 
@@ -188,6 +193,9 @@ class SQSConnection(AWSQueryConnection):
             self.build_list_params(params, attributes, 'AttributeName')
         if wait_time_seconds is not None:
             params['WaitTimeSeconds'] = wait_time_seconds
+        if message_attributes is not None:
+            self.build_list_params(params, message_attributes,
+                                   'MessageAttributeName')
         return self.get_list('ReceiveMessage', params,
                              [('Message', queue.message_class)],
                              queue.id, queue)
@@ -244,10 +252,61 @@ class SQSConnection(AWSQueryConnection):
         params = {'ReceiptHandle' : receipt_handle}
         return self.get_status('DeleteMessage', params, queue.id)
 
-    def send_message(self, queue, message_content, delay_seconds=None):
+    def send_message(self, queue, message_content, delay_seconds=None,
+                     message_attributes=None):
+        """
+        Send a new message to the queue.
+
+        :type queue: A :class:`boto.sqs.queue.Queue` object.
+        :param queue: The Queue to which the messages will be written.
+
+        :type message_content: string
+        :param message_content: The body of the message
+
+        :type delay_seconds: int
+        :param delay_seconds: Number of seconds (0 - 900) to delay this
+            message from being processed.
+
+        :type message_attributes: dict
+        :param message_attributes: Message attributes to set. Should be
+            of the form:
+
+            {
+                "name1": {
+                    "data_type": "Number",
+                    "string_value": "1"
+                },
+                "name2": {
+                    "data_type": "String",
+                    "string_value": "Bob"
+                }
+            }
+
+        """
         params = {'MessageBody' : message_content}
         if delay_seconds:
             params['DelaySeconds'] = int(delay_seconds)
+
+        if message_attributes is not None:
+            for i, name in enumerate(message_attributes.keys(), start=1):
+                attribute = message_attributes[name]
+                params['MessageAttribute.%s.Name' % i] = name
+                if 'data_type' in attribute:
+                    params['MessageAttribute.%s.Value.DataType' % i] = \
+                        attribute['data_type']
+                if 'string_value' in attribute:
+                    params['MessageAttribute.%s.Value.StringValue' % i] = \
+                        attribute['string_value']
+                if 'binary_value' in attribute:
+                    params['MessageAttribute.%s.Value.BinaryValue' % i] = \
+                        attribute['binary_value']
+                if 'string_list_value' in attribute:
+                    params['MessageAttribute.%s.Value.StringListValue' % i] = \
+                        attribute['string_list_value']
+                if 'binary_list_value' in attribute:
+                    params['MessageAttribute.%s.Value.BinaryListValue' % i] = \
+                        attribute['binary_list_value']
+
         return self.get_object('SendMessage', params, Message,
                                queue.id, verb='POST')
 
@@ -263,19 +322,44 @@ class SQSConnection(AWSQueryConnection):
             tuple represents a single message to be written
             and consists of and ID (string) that must be unique
             within the list of messages, the message body itself
-            which can be a maximum of 64K in length, and an
+            which can be a maximum of 64K in length, an
             integer which represents the delay time (in seconds)
             for the message (0-900) before the message will
-            be delivered to the queue.
+            be delivered to the queue, and an optional dict of
+            message attributes like those passed to ``send_message``
+            above.
+
         """
         params = {}
         for i, msg in enumerate(messages):
-            p_name = 'SendMessageBatchRequestEntry.%i.Id' % (i+1)
-            params[p_name] = msg[0]
-            p_name = 'SendMessageBatchRequestEntry.%i.MessageBody' % (i+1)
-            params[p_name] = msg[1]
-            p_name = 'SendMessageBatchRequestEntry.%i.DelaySeconds' % (i+1)
-            params[p_name] = msg[2]
+            base = 'SendMessageBatchRequestEntry.%i' % (i + 1)
+            params['%s.Id' % base] = msg[0]
+            params['%s.MessageBody' % base] = msg[1]
+            params['%s.DelaySeconds' % base] = msg[2]
+            if len(msg) > 3:
+                base += '.MessageAttribute'
+                for j, name in enumerate(msg[3].keys()):
+                    attribute = msg[3][name]
+
+                    p_name = '%s.%i.Name' % (base, j + 1)
+                    params[p_name] = name
+
+                    if 'data_type' in attribute:
+                        p_name = '%s.%i.DataType' % (base, j + 1)
+                        params[p_name] = attribute['data_type']
+                    if 'string_value' in attribute:
+                        p_name = '%s.%i.StringValue' % (base, j + 1)
+                        params[p_name] = attribute['string_value']
+                    if 'binary_value' in attribute:
+                        p_name = '%s.%i.BinaryValue' % (base, j + 1)
+                        params[p_name] = attribute['binary_value']
+                    if 'string_list_value' in attribute:
+                        p_name = '%s.%i.StringListValue' % (base, j + 1)
+                        params[p_name] = attribute['string_list_value']
+                    if 'binary_list_value' in attribute:
+                        p_name = '%s.%i.BinaryListValue' % (base, j + 1)
+                        params[p_name] = attribute['binary_list_value']
+
         return self.get_object('SendMessageBatch', params, BatchResults,
                                queue.id, verb='POST')
 

--- a/boto/sqs/message.py
+++ b/boto/sqs/message.py
@@ -66,6 +66,7 @@ in the format in which it would be stored in SQS.
 import base64
 import StringIO
 from boto.sqs.attributes import Attributes
+from boto.sqs.messageattributes import MessageAttributes
 from boto.exception import SQSDecodeError
 import boto
 
@@ -84,6 +85,8 @@ class RawMessage(object):
         self.receipt_handle = None
         self.md5 = None
         self.attributes = Attributes(self)
+        self.message_attributes = MessageAttributes(self)
+        self.md5_message_attributes = None
 
     def __len__(self):
         return len(self.encode(self._body))
@@ -91,6 +94,8 @@ class RawMessage(object):
     def startElement(self, name, attrs, connection):
         if name == 'Attribute':
             return self.attributes
+        if name == 'MessageAttribute':
+            return self.message_attributes
         return None
 
     def endElement(self, name, value, connection):
@@ -100,8 +105,10 @@ class RawMessage(object):
             self.id = value
         elif name == 'ReceiptHandle':
             self.receipt_handle = value
-        elif name == 'MD5OfMessageBody':
+        elif name == 'MD5OfBody':
             self.md5 = value
+        elif name == 'MD5OfMessageAttributes':
+            self.md5_message_attributes = value
         else:
             setattr(self, name, value)
 

--- a/boto/sqs/messageattributes.py
+++ b/boto/sqs/messageattributes.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2006,2007 Mitch Garnaat http://garnaat.org/
+# Copyright (c) 2014 Amazon.com, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+"""
+Represents an SQS MessageAttribute Name/Value set
+"""
+
+class MessageAttributes(dict):
+    def __init__(self, parent):
+        self.parent = parent
+        self.current_key = None
+        self.current_value = None
+
+    def startElement(self, name, attrs, connection):
+        if name == 'Value':
+            self.current_value = MessageAttributeValue(self)
+            return self.current_value
+
+    def endElement(self, name, value, connection):
+        if name == 'MessageAttribute':
+            self[self.current_key] = self.current_value
+        elif name == 'Name':
+            self.current_key = value
+        elif name == 'Value':
+            pass
+        else:
+            setattr(self, name, value)
+
+
+class MessageAttributeValue(dict):
+    def __init__(self, parent):
+        self.parent = parent
+
+    def startElement(self, name, attrs, connection):
+        pass
+
+    def endElement(self, name, value, connection):
+        if name == 'DataType':
+            self['data_type'] = value
+        elif name == 'StringValue':
+            self['string_value'] = value
+        elif name == 'BinaryValue':
+            self['binary_value'] = value
+        elif name == 'StringListValue':
+            self['string_list_value'] = value
+        elif name == 'BinaryListValue':
+            self['binary_list_value'] = value

--- a/boto/sqs/queue.py
+++ b/boto/sqs/queue.py
@@ -182,7 +182,8 @@ class Queue(object):
         """
         return self.connection.remove_permission(self, label)
 
-    def read(self, visibility_timeout=None, wait_time_seconds=None):
+    def read(self, visibility_timeout=None, wait_time_seconds=None,
+             message_attributes=None):
         """
         Read a single message from the queue.
 
@@ -195,11 +196,17 @@ class Queue(object):
             If a message is available, the call will return sooner than
             wait_time_seconds.
 
+        :type message_attributes: list
+        :param message_attributes: The name(s) of additional message
+            attributes to return. The default is to return no additional
+            message attributes. Use ``['All']`` or ``['.*']`` to return all.
+
         :rtype: :class:`boto.sqs.message.Message`
         :return: A single message or None if queue is empty
         """
         rs = self.get_messages(1, visibility_timeout,
-                               wait_time_seconds=wait_time_seconds)
+                               wait_time_seconds=wait_time_seconds,
+                               message_attributes=message_attributes)
         if len(rs) == 1:
             return rs[0]
         else:
@@ -216,8 +223,8 @@ class Queue(object):
         :return: The :class:`boto.sqs.message.Message` object that was written.
         """
         new_msg = self.connection.send_message(self,
-                                               message.get_body_encoded(),
-                                               delay_seconds)
+            message.get_body_encoded(), delay_seconds=delay_seconds,
+            message_attributes=message.message_attributes)
         message.id = new_msg.id
         message.md5 = new_msg.md5
         return message
@@ -231,10 +238,12 @@ class Queue(object):
             tuple represents a single message to be written
             and consists of and ID (string) that must be unique
             within the list of messages, the message body itself
-            which can be a maximum of 64K in length, and an
+            which can be a maximum of 64K in length, an
             integer which represents the delay time (in seconds)
             for the message (0-900) before the message will
-            be delivered to the queue.
+            be delivered to the queue, and an optional dict of
+            message attributes like those passed to ``send_message``
+            in the connection class.
         """
         return self.connection.send_message_batch(self, messages)
 
@@ -254,7 +263,8 @@ class Queue(object):
 
     # get a variable number of messages, returns a list of messages
     def get_messages(self, num_messages=1, visibility_timeout=None,
-                     attributes=None, wait_time_seconds=None):
+                     attributes=None, wait_time_seconds=None,
+                     message_attributes=None):
         """
         Get a variable number of messages.
 
@@ -278,13 +288,19 @@ class Queue(object):
             If a message is available, the call will return sooner than
             wait_time_seconds.
 
+        :type message_attributes: list
+        :param message_attributes: The name(s) of additional message
+            attributes to return. The default is to return no additional
+            message attributes. Use ``['All']`` or ``['.*']`` to return all.
+
         :rtype: list
         :return: A list of :class:`boto.sqs.message.Message` objects.
         """
         return self.connection.receive_message(
             self, number_messages=num_messages,
             visibility_timeout=visibility_timeout, attributes=attributes,
-            wait_time_seconds=wait_time_seconds)
+            wait_time_seconds=wait_time_seconds,
+            message_attributes=message_attributes)
 
     def delete_message(self, message):
         """

--- a/docs/source/sqs_tut.rst
+++ b/docs/source/sqs_tut.rst
@@ -113,6 +113,25 @@ The write method will return the ``Message`` object.  The ``id`` and
 ``md5`` attribute of the ``Message`` object will be updated with the
 values of the message that was written to the queue.
 
+Arbitrary message attributes can be defined by setting a simple dictionary
+of values on the message object::
+
+>>> m = Message()
+>>> m.message_attributes = {
+    "name1": {
+        "data_type": "String",
+        "string_value": "I am a string"
+    },
+    "name2": {
+        "data_type": "Number",
+        "string_value": "12"
+    }
+}
+
+Note that by default, these arbitrary attributes are not returned when
+you request messages from a queue. Instead, you must request them via
+the ``message_attributes`` parameter (see below).
+
 If the message cannot be written an ``SQSError`` exception will be raised.
 
 Writing Messages (Custom Format)
@@ -205,6 +224,19 @@ a visibility_timeout parameter to read, if you desire:
 >>> m = q.read(60)
 >>> m.get_body()
 u'This is my first message'
+
+Reading Message Attributes
+--------------------------
+By default, no arbitrary message attributes are returned when requesting
+messages. You can change this behavior by specifying the names of attributes
+you wish to have returned::
+
+>>> rs = queue.get_messages(message_attributes=['name1', 'name2'])
+>>> print rs[0].message_attributes['name1']['string_value']
+'I am a string'
+
+A special value of ``All`` or ``.*`` may be passed to return all available
+message attributes.
 
 Deleting Messages and Queues
 ----------------------------


### PR DESCRIPTION
Adds support for [SQS message attributes](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSMessageAttributes.html) to both the low level and high level client code, adds a new MessageAttributes object, adds unit tests, updates SQS tutorial with notes and examples of the feature.

@garnaat, @toastdriven any chance of a review?
