### PR TITLE
EC2 UserData encoding fix (Full version of #1698)

### DIFF
--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -222,7 +222,7 @@ class AutoScaleConnection(AWSQueryConnection):
         if launch_config.key_name:
             params['KeyName'] = launch_config.key_name
         if launch_config.user_data:
-            params['UserData'] = base64.b64encode(launch_config.user_data)
+            params['UserData'] = base64.b64encode(launch_config.user_data).decode('utf-8')
         if launch_config.kernel_id:
             params['KernelId'] = launch_config.kernel_id
         if launch_config.ramdisk_id:

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -900,7 +900,7 @@ class EC2Connection(AWSQueryConnection):
                     l.append(group)
             self.build_list_params(params, l, 'SecurityGroup')
         if user_data:
-            params['UserData'] = base64.b64encode(user_data)
+            params['UserData'] = base64.b64encode(user_data).decode('utf-8')
         if addressing_type:
             params['AddressingType'] = addressing_type
         if instance_type:

--- a/tests/unit/ec2/autoscale/test_group.py
+++ b/tests/unit/ec2/autoscale/test_group.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 
+import base64
 from datetime import datetime
 
 from tests.unit import unittest
@@ -356,6 +357,7 @@ class TestLaunchConfiguration(AWSMockServiceTestCase):
                 name='launch_config',
                 image_id='123456',
                 instance_type = 'm1.large',
+                user_data = '#!/bin/bash',
                 security_groups = ['group1', 'group2'],
                 spot_price='price',
                 block_device_mappings = [bdm],
@@ -378,6 +380,7 @@ class TestLaunchConfiguration(AWSMockServiceTestCase):
             'EbsOptimized': 'false',
             'LaunchConfigurationName': 'launch_config',
             'ImageId': '123456',
+            'UserData': base64.b64encode('#!/bin/bash').decode('utf-8'),
             'InstanceMonitoring.Enabled': 'false',
             'InstanceType': 'm1.large',
             'SecurityGroups.member.1': 'group1',


### PR DESCRIPTION
Based on #1698 I made the fix with an updated branch using boto:develop as base and added Unit Tests for it, including a class for Testing boto.ec2.run_instances that doesn't exist yet.
