### PR TITLE
Fixes boto.sqs.load_from_file to work correctly

### DIFF
--- a/boto/sqs/queue.py
+++ b/boto/sqs/queue.py
@@ -475,7 +475,7 @@ class Queue(object):
 	    l = buffer.read(1)
 	    while l:
 		if l == sep:
-		    m = Message(self, ''.join(body))
+		    m = self.message_class(self, ''.join(body))
 		    self.write(m)
 		    n += 1
 		    print 'writing message %d' % n


### PR DESCRIPTION
Adds in a dependency on io.
Previously load_from_file would not operate in conjunction with boto.sqs.save_to_file. This makes the two compatible as long as the same separator is used in both and as long as the queue's Message encoding does not contain said separator.
