### PR TITLE
elasticache module: add backward-compatible support for Python 3.3+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ At the moment, boto supports:
   * Amazon Relational Data Service (RDS)
   * Amazon DynamoDB
   * Amazon SimpleDB
-  * Amazon ElastiCache
+  * Amazon ElastiCache (Python 3)
   * Amazon Redshift
 
 * Deployment and Management

--- a/boto/elasticache/layer1.py
+++ b/boto/elasticache/layer1.py
@@ -1657,7 +1657,7 @@ class ElastiCacheConnection(AWSQueryConnection):
         params['ContentType'] = 'JSON'
         response = self.make_request(action=action, verb='POST',
                                      path='/', params=params)
-        body = response.read()
+        body = response.read().decode('utf-8')
         boto.log.debug(body)
         if response.status == 200:
             return json.loads(body)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,7 +47,7 @@ Currently Supported Services
   * :doc:`DynamoDB <dynamodb_tut>` -- (:doc:`API Reference <ref/dynamodb>`)
   * Relational Data Services 2 (RDS) -- (:doc:`API Reference <ref/rds2>`) -- (:doc:`Migration Guide from v1 <migrations/rds_v1_to_v2>`)
   * :doc:`Relational Data Services (RDS) <rds_tut>` -- (:doc:`API Reference <ref/rds>`)
-  * ElastiCache -- (:doc:`API Reference <ref/elasticache>`)
+  * ElastiCache -- (:doc:`API Reference <ref/elasticache>`) (Python 3)
   * Redshift -- (:doc:`API Reference <ref/redshift>`)
   * :doc:`SimpleDB <simpledb_tut>` -- (:doc:`API Reference <ref/sdb>`)
 

--- a/tests/unit/elasticache/test_api_interface.py
+++ b/tests/unit/elasticache/test_api_interface.py
@@ -8,7 +8,7 @@ class TestAPIInterface(AWSMockServiceTestCase):
     def test_required_launch_params(self):
         """ Make sure only the AWS required params are required by boto """
         name = 'test_cache_cluster'
-        self.set_http_response(status_code=200, body='{}')
+        self.set_http_response(status_code=200, body=b'{}')
         self.service_connection.create_cache_cluster(name)
 
         self.assert_request_parameters({


### PR DESCRIPTION
All tests passed.
