### PR TITLE
autoscale module: add backward-compatible support for Python 3.3+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ At the moment, boto supports:
 
   * Amazon Elastic Compute Cloud (EC2)
   * Amazon Elastic Map Reduce (EMR) (Python 3)
-  * AutoScaling
+  * AutoScaling (Python 3)
   * Amazon Kinesis (Python 3)
 
 * Content Delivery

--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -143,7 +143,7 @@ class AutoScaleConnection(AWSQueryConnection):
                             params['%s.member.%d.%s.%s' % (label, i, k, kk)] = vv
                     else:
                         params['%s.member.%d.%s' % (label, i, k)] = v
-            elif isinstance(items[i - 1], basestring):
+            elif isinstance(items[i - 1], six.string_types):
                 params['%s.member.%d' % (label, i)] = items[i - 1]
 
     def _update_group(self, op, as_group):

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,7 +34,7 @@ Currently Supported Services
 
   * :doc:`Elastic Compute Cloud (EC2) <ec2_tut>` -- (:doc:`API Reference <ref/ec2>`)
   * :doc:`Elastic MapReduce (EMR) <emr_tut>` -- (:doc:`API Reference <ref/emr>`) (Python 3)
-  * :doc:`Auto Scaling <autoscale_tut>` -- (:doc:`API Reference <ref/autoscale>`)
+  * :doc:`Auto Scaling <autoscale_tut>` -- (:doc:`API Reference <ref/autoscale>`) (Python 3)
   * Kinesis -- (:doc:`API Reference <ref/kinesis>`) (Python 3)
 
 * **Content Delivery**

--- a/tests/integration/ec2/autoscale/test_connection.py
+++ b/tests/integration/ec2/autoscale/test_connection.py
@@ -24,7 +24,7 @@
 Some unit tests for the AutoscaleConnection
 """
 
-import unittest
+from __future__ import print_function
 import time
 from boto.ec2.autoscale import AutoScaleConnection
 from boto.ec2.autoscale.activity import Activity
@@ -34,6 +34,7 @@ from boto.ec2.autoscale.policy import AdjustmentType, MetricCollectionTypes, Sca
 from boto.ec2.autoscale.scheduled import ScheduledUpdateGroupAction
 from boto.ec2.autoscale.instance import Instance
 from boto.ec2.autoscale.tag import Tag
+from boto.compat import unittest
 
 
 class AutoscaleConnectionTest(unittest.TestCase):
@@ -46,7 +47,7 @@ class AutoscaleConnectionTest(unittest.TestCase):
         # have any autoscale groups to introspect. It's useful, however, to
         # catch simple errors
 
-        print '--- running %s tests ---' % self.__class__.__name__
+        print('--- running %s tests ---' % self.__class__.__name__)
         c = AutoScaleConnection()
 
         self.assertTrue(repr(c).startswith('AutoScaleConnection'))
@@ -164,7 +165,7 @@ class AutoscaleConnectionTest(unittest.TestCase):
 
         assert not found
 
-        print '--- tests completed ---'
+        print('--- tests completed ---')
 
     def test_ebs_optimized_regression(self):
         c = AutoScaleConnection()

--- a/tests/test.py
+++ b/tests/test.py
@@ -47,6 +47,7 @@ PY3_WHITELIST = (
     'tests/unit/emr',
     'tests/unit/glacier',
     'tests/unit/iam',
+    'tests/unit/ec2/autoscale',
     'tests/unit/ec2/elb',
     'tests/unit/manage',
     'tests/unit/provider',

--- a/tests/unit/ec2/autoscale/test_group.py
+++ b/tests/unit/ec2/autoscale/test_group.py
@@ -42,7 +42,7 @@ class TestAutoScaleGroup(AWSMockServiceTestCase):
         super(TestAutoScaleGroup, self).setUp()
 
     def default_body(self):
-        return """
+        return b"""
             <CreateLaunchConfigurationResponse>
               <ResponseMetadata>
                 <RequestId>requestid</RequestId>
@@ -110,7 +110,7 @@ class TestAutoScaleGroupHonorCooldown(AWSMockServiceTestCase):
     connection_class = AutoScaleConnection
 
     def default_body(self):
-        return """
+        return b"""
             <SetDesiredCapacityResponse>
               <ResponseMetadata>
                 <RequestId>9fb7e2db-6998-11e2-a985-57c82EXAMPLE</RequestId>
@@ -135,7 +135,7 @@ class TestScheduledGroup(AWSMockServiceTestCase):
         super(TestScheduledGroup, self).setUp()
 
     def default_body(self):
-        return """
+        return b"""
             <PutScheduledUpdateGroupActionResponse>
                 <ResponseMetadata>
                   <RequestId>requestid</RequestId>
@@ -169,7 +169,7 @@ class TestParseAutoScaleGroupResponse(AWSMockServiceTestCase):
     connection_class = AutoScaleConnection
 
     def default_body(self):
-        return """
+        return b"""
           <DescribeAutoScalingGroupsResult>
              <AutoScalingGroups>
                <member>
@@ -238,7 +238,7 @@ class TestDescribeTerminationPolicies(AWSMockServiceTestCase):
     connection_class = AutoScaleConnection
 
     def default_body(self):
-        return """
+        return b"""
           <DescribeTerminationPolicyTypesResponse>
             <DescribeTerminationPolicyTypesResult>
               <TerminationPolicyTypes>
@@ -268,7 +268,7 @@ class TestLaunchConfigurationDescribe(AWSMockServiceTestCase):
 
     def default_body(self):
         # This is a dummy response
-        return """
+        return b"""
         <DescribeLaunchConfigurationsResponse>
           <DescribeLaunchConfigurationsResult>
             <LaunchConfigurations>
@@ -336,7 +336,7 @@ class TestLaunchConfiguration(AWSMockServiceTestCase):
 
     def default_body(self):
         # This is a dummy response
-        return """
+        return b"""
         <DescribeLaunchConfigurationsResponse>
         </DescribeLaunchConfigurationsResponse>
         """
@@ -397,7 +397,7 @@ class TestCreateAutoScalePolicy(AWSMockServiceTestCase):
         super(TestCreateAutoScalePolicy, self).setUp()
 
     def default_body(self):
-        return """
+        return b"""
             <PutScalingPolicyResponse xmlns="http://autoscaling.amazonaws.com\
             /doc/2011-01-01/">
               <PutScalingPolicyResult>
@@ -472,7 +472,7 @@ class TestPutNotificationConfiguration(AWSMockServiceTestCase):
         super(TestPutNotificationConfiguration, self).setUp()
 
     def default_body(self):
-        return """
+        return b"""
             <PutNotificationConfigurationResponse>
               <ResponseMetadata>
                 <RequestId>requestid</RequestId>
@@ -502,7 +502,7 @@ class TestDeleteNotificationConfiguration(AWSMockServiceTestCase):
         super(TestDeleteNotificationConfiguration, self).setUp()
 
     def default_body(self):
-        return """
+        return b"""
             <DeleteNotificationConfigurationResponse>
               <ResponseMetadata>
                 <RequestId>requestid</RequestId>
@@ -527,7 +527,7 @@ class TestAutoScalingTag(AWSMockServiceTestCase):
     connection_class = AutoScaleConnection
 
     def default_body(self):
-        return """
+        return b"""
         <CreateOrUpdateTagsResponse>
             <ResponseMetadata>
                 <RequestId>requestId</RequestId>
@@ -599,7 +599,7 @@ class TestAttachInstances(AWSMockServiceTestCase):
         super(TestAttachInstances, self).setUp()
 
     def default_body(self):
-        return """
+        return b"""
             <AttachInstancesResponse>
               <ResponseMetadata>
                 <RequestId>requestid</RequestId>
@@ -629,7 +629,7 @@ class TestGetAccountLimits(AWSMockServiceTestCase):
         super(TestGetAccountLimits, self).setUp()
 
     def default_body(self):
-        return """
+        return b"""
             <DescribeAccountLimitsAnswer>
               <MaxNumberOfAutoScalingGroups>6</MaxNumberOfAutoScalingGroups>
               <MaxNumberOfLaunchConfigurations>3</MaxNumberOfLaunchConfigurations>
@@ -655,7 +655,7 @@ class TestGetAdjustmentTypes(AWSMockServiceTestCase):
         super(TestGetAdjustmentTypes, self).setUp()
 
     def default_body(self):
-        return """
+        return b"""
             <DescribeAdjustmentTypesResponse xmlns="http://autoscaling.amazonaws.com/doc/201-01-01/">
               <DescribeAdjustmentTypesResult>
                 <AdjustmentTypes>
@@ -693,7 +693,7 @@ class TestLaunchConfigurationDescribeWithBlockDeviceTypes(AWSMockServiceTestCase
 
     def default_body(self):
         # This is a dummy response
-        return """
+        return b"""
         <DescribeLaunchConfigurationsResponse>
           <DescribeLaunchConfigurationsResult>
             <LaunchConfigurations>


### PR DESCRIPTION
All tests passed.
