### PR TITLE
In Table.describe(), try also to update the global indexes information.

### DIFF
--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -339,6 +339,11 @@ class Table(object):
             raw_indexes = result['Table'].get('LocalSecondaryIndexes', [])
             self.indexes = self._introspect_indexes(raw_indexes)
 
+        if not self.global_indexes:
+            # Build the global secondary index information if it's there.
+            raw_global_indexes = result['Table'].get('GlobalSecondaryIndexes', [])
+            self.global_indexes = self._introspect_indexes(raw_global_indexes)
+
         # This is leaky.
         return result
 


### PR DESCRIPTION
Without this I'm unable to perform a query using global secondary index on a table that has single hash key as primary index as boto is erroring with "QueryError: You must specify more than one key to filter on."
