### PR TITLE
swf module: add backward-compatible support for Python 3.3+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ At the moment, boto supports:
 
   * Amazon CloudSearch
   * Amazon Elastic Transcoder (Python 3)
-  * Amazon Simple Workflow Service (SWF)
+  * Amazon Simple Workflow Service (SWF) (Python 3)
   * Amazon Simple Queue Service (SQS) (Python 3)
   * Amazon Simple Notification Server (SNS) (Python 3)
   * Amazon Simple Email Service (SES) (Python 3)

--- a/boto/swf/layer1.py
+++ b/boto/swf/layer1.py
@@ -96,7 +96,7 @@ class Layer1(AWSAuthConnection):
         :type data: dict
         :param data: Specifies request parameters with default values to be removed.
         """
-        for item in data.keys():
+        for item in list(data.keys()):
             if isinstance(data[item], dict):
                 cls._normalize_request_dict(data[item])
             if data[item] in (None, {}):
@@ -130,7 +130,7 @@ class Layer1(AWSAuthConnection):
                                                     {}, headers, body, None)
         response = self._mexe(http_request, sender=None,
                               override_num_retries=10)
-        response_body = response.read()
+        response_body = response.read().decode('utf-8')
         boto.log.debug(response_body)
         if response.status == 200:
             if response_body:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -69,7 +69,7 @@ Currently Supported Services
   * Cloudsearch 2 -- (:doc:`API Reference <ref/cloudsearch2>`)
   * :doc:`Cloudsearch <cloudsearch_tut>` -- (:doc:`API Reference <ref/cloudsearch>`)
   * Elastic Transcoder -- (:doc:`API Reference <ref/elastictranscoder>`) (Python 3)
-  * :doc:`Simple Workflow Service (SWF) <swf_tut>` -- (:doc:`API Reference <ref/swf>`)
+  * :doc:`Simple Workflow Service (SWF) <swf_tut>` -- (:doc:`API Reference <ref/swf>`) (Python 3)
   * :doc:`Simple Queue Service (SQS) <sqs_tut>` -- (:doc:`API Reference <ref/sqs>`) (Python 3)
   * Simple Notification Service (SNS) -- (:doc:`API Reference <ref/sns>`) (Python 3)
   * :doc:`Simple Email Service (SES) <ses_tut>` -- (:doc:`API Reference <ref/ses>`) (Python 3)

--- a/tests/integration/swf/test_layer1_workflow_execution.py
+++ b/tests/integration/swf/test_layer1_workflow_execution.py
@@ -9,7 +9,7 @@ import traceback
 
 from boto.swf.layer1_decisions import Layer1Decisions
 
-from test_layer1 import SimpleWorkflowLayer1TestBase
+from tests.integration.swf.test_layer1 import SimpleWorkflowLayer1TestBase
 
 
 


### PR DESCRIPTION
The last two integration tests already failed for unmodified version, sorry but I didn't figure out why.

My port passed the unit tests, and get the same two errors across all python versions.
