### PR TITLE
ec2/connection.py - add filter parameter to trim_snapshots() (develop)

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -2513,7 +2513,8 @@ class EC2Connection(AWSQueryConnection):
         return snapshot.id
 
     def trim_snapshots(self, hourly_backups=8, daily_backups=7,
-                       weekly_backups=4, monthly_backups=True):
+                       weekly_backups=4, monthly_backups=True,
+                       filters=None):
         """
         Trim excess snapshots, based on when they were taken. More current
         snapshots are retained, with the number retained decreasing as you
@@ -2544,6 +2545,16 @@ class EC2Connection(AWSQueryConnection):
 
         :type monthly_backups: int
         :param monthly_backups: How many monthly backups should be saved. Use True for no limit.
+
+        :type filters: dict
+        :param filters: Optional filters that can be used to limit
+                        the snapshots trimmed.  Filters are provided
+                        in the form of a dictionary consisting of
+                        filter names as the key and filter values
+                        as the value.  The set of allowable filter
+                        names/values is dependent on the request
+                        being performed.  Check the EC2 API guide
+                        for details.
         """
 
         # This function first builds up an ordered list of target times
@@ -2606,7 +2617,7 @@ class EC2Connection(AWSQueryConnection):
 
         # get all the snapshots, sort them by date and time, and
         # organize them into one array for each volume:
-        all_snapshots = self.get_all_snapshots(owner = 'self')
+        all_snapshots = self.get_all_snapshots(owner = 'self', filters = filters)
         all_snapshots.sort(cmp = lambda x, y: cmp(x.start_time, y.start_time))
         snaps_for_each_volume = {}
         for snap in all_snapshots:

--- a/tests/unit/ec2/test_connection.py
+++ b/tests/unit/ec2/test_connection.py
@@ -1001,9 +1001,17 @@ class TestTrimSnapshots(TestEC2ConnectionBase):
         ]
 
         for date in dates:
-            # Create a fake snapshot for each date
+            # Create a fake snapshot for each date with name tag "foo"
             snap = Snapshot(self.ec2)
             snap.tags['Name'] = 'foo'
+            # Times are expected to be ISO8601 strings
+            snap.start_time = date.strftime('%Y-%m-%dT%H:%M:%S.000Z')
+            snaps.append(snap)
+
+        for date in dates:
+            # Create a fake snapshot for each date named tagged "foo2"
+            snap = Snapshot(self.ec2)
+            snap.tags['Name'] = 'foo2'
             # Times are expected to be ISO8601 strings
             snap.start_time = date.strftime('%Y-%m-%dT%H:%M:%S.000Z')
             snaps.append(snap)
@@ -1042,7 +1050,8 @@ class TestTrimSnapshots(TestEC2ConnectionBase):
         """
         Test trimming monthly snapshots and ensure that older months
         get deleted properly. The result of this test should be that
-        the two oldest snapshots get deleted.
+        the four oldest snapshots get deleted (two each of "foo" and
+        "foo2").
         """
         # Setup mocks
         orig = {
@@ -1057,6 +1066,34 @@ class TestTrimSnapshots(TestEC2ConnectionBase):
 
         # Call the tested method
         self.ec2.trim_snapshots(monthly_backups=1)
+
+        # Assertions
+        self.assertEqual(True, self.ec2.get_all_snapshots.called)
+        self.assertEqual(4, self.ec2.delete_snapshot.call_count)
+
+        # Restore
+        self.ec2.get_all_snapshots = orig['get_all_snapshots']
+        self.ec2.delete_snapshot = orig['delete_snapshot']
+
+    def test_trim_filter(self):
+        """
+        Test trimming filtered snapshots and ensure that older
+        snapshots get deleted properly. The result of this test should
+        be that the two oldest snapshots with name "foo2" get deleted.
+        """
+        # Setup mocks
+        orig = {
+            'get_all_snapshots': self.ec2.get_all_snapshots,
+            'delete_snapshot': self.ec2.delete_snapshot
+        }
+
+        snaps = self._get_snapshots()
+
+        self.ec2.get_all_snapshots = MagicMock(return_value=snaps)
+        self.ec2.delete_snapshot = MagicMock()
+
+        # Call the tested method
+	self.ec2.trim_snapshots(months=1, filters={'tag:Name': 'foo2'})
 
         # Assertions
         self.assertEqual(True, self.ec2.get_all_snapshots.called)


### PR DESCRIPTION
This patch allows you to filter the trimmed snapshots. In some cases you may not want to trim all snapshots in an account or you may not have the same retention requirements for all snapshots. With this patch you can filter the snapshots to be trimmed by a tag.

If you require any changes before merging, let me know.

Thanks.
