### PR TITLE
crate.io is no longer a package index

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Released: 8-May-2014
         :target: https://travis-ci.org/boto/boto
 
 .. image:: https://pypip.in/d/boto/badge.png
-        :target: https://crate.io/packages/boto/
+        :target: https://pypi.python.org/pypi/boto/
 
 ************
 Introduction


### PR DESCRIPTION
Refer to PyPI instead.

crate.io was transferred to another company; they kindly redirect package requests to PyPI for now, but projects shouldn't rely on this.
