### PR TITLE
ses module: add backward-compatible support for Python 3.3+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ At the moment, boto supports:
   * Amazon Simple Workflow Service (SWF)
   * Amazon Simple Queue Service (SQS) (Python 3)
   * Amazon Simple Notification Server (SNS)
-  * Amazon Simple Email Service (SES)
+  * Amazon Simple Email Service (SES) (Python 3)
 
 * Monitoring
 

--- a/boto/ses/connection.py
+++ b/boto/ses/connection.py
@@ -20,9 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 import re
-import urllib
 import base64
 
+from boto.compat import six, urllib
 from boto.connection import AWSAuthConnection
 from boto.exception import BotoServerError
 from boto.regioninfo import RegionInfo
@@ -71,7 +71,7 @@ class SESConnection(AWSAuthConnection):
         :type label: string
         :param label: The parameter list's name
         """
-        if isinstance(items, basestring):
+        if isinstance(items, six.string_types):
             items = [items]
         for i in range(1, len(items) + 1):
             params['%s.%d' % (label, i)] = items[i - 1]
@@ -92,16 +92,16 @@ class SESConnection(AWSAuthConnection):
         params['Action'] = action
 
         for k, v in params.items():
-            if isinstance(v, unicode):  # UTF-8 encode only if it's Unicode
+            if isinstance(v, six.text_type):  # UTF-8 encode only if it's Unicode
                 params[k] = v.encode('utf-8')
 
         response = super(SESConnection, self).make_request(
             'POST',
             '/',
             headers=headers,
-            data=urllib.urlencode(params)
+            data=urllib.parse.urlencode(params)
         )
-        body = response.read()
+        body = response.read().decode('utf-8')
         if response.status == 200:
             list_markers = ('VerifiedEmailAddresses', 'Identities',
                             'DkimTokens', 'VerificationAttributes',
@@ -306,7 +306,7 @@ class SESConnection(AWSAuthConnection):
 
         """
 
-        if isinstance(raw_message, unicode):
+        if isinstance(raw_message, six.text_type):
             raw_message = raw_message.encode('utf-8')
 
         params = {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,7 +72,7 @@ Currently Supported Services
   * :doc:`Simple Workflow Service (SWF) <swf_tut>` -- (:doc:`API Reference <ref/swf>`)
   * :doc:`Simple Queue Service (SQS) <sqs_tut>` -- (:doc:`API Reference <ref/sqs>`) (Python 3)
   * Simple Notification Service (SNS) -- (:doc:`API Reference <ref/sns>`)
-  * :doc:`Simple Email Service (SES) <ses_tut>` -- (:doc:`API Reference <ref/ses>`)
+  * :doc:`Simple Email Service (SES) <ses_tut>` -- (:doc:`API Reference <ref/ses>`) (Python 3)
 
 * **Monitoring**
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -45,6 +45,7 @@ PY3_WHITELIST = (
     'tests/unit/provider',
     'tests/unit/rds2',
     'tests/unit/s3',
+    'tests/unit/ses',
     'tests/unit/sqs',
     'tests/unit/sts',
     'tests/unit/swf',

--- a/tests/unit/ses/test_identity.py
+++ b/tests/unit/ses/test_identity.py
@@ -34,7 +34,7 @@ class TestSESIdentity(AWSMockServiceTestCase):
         super(TestSESIdentity, self).setUp()
 
     def default_body(self):
-        return """<GetIdentityDkimAttributesResponse \
+        return b"""<GetIdentityDkimAttributesResponse \
 xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
   <GetIdentityDkimAttributesResult>
     <DkimAttributes>
@@ -85,7 +85,7 @@ class TestSESSetIdentityNotificationTopic(AWSMockServiceTestCase):
         super(TestSESSetIdentityNotificationTopic, self).setUp()
 
     def default_body(self):
-        return """<SetIdentityNotificationTopicResponse \
+        return b"""<SetIdentityNotificationTopicResponse \
         xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
            <SetIdentityNotificationTopicResult/>
            <ResponseMetadata>
@@ -130,7 +130,7 @@ class TestSESSetIdentityFeedbackForwardingEnabled(AWSMockServiceTestCase):
         super(TestSESSetIdentityFeedbackForwardingEnabled, self).setUp()
 
     def default_body(self):
-        return """<SetIdentityFeedbackForwardingEnabledResponse \
+        return b"""<SetIdentityFeedbackForwardingEnabledResponse \
         xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
           <SetIdentityFeedbackForwardingEnabledResult/>
           <ResponseMetadata>


### PR DESCRIPTION
Tests passed, and I've tried to send a few e-mails with Python 2.7.8 and 3.4.1, both worked.
