### PR TITLE
Add S3 SigV4 Presigning

### DIFF
--- a/tests/unit/s3/test_connection.py
+++ b/tests/unit/s3/test_connection.py
@@ -93,6 +93,49 @@ class TestSigV4HostError(MockServiceWithConfigTestCase):
         )
 
 
+class TestSigV4Presigned(MockServiceWithConfigTestCase):
+    connection_class = S3Connection
+
+    def test_sigv4_presign(self):
+        self.config = {
+            's3': {
+                'use-sigv4': True,
+            }
+        }
+
+        conn = self.connection_class(
+            aws_access_key_id='less',
+            aws_secret_access_key='more',
+            host='s3.amazonaws.com'
+        )
+
+        # Here we force an input iso_date to ensure we always get the
+        # same signature.
+        url = conn.generate_url_sigv4(86400, 'GET', bucket='examplebucket',
+            key='test.txt', iso_date='20140625T000000Z')
+
+        self.assertIn('a937f5fbc125d98ac8f04c49e0204ea1526a7b8ca058000a54c192457be05b7d', url)
+
+    def test_sigv4_presign_optional_params(self):
+        self.config = {
+            's3': {
+                'use-sigv4': True,
+            }
+        }
+
+        conn = self.connection_class(
+            aws_access_key_id='less',
+            aws_secret_access_key='more',
+            security_token='token',
+            host='s3.amazonaws.com'
+        )
+
+        url = conn.generate_url_sigv4(86400, 'GET', bucket='examplebucket',
+            key='test.txt', version_id=2)
+
+        self.assertIn('VersionId=2', url)
+        self.assertIn('X-Amz-Security-Token=token', url)
+
 
 class TestUnicodeCallingFormat(AWSMockServiceTestCase):
     connection_class = S3Connection


### PR DESCRIPTION
This change fixes an issue with presigning when signature version 4 is used with S3. It also includes a minor fix for determining the signing region name for vhosted classic domains. Example output:

```
https://taylordt-v4test.s3-us-west-2.amazonaws.com/chicago.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=48a81a59132d9b93bf81878a36f4aff38ea56107682face528b2a605886a1c33&X-Amz-Date=20140627T181333Z&X-Amz-Credential=AKIAIFM3UXOJ72EAMEYA%2F20140627%2Fus-west-2%2Fs3%2Faws4_request
```

@jamesls, please review.
