### PR TITLE
Allow boto to execute ssh command over private interface if public is not present.

### DIFF
--- a/boto/manage/cmdshell.py
+++ b/boto/manage/cmdshell.py
@@ -204,6 +204,8 @@ class FakeServer(object):
         self.instance = instance
         self.ssh_key_file = ssh_key_file
         self.hostname = instance.dns_name
+        if not self.hostname:
+            self.hostname = instance.private_dns_name
         self.instance_id = self.instance.id
 
 def start(server):


### PR DESCRIPTION
...e (as boto might be used internally between AWS instances running on private network).
