### PR TITLE
Fix SWF continue_as_new_workflow_execution start_to_close_timeout.

### DIFF
--- a/boto/swf/layer1_decisions.py
+++ b/boto/swf/layer1_decisions.py
@@ -167,7 +167,7 @@ class Layer1Decisions(object):
         if task_list is not None:
             attrs['taskList'] = {'name': task_list}
         if start_to_close_timeout is not None:
-            attrs['startToCloseTimeout'] = start_to_close_timeout
+            attrs['taskStartToCloseTimeout'] = start_to_close_timeout
         if workflow_type_version is not None:
             attrs['workflowTypeVersion'] = workflow_type_version
         self._data.append(o)

--- a/tests/unit/swf/test_layer1_decisions.py
+++ b/tests/unit/swf/test_layer1_decisions.py
@@ -1,0 +1,35 @@
+from tests.unit import unittest
+
+import boto.swf.layer1_decisions
+
+
+class TestDecisions(unittest.TestCase):
+
+    def setUp(self):
+        self.decisions = boto.swf.layer1_decisions.Layer1Decisions()
+
+    def assert_data(self, *data):
+        self.assertEquals(self.decisions._data, list(data))
+
+    def test_continue_as_new_workflow_execution(self):
+        self.decisions.continue_as_new_workflow_execution(
+            child_policy='TERMINATE',
+            execution_start_to_close_timeout='10',
+            input='input',
+            tag_list=['t1', 't2'],
+            task_list='tasklist',
+            start_to_close_timeout='20',
+            workflow_type_version='v2'
+        )
+        self.assert_data({
+            'decisionType': 'ContinueAsNewWorkflowExecution',
+            'continueAsNewWorkflowExecutionDecisionAttributes': {
+                'childPolicy': 'TERMINATE',
+                'executionStartToCloseTimeout': '10',
+                'input': 'input',
+                'tagList': ['t1', 't2'],
+                'taskList': {'name': 'tasklist'},
+                'taskStartToCloseTimeout': '20',
+                'workflowTypeVersion': 'v2',
+            }
+        })


### PR DESCRIPTION
This fixes a typo. As per [SWF docs](http://docs.aws.amazon.com/amazonswf/latest/apireference/API_ContinueAsNewWorkflowExecutionDecisionAttributes.html) the correct name for `start_to_close_timeout` argument in `continue_as_new_workflow_execution` method should be `taskStartToCloseTimeout`.

I couldn't find any unittests for `layer1_decisions` module so I've added a new file with only this specific test case. It can be expanded later if other bugs are found or if someone has the time to contribute the missing ones.
