### PR TITLE
Fix timezones in CloudWatch date range example.

### DIFF
--- a/docs/source/cloudwatch_tut.rst
+++ b/docs/source/cloudwatch_tut.rst
@@ -76,7 +76,7 @@ that we are interested in.  For this example, let's say we want the
 data for the previous hour::
 
     >>> import datetime
-    >>> end = datetime.datetime.now()
+    >>> end = datetime.datetime.utcnow()
     >>> start = end - datetime.timedelta(hours=1)
 
 We also need to supply the Statistic that we want reported and


### PR DESCRIPTION
The current example uses "datetime.now()", which returns in local time. This may appear to work for users behind UTC, but for users head of UTC like here in Australia, no data will be returned.
