### PR TITLE
Add support for encrypted EBS volumes

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -71,7 +71,7 @@ from boto.exception import EC2ResponseError
 
 class EC2Connection(AWSQueryConnection):
 
-    APIVersion = boto.config.get('Boto', 'ec2_version', '2013-10-15')
+    APIVersion = boto.config.get('Boto', 'ec2_version', '2014-05-01')
     DefaultRegionName = boto.config.get('Boto', 'ec2_region_name', 'us-east-1')
     DefaultRegionEndpoint = boto.config.get('Boto', 'ec2_region_endpoint',
                                             'ec2.us-east-1.amazonaws.com')
@@ -2231,8 +2231,8 @@ class EC2Connection(AWSQueryConnection):
             params['DryRun'] = 'true'
         return self.get_status('ModifyVolumeAttribute', params, verb='POST')
 
-    def create_volume(self, size, zone, snapshot=None,
-                      volume_type=None, iops=None, dry_run=False):
+    def create_volume(self, size, zone, snapshot=None, volume_type=None,
+                      iops=None, encrypted=False, dry_run=False):
         """
         Create a new EBS Volume.
 
@@ -2254,6 +2254,10 @@ class EC2Connection(AWSQueryConnection):
         :param iops: The provisioned IOPs you want to associate with
             this volume. (optional)
 
+        :type encrypted: bool
+        :param encrypted: Specifies whether the volume should be encrypted.
+            (optional)
+
         :type dry_run: bool
         :param dry_run: Set to True if the operation should not actually run.
 
@@ -2271,6 +2275,8 @@ class EC2Connection(AWSQueryConnection):
             params['VolumeType'] = volume_type
         if iops:
             params['Iops'] = str(iops)
+        if encrypted:
+            params['Encrypted'] = 'true'
         if dry_run:
             params['DryRun'] = 'true'
         return self.get_object('CreateVolume', params, Volume, verb='POST')

--- a/boto/ec2/snapshot.py
+++ b/boto/ec2/snapshot.py
@@ -41,6 +41,7 @@ class Snapshot(TaggedEC2Object):
         self.owner_alias = None
         self.volume_size = None
         self.description = None
+        self.encrypted = None
 
     def __repr__(self):
         return 'Snapshot:%s' % self.id
@@ -65,6 +66,8 @@ class Snapshot(TaggedEC2Object):
                 self.volume_size = value
         elif name == 'description':
             self.description = value
+        elif name == 'encrypted':
+            self.encrypted = (value.lower() == 'true')
         else:
             setattr(self, name, value)
 
@@ -152,6 +155,7 @@ class Snapshot(TaggedEC2Object):
             self.id,
             volume_type,
             iops,
+            self.encrypted,
             dry_run=dry_run
         )
 

--- a/boto/ec2/volume.py
+++ b/boto/ec2/volume.py
@@ -44,6 +44,7 @@ class Volume(TaggedEC2Object):
     :ivar type: The type of volume (standard or consistent-iops)
     :ivar iops: If this volume is of type consistent-iops, this is
         the number of IOPS provisioned (10-300).
+    :ivar encrypted: True if this volume is encrypted.
     """
 
     def __init__(self, connection=None):
@@ -57,6 +58,7 @@ class Volume(TaggedEC2Object):
         self.zone = None
         self.type = None
         self.iops = None
+        self.encrypted = None
 
     def __repr__(self):
         return 'Volume:%s' % self.id
@@ -92,6 +94,8 @@ class Volume(TaggedEC2Object):
             self.type = value
         elif name == 'iops':
             self.iops = int(value)
+        elif name == 'encrypted':
+            self.encrypted = (value.lower() == 'true')
         else:
             setattr(self, name, value)
 

--- a/tests/unit/ec2/test_snapshot.py
+++ b/tests/unit/ec2/test_snapshot.py
@@ -28,12 +28,13 @@ class TestDescribeSnapshots(AWSMockServiceTestCase):
                            <value>demo_db_14_backup</value>
                         </item>
                      </tagSet>
+                     <encrypted>false</encrypted>
                   </item>
                </snapshotSet>
             </DescribeSnapshotsResponse>
         """
 
-    def test_cancel_spot_instance_requests(self):
+    def test_describe_snapshots(self):
         self.set_http_response(status_code=200)
         response = self.service_connection.get_all_snapshots(['snap-1a2b3c4d', 'snap-9f8e7d6c'],
                                                              owner=['self', '111122223333'],

--- a/tests/unit/ec2/test_volume.py
+++ b/tests/unit/ec2/test_volume.py
@@ -78,10 +78,11 @@ class VolumeTests(unittest.TestCase):
         retval = volume.startElement("not tagSet or attachmentSet", None, None)
         self.assertEqual(retval, None)
 
-    def check_that_attribute_has_been_set(self, name, value, attribute):
+    def check_that_attribute_has_been_set(self, name, value, attribute, obj_value=None):
         volume = Volume()
         volume.endElement(name, value, None)
-        self.assertEqual(getattr(volume, attribute), value)
+        expected_value = obj_value if obj_value is not None else value
+        self.assertEqual(getattr(volume, attribute), expected_value)
 
     def test_endElement_sets_correct_attributes_with_values(self):
         for arguments in [("volumeId", "some value", "id"),
@@ -90,8 +91,9 @@ class VolumeTests(unittest.TestCase):
                           ("size", 5, "size"),
                           ("snapshotId", 1, "snapshot_id"),
                           ("availabilityZone", "some zone", "zone"),
-                          ("someName", "some value", "someName")]:
-            self.check_that_attribute_has_been_set(arguments[0], arguments[1], arguments[2])
+                          ("someName", "some value", "someName"),
+                          ("encrypted", "true", "encrypted", True)]:
+            self.check_that_attribute_has_been_set(*arguments)
 
     def test_endElement_with_name_status_and_empty_string_value_doesnt_set_status(self):
         volume = Volume()


### PR DESCRIPTION
This pull requests adds support for the newly released features for server-side encryption of EBS volumes, as described in http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html.

This pull request was forced to update the EC2 API version to 2014-05-01; Amazon rejected the API requests saying that there was no such field "Encrypted" if it wasn't changed. This may affect other APIs, so this should be looked at closely.

This pull request also adds unit tests for all the affected functions (get_all_snapshots, get_all_volumes, create_volume).
