### PR TITLE
Add documentation for top-level S3 module

### DIFF
--- a/docs/source/ref/s3.rst
+++ b/docs/source/ref/s3.rst
@@ -4,6 +4,13 @@
 S3
 ===
 
+boto.s3
+--------
+
+.. automodule:: boto.s3
+   :members:
+   :undoc-members:
+
 boto.s3.acl
 -----------
 


### PR DESCRIPTION
The docs are missing content for functions in the top of the boto.s3 module.
