### PR TITLE
Fixing description of param tags into rds2.create_db_subnet_group

### DIFF
--- a/boto/rds2/layer1.py
+++ b/boto/rds2/layer1.py
@@ -1011,7 +1011,7 @@ class RDSConnection(AWSQueryConnection):
         :param subnet_ids: The EC2 Subnet IDs for the DB subnet group.
 
         :type tags: list
-        :param tags: A list of tags.
+        :param tags: A list of tags into tuples.
 
         """
         params = {


### PR DESCRIPTION
The param tags of create_db_subnet_group into module rds2 is not clear and since all other modules uses dictionary instead tuples is better to explicit it.
