### PR TITLE
Removed the improper setting of a default value for CloudSearch int indexes

### DIFF
--- a/boto/cloudsearch2/domain.py
+++ b/boto/cloudsearch2/domain.py
@@ -340,7 +340,6 @@ class Domain(object):
                     ','.join(source_field)
         elif field_type == 'int':
             index['IntOptions'] = {
-                'DefaultValue': default,
                 'FacetEnabled': facet,
                 'ReturnEnabled': returnable,
                 'SearchEnabled': searchable,


### PR DESCRIPTION
DefaultValue was being set both inside the always-run block, and of course in the block in which the value to set is checked for existence. Removed the former so that empty DefaultValue does not make it into a request (this causes the request to fail)