### PR TITLE
Remove redundant lines in auth.py

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -313,7 +313,6 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         in the StringToSign.
         """
         host_header_value = self.host_header(self.host, http_request)
-        headers_to_sign = {}
         headers_to_sign = {'Host': host_header_value}
         for name, value in http_request.headers.items():
             lname = name.lower()
@@ -563,7 +562,6 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         in the StringToSign.
         """
         host_header_value = self.host_header(self.host, http_request)
-        headers_to_sign = {}
         headers_to_sign = {'Host': host_header_value}
         for name, value in http_request.headers.items():
             lname = name.lower()


### PR DESCRIPTION
headers_to_sign is initialized twice in a row
