### PR TITLE
add 'name' param to documentation of LoadBalancer

### DIFF
--- a/boto/ec2/elb/loadbalancer.py
+++ b/boto/ec2/elb/loadbalancer.py
@@ -82,6 +82,7 @@ class LoadBalancer(object):
             check policy for this load balancer.
         :ivar boto.ec2.elb.policies.Policies policies: Cookie stickiness and
             other policies.
+        :ivar str name: The name of the Load Balancer.
         :ivar str dns_name: The external DNS name for the balancer.
         :ivar str created_time: A date+time string showing when the
             load balancer was created.


### PR DESCRIPTION
the 'name' is there, it's just not exposed in the documentation. Since it's
used to as an argument to elb functions, it's worth being explicitly stated.
