### PR TITLE
Fix bug when provider is `google` and add test coverage

### DIFF
--- a/boto/provider.py
+++ b/boto/provider.py
@@ -189,7 +189,7 @@ class Provider(object):
         self._credential_expiry_time = None
 
         # Load shared credentials file if it exists
-        shared_path = os.path.join(expanduser('~'), '.aws', 'credentials')
+        shared_path = os.path.join(expanduser('~'), '.' + name, 'credentials')
         self.shared_credentials = Config(do_load=False)
         if os.path.exists(shared_path):
             self.shared_credentials.load_from_path(shared_path)
@@ -265,7 +265,8 @@ class Provider(object):
 
         # Load profile from shared environment variable if it was not
         # already passed in and the environment variable exists
-        if profile_name is None and profile_name_name.upper() in os.environ:
+        if profile_name is None and profile_name_name is not None and \
+           profile_name_name.upper() in os.environ:
             profile_name = os.environ[profile_name_name.upper()]
 
         shared = self.shared_credentials


### PR DESCRIPTION
This adds test coverage that was unfortunately missing and resulted in #2298 shortly after yesterday's release. It also fixes the issue and as a side effect sets the shared credential file name based on the provider name.

Note: this **only** affects users who have set the provider to something other than `aws`.

@jamesls please review.
