### PR TITLE
datapipeline module: add backward-compatible support for Python 3.3+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ At the moment, boto supports:
 
   * AWS Elastic Beanstalk
   * AWS CloudFormation
-  * AWS Data Pipeline
+  * AWS Data Pipeline (Python 3)
   * AWS Opsworks
   * AWS CloudTrail (Python 3)
 

--- a/boto/datapipeline/layer1.py
+++ b/boto/datapipeline/layer1.py
@@ -627,7 +627,7 @@ class DataPipelineConnection(AWSQueryConnection):
             headers=headers, data=body)
         response = self._mexe(http_request, sender=None,
                               override_num_retries=10)
-        response_body = response.read()
+        response_body = response.read().decode('utf-8')
         boto.log.debug(response_body)
         if response.status == 200:
             if response_body:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,7 +55,7 @@ Currently Supported Services
 
   * CloudFormation -- (:doc:`API Reference <ref/cloudformation>`)
   * Elastic Beanstalk -- (:doc:`API Reference <ref/beanstalk>`)
-  * Data Pipeline -- (:doc:`API Reference <ref/datapipeline>`)
+  * Data Pipeline -- (:doc:`API Reference <ref/datapipeline>`) (Python 3)
   * Opsworks -- (:doc:`API Reference <ref/opsworks>`)
   * CloudTrail -- (:doc:`API Reference <ref/cloudtrail>`) (Python 3)
 


### PR DESCRIPTION
All tests passed.
