### PR TITLE
Fix "consistent" argument to boto.dynamodb2.table.Table.batch_get

### DIFF
--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -1270,7 +1270,7 @@ class Table(object):
         # We pass the keys to the constructor instead, so it can maintain it's
         # own internal state as to what keys have been processed.
         results = BatchGetResultSet(keys=keys, max_batch_get=self.max_batch_get)
-        results.to_call(self._batch_get, consistent=False)
+        results.to_call(self._batch_get, consistent=consistent)
         return results
 
     def _batch_get(self, keys, consistent=False):


### PR DESCRIPTION
It looks like the argument `consistent` is ignored, and instead `False` is passed to helper function `self._batch_get`, effectively enforcing eventual consistency for all reads made via `boto.dynamodb2.table.Table.batch_get`.

This fixes what could be a serious issue for callers expecting strongly consistent reads when setting `consistent=True`.

``` diff
@@ -1270,7 +1270,7 @@ def batch_get(self, keys, consistent=False):
         # We pass the keys to the constructor instead, so it can maintain it's
         # own internal state as to what keys have been processed.
         results = BatchGetResultSet(keys=keys, max_batch_get=self.max_batch_get)
-        results.to_call(self._batch_get, consistent=False)
+        results.to_call(self._batch_get, consistent=consistent)
         return results

     def _batch_get(self, keys, consistent=False):
```
