### PR TITLE
Skip the ETag header check in responce while using SSE-C encrpytion of S3

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -950,8 +950,11 @@ class Key(object):
             if isinstance(md5, bytes):
                 md5 = md5.decode('utf-8')
 
-            # If you use customer-provided encryption keys, the ETag value that Amazon S3 returns in the response will not be the MD5 of the object.
-            server_side_encryption_customer_algorithm = response.getheader('x-amz-server-side-encryption-customer-algorithm', None)
+            # If you use customer-provided encryption keys, the ETag value that
+            # Amazon S3 returns in the response will not be the MD5 of the
+            # object.
+            server_side_encryption_customer_algorithm = response.getheader(
+                'x-amz-server-side-encryption-customer-algorithm', None)
             if server_side_encryption_customer_algorithm is None:
                 if self.etag != '"%s"' % md5:
                     raise provider.storage_data_error(

--- a/tests/integration/s3/test_key.py
+++ b/tests/integration/s3/test_key.py
@@ -421,3 +421,21 @@ class S3KeyTest(unittest.TestCase):
             urllib.parse.unquote(check.content_disposition),
             expected
         )
+
+    def test_set_contents_with_sse_c(self):
+        content="01234567890123456789"
+        # the plain text of customer key is "01testKeyToSSEC!"
+        header = {
+            "x-amz-server-side-encryption-customer-algorithm" :
+             "AES256",
+            "x-amz-server-side-encryption-customer-key" :
+             "MAAxAHQAZQBzAHQASwBlAHkAVABvAFMAUwBFAEMAIQA=",
+            "x-amz-server-side-encryption-customer-key-MD5" :
+             "fUgCZDDh6bfEMuP2bN38mg=="
+        }
+        # upload and download content with AWS specified headers
+        k = self.bucket.new_key("testkey_for_sse_c")
+        k.set_contents_from_string(content, headers=header)
+        kn = self.bucket.new_key("testkey_for_sse_c")
+        ks = kn.get_contents_as_string(headers=header)
+        self.assertEqual(ks, content)


### PR DESCRIPTION
AWS S3 provides the new feature - [server side  encrpytion with customer keys](http://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html). I can add three headers - "x-amz-server-side​-encryption​-customer-algorithm,x-amz-server-side​-encryption​-customer-key,x-amz-server-side​-encryption​-customer-key-MD5" to use the Key.set_contents_from_filename and upload the file. However, the ETag check in response stops the operation. 

According to the AWS document, this header takes no effect while using the new SSE-C encryption. So this fix is to skip this check. "x-amz-server-side​-encryption​-customer-algorithm" is [one header in the response](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html), which I use to determine if it is SSE-C encryption.
