### PR TITLE
Fixed EMR step state filtering.

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -264,7 +264,7 @@ class EmrConnection(AWSQueryConnection):
             params['Marker'] = marker
 
         if step_states:
-            self.build_list_params(params, step_states, 'StepStateList.member')
+            self.build_list_params(params, step_states, 'StepStates.member')
 
         return self.get_object('ListSteps', params, StepSummaryList)
 

--- a/tests/unit/emr/test_connection.py
+++ b/tests/unit/emr/test_connection.py
@@ -402,8 +402,8 @@ class TestListSteps(AWSMockServiceTestCase):
         self.assert_request_parameters({
             'Action': 'ListSteps',
             'ClusterId': 'j-123',
-            'StepStateList.member.1': 'COMPLETED',
-            'StepStateList.member.2': 'FAILED',
+            'StepStates.member.1': 'COMPLETED',
+            'StepStates.member.2': 'FAILED',
             'Version': '2009-03-31'
         })
         self.assertTrue(isinstance(response, StepSummaryList))


### PR DESCRIPTION
Request parameter should be called StepStates instead of StepStateList according to API reference:
http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_ListSteps.html
