### PR TITLE
Added documentation for /manage/cmdshell.py

### DIFF
--- a/boto/manage/cmdshell.py
+++ b/boto/manage/cmdshell.py
@@ -348,9 +348,10 @@ class LocalClient(object):
 
 class FakeServer(object):
     """
-    This object has the same variables as a boto.manage.server.Server
-    object. You can use this object to create an SSHClient object
-    instead of creating an actual Server object.
+    This object has a subset of the variables that are normally in a
+    :class:`boto.manage.server.Server` object. You can use this FakeServer
+    object to create a :class:`boto.manage.SSHClient` object if you
+    don't have a real Server object.
     
     :ivar instance: A boto Instance object.
     :ivar ssh_key_file: The path to the SSH key file.


### PR DESCRIPTION
No code changes, just documentation. I tested the :class:`paramiko.channel.Channel` links with a documentation build. They generate bold text, but are not clickable URLs since they wouldn't resolve anyway. Is that an acceptable solution, or should I refer to the paramiko objects with different mark up?

I think I got everything right. Let me know if I messed up anywhere or if any of my descriptions are inaccurate and I'll change it.

I made these same changes to my master branch. Do I need to create a pull request for that as well so the current version gets updated?

On an side note, I'm wondering why the isdir() function in the SSHClient class returns 1 and 0 instead of True and False. The equivalent function in the LocalClient class returns True and False. Just curious.
