### PR TITLE
Fixes to support authentication using IAM roles + S3 uploads.

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -166,7 +166,7 @@ class Key(object):
 
     def _set_md5(self, value):
         if value:
-            self.local_hashes['md5'] = binascii.a2b_hex(value)
+            self.local_hashes['md5'] = binascii.a2b_hex(value.encode('ascii'))
         elif 'md5' in self.local_hashes:
             self.local_hashes.pop('md5', None)
 
@@ -178,7 +178,7 @@ class Key(object):
 
     def _set_base64md5(self, value):
         if value:
-            self.local_hashes['md5'] = binascii.a2b_base64(value)
+            self.local_hashes['md5'] = binascii.a2b_base64(value.encode('ascii'))
         elif 'md5' in self.local_hashes:
             del self.local_hashes['md5']
 


### PR DESCRIPTION
The `boto.utils.get_instance_metadata()` function was broken in Py3k, causing IAM Role authentication to break. Also, uploading with `set_contents_from_filename()` was broken due to binascii expecting binary instead of unicode.

I tested this patch under both Python 2.7 and Python 3.4, and it's compatible with both versions.
