### PR TITLE
elastictranscoder module: add backward-compatible support for Python 3.3+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ At the moment, boto supports:
 * Application Services
 
   * Amazon CloudSearch
-  * Amazon Elastic Transcoder
+  * Amazon Elastic Transcoder (Python 3)
   * Amazon Simple Workflow Service (SWF)
   * Amazon Simple Queue Service (SQS) (Python 3)
   * Amazon Simple Notification Server (SNS) (Python 3)

--- a/boto/elastictranscoder/layer1.py
+++ b/boto/elastictranscoder/layer1.py
@@ -923,7 +923,7 @@ class ElasticTranscoderConnection(AWSAuthConnection):
             headers = {}
         response = super(ElasticTranscoderConnection, self).make_request(
             verb, resource, headers=headers, data=data)
-        body = json.load(response)
+        body = json.loads(response.read().decode('utf-8'))
         if response.status == expected_status:
             return body
         else:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,7 +68,7 @@ Currently Supported Services
 
   * Cloudsearch 2 -- (:doc:`API Reference <ref/cloudsearch2>`)
   * :doc:`Cloudsearch <cloudsearch_tut>` -- (:doc:`API Reference <ref/cloudsearch>`)
-  * Elastic Transcoder -- (:doc:`API Reference <ref/elastictranscoder>`)
+  * Elastic Transcoder -- (:doc:`API Reference <ref/elastictranscoder>`) (Python 3)
   * :doc:`Simple Workflow Service (SWF) <swf_tut>` -- (:doc:`API Reference <ref/swf>`)
   * :doc:`Simple Queue Service (SQS) <sqs_tut>` -- (:doc:`API Reference <ref/sqs>`) (Python 3)
   * Simple Notification Service (SNS) -- (:doc:`API Reference <ref/sns>`) (Python 3)

--- a/tests/integration/elastictranscoder/test_cert_verification.py
+++ b/tests/integration/elastictranscoder/test_cert_verification.py
@@ -19,11 +19,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-import unittest
 
 from tests.integration import ServiceCertVerificationTest
 
 import boto.elastictranscoder
+from boto.compat import unittest
 
 
 class ElasticTranscoderCertVerificationTest(unittest.TestCase, ServiceCertVerificationTest):

--- a/tests/integration/elastictranscoder/test_layer1.py
+++ b/tests/integration/elastictranscoder/test_layer1.py
@@ -19,11 +19,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-import unittest
 import time
 
 from boto.elastictranscoder.layer1 import ElasticTranscoderConnection
 from boto.elastictranscoder.exceptions import ValidationException
+from boto.compat import unittest
 import boto.s3
 import boto.sns
 import boto.iam


### PR DESCRIPTION
No unit test to test with, I've tested only with integration tests and they passed here.
