### PR TITLE
Give a chance to establish connection via IPv6.

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -787,13 +787,13 @@ class AWSAuthConnection(object):
             host = '%s:%d' % (host, port)
         else:
             host = '%s:%d' % (self.host, self.port)
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            sock.connect((self.proxy, int(self.proxy_port)))
-            if "timeout" in self.http_connection_kwargs:
-                sock.settimeout(self.http_connection_kwargs["timeout"])
-        except:
-            raise
+        # Seems properly to use timeout for connect too
+        timeout = self.https_connection_kwargs.get("timeout")
+        if timeout is not None:
+            sock = socket.create_connection((self.proxy,
+                                             int(self.proxy_port)), timeout)
+        else:
+            sock = socket.create_connection((self.proxy, int(self.proxy_port)))
         boto.log.debug("Proxy connection: CONNECT %s HTTP/1.0\r\n", host)
         sock.sendall("CONNECT %s HTTP/1.0\r\n" % host)
         sock.sendall("User-Agent: %s\r\n" % UserAgent)

--- a/boto/https_connection.py
+++ b/boto/https_connection.py
@@ -112,10 +112,10 @@ class CertValidatingHTTPSConnection(http_client.HTTPConnection):
 
   def connect(self):
     "Connect to a host on a given (SSL) port."
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    if hasattr(self, "timeout") and self.timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
-        sock.settimeout(self.timeout)
-    sock.connect((self.host, self.port))
+    if hasattr(self, "timeout"):
+        sock = socket.create_connection((self.host, self.port), self.timeout)
+    else:
+        sock = socket.create_connection((self.host, self.port))
     msg = "wrapping ssl socket; "
     if self.ca_certs:
         msg += "CA certificate file=%s" %self.ca_certs


### PR DESCRIPTION
Use `create_connection` instead of an explicit setting of AF_INET to socket.
