### PR TITLE
directconnect module: add backward-compatible support for Python 3.3+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ At the moment, boto supports:
   * Amazon Route53
   * Amazon Virtual Private Cloud (VPC)
   * Elastic Load Balancing (ELB)
-  * AWS Direct Connect
+  * AWS Direct Connect (Python 3)
 
 * Payments and Billing
 

--- a/boto/directconnect/layer1.py
+++ b/boto/directconnect/layer1.py
@@ -20,16 +20,12 @@
 # IN THE SOFTWARE.
 #
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
 import boto
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.directconnect import exceptions
+from boto.compat import json
 
 
 class DirectConnectConnection(AWSQueryConnection):
@@ -619,7 +615,7 @@ class DirectConnectConnection(AWSQueryConnection):
             headers=headers, data=body)
         response = self._mexe(http_request, sender=None,
                               override_num_retries=10)
-        response_body = response.read()
+        response_body = response.read().decode('utf-8')
         boto.log.debug(response_body)
         if response.status == 200:
             if response_body:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -83,6 +83,7 @@ Currently Supported Services
   * :doc:`Route 53 <route53_tut>` -- (:doc:`API Reference <ref/route53>`)
   * :doc:`Virtual Private Cloud (VPC) <vpc_tut>` -- (:doc:`API Reference <ref/vpc>`)
   * :doc:`Elastic Load Balancing (ELB) <elb_tut>` -- (:doc:`API Reference <ref/elb>`)
+  * AWS Direct Connect (Python 3)
 
 * **Payments & Billing**
 

--- a/tests/unit/directconnect/test_layer1.py
+++ b/tests/unit/directconnect/test_layer1.py
@@ -28,7 +28,7 @@ class TestDescribeTrails(AWSMockServiceTestCase):
     connection_class = DirectConnectConnection
 
     def default_body(self):
-        return '''
+        return b'''
 {
     "connections": [
         {


### PR DESCRIPTION
All tests passed.
