### PR TITLE
Documentation updates:

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -2254,10 +2254,10 @@ class EC2Connection(AWSQueryConnection):
 
         :type volume_type: string
         :param volume_type: The type of the volume. (optional).  Valid
-            values are: standard | io1.
+            values are: standard | io1 | gp2.
 
         :type iops: int
-        :param iops: The provisioned IOPs you want to associate with
+        :param iops: The provisioned IOPS you want to associate with
             this volume. (optional)
 
         :type encrypted: bool

--- a/boto/ec2/image.py
+++ b/boto/ec2/image.py
@@ -233,6 +233,9 @@ class Image(TaggedEC2Object):
             * i2.2xlarge
             * i2.4xlarge
             * i2.8xlarge
+            * t2.micro
+            * t2.small
+            * t2.medium
 
         :type placement: string
         :param placement: The Availability Zone to launch the instance into.

--- a/boto/sqs/connection.py
+++ b/boto/sqs/connection.py
@@ -122,12 +122,18 @@ class SQSConnection(AWSQueryConnection):
             supplied, the default is to return all attributes.  Valid
             attributes are:
 
+            * All
             * ApproximateNumberOfMessages
             * ApproximateNumberOfMessagesNotVisible
             * VisibilityTimeout
             * CreatedTimestamp
             * LastModifiedTimestamp
             * Policy
+            * MaximumMessageSize
+            * MessageRetentionPeriod
+            * QueueArn
+            * ApproximateNumberOfMessagesDelayed
+            * DelaySeconds
             * ReceiveMessageWaitTimeSeconds
             * RedrivePolicy
 


### PR DESCRIPTION
- new General Purpose (SSD) EBS volume type: gp2
- more doc changes for T2 instance types
- add missing SQS queue attributes

Also, 1 minor change: IOPS should be all CAP as it stands for "Input/Output Operations Per Second".
