### PR TITLE
Update the wheel to be python 2 compatible only.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[wheel]
-universal = 1
+[bdist_wheel]
+python-tag = py2


### PR DESCRIPTION
Indicating it's universal will imply that its also compatible with python 3 and allow it to be mistakenly installed on 3.x's.

The `python-tag` var is available from wheel 0.23

Also see http://wheel.readthedocs.org/en/latest/#defining-the-python-version
