### PR TITLE
Fix erroneous param description

### DIFF
--- a/boto/iam/connection.py
+++ b/boto/iam/connection.py
@@ -1142,7 +1142,7 @@ class IAMConnection(AWSQueryConnection):
             permission to assume the role.
 
         :type path: string
-        :param path: The path to the instance profile.
+        :param path: The path to the role.
         """
         params = {
             'RoleName': role_name,


### PR DESCRIPTION
I think this is just a copy/paste error from the path param of `create_instance_profile`.
