### PR TITLE
Add ~ as safe field for connection build_url_base

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -92,7 +92,7 @@ class _CallingFormat(object):
         path = ''
         if bucket != '':
             path = '/' + bucket
-        return path + '/%s' % urllib.quote(key)
+        return path + '/%s' % urllib.quote(key, safe='~')
 
     def build_path_base(self, bucket, key=''):
         key = boto.utils.get_utf8_value(key)


### PR DESCRIPTION
Without this key signing through Amazon will actually fail for any keys with a ~ inside of them. (I.E. key.generate_url -> connection.generate_url returns a URL that isn't validly signed).