### PR TITLE
ecs module: add backward-compatible support for Python 3.3+

### DIFF
--- a/boto/ecs/__init__.py
+++ b/boto/ecs/__init__.py
@@ -62,7 +62,7 @@ class ECSConnection(AWSQueryConnection):
         if page:
             params['ItemPage'] = page
         response = self.make_request(None, params, "/onca/xml")
-        body = response.read()
+        body = response.read().decode('utf-8')
         boto.log.debug(body)
 
         if response.status != 200:
@@ -75,7 +75,7 @@ class ECSConnection(AWSQueryConnection):
         else:
             rs = itemSet
         h = handler.XmlHandler(rs, self)
-        xml.sax.parseString(body, h)
+        xml.sax.parseString(body.encode('utf-8'), h)
         if not rs.is_valid:
             raise BotoServerError(response.status, '{Code}: {Message}'.format(**rs.errors[0]))
         return rs

--- a/boto/ecs/item.py
+++ b/boto/ecs/item.py
@@ -22,8 +22,7 @@
 
 import xml.sax
 import cgi
-from StringIO import StringIO
-from boto.compat import six
+from boto.compat import six, StringIO
 
 class ResponseGroup(xml.sax.ContentHandler):
     """A Generic "Response Group", which can
@@ -137,7 +136,7 @@ class ItemSet(ResponseGroup):
             self.curItem.endElement(name, value, connection)
         return None
 
-    def next(self):
+    def __next__(self):
         """Special paging functionality"""
         if self.iter is None:
             self.iter = iter(self.objs)
@@ -152,6 +151,8 @@ class ItemSet(ResponseGroup):
                 return next(self)
             else:
                 raise
+
+    next = __next__
 
     def __iter__(self):
         return self

--- a/tests/test.py
+++ b/tests/test.py
@@ -40,6 +40,7 @@ PY3_WHITELIST = (
     'tests/unit/beanstalk',
     'tests/unit/cloudtrail',
     'tests/unit/directconnect',
+    'tests/unit/ecs',
     'tests/unit/elasticache',
     'tests/unit/manage',
     'tests/unit/provider',

--- a/tests/unit/ecs/test_connection.py
+++ b/tests/unit/ecs/test_connection.py
@@ -29,7 +29,7 @@ class TestECSConnection(AWSMockServiceTestCase):
     connection_class = ECSConnection
 
     def default_body(self):
-        return """
+        return b"""
             <Items>
               <Request>
               <IsValid>True</IsValid>


### PR DESCRIPTION
All tests passed.
