### PR TITLE
Make sure integer values in rds parameter are not based on variables

### DIFF
--- a/boto/rds/parametergroup.py
+++ b/boto/rds/parametergroup.py
@@ -137,13 +137,17 @@ class Parameter(object):
             raise ValueError('value must be of type str')
         if self.allowed_values:
             choices = self.allowed_values.split(',')
-            if value not in choices:
+            if value not in choices and not value.startswith('{'):
                 raise ValueError('value must be in %s' % self.allowed_values)
         self._value = value
 
     def _set_integer_value(self, value):
         if isinstance(value, basestring):
-            value = int(value)
+            if value.startswith('{'):
+                self._set_string_value(value)
+                return
+            else:
+                value = int(value)
         if isinstance(value, int) or isinstance(value, long):
             if self.allowed_values:
                 min, max = self.allowed_values.split('-')
@@ -180,7 +184,8 @@ class Parameter(object):
         if self.type == 'string':
             return self._value
         elif self.type == 'integer':
-            if not isinstance(self._value, int) and not isinstance(self._value, long):
+            if not isinstance(self._value, int) and not isinstance(self._value, long) and \
+               not (isinstance(self._value, basestring) and self._value.startswith('{')):
                 self._set_integer_value(self._value)
             return self._value
         elif self.type == 'boolean':


### PR DESCRIPTION
Some RDS parameter group values may be based on variables. For example,
by default the innodb_buffer_pool_size parameter has a default value of
'{DBInstanceClassMemory*3/4}' when the group is created. Trying to even
fetch the value of this parameter results in a traceback:

  File "../site-packages/boto/rds/parametergroup.py", line 184, in get_value
    self._set_integer_value(self._value)
  File "../site-packages/boto/rds/parametergroup.py", line 146, in _set_integer_value
    value = int(value)
ValueError: invalid literal for int() with base 10: '{DBInstanceClassMemory/12582880}'

This patch corrects this by checking if the value is a basestring, and
only converting it to an integer if it does not start with a '{'.
