### PR TITLE
cloudwatch module: add backward-compatible support for Python 3.3+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ At the moment, boto supports:
 
 * Monitoring
 
-  * Amazon CloudWatch (EC2 Only)
+  * Amazon CloudWatch (EC2 Only) (Python 3)
   * Amazon CloudWatch Logs (Python 3)
 
 * Networking

--- a/boto/compat.py
+++ b/boto/compat.py
@@ -45,6 +45,11 @@ try:
 except ImportError:
     import unittest
 
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
+
 from boto.vendored import six
 
 from boto.vendored.six import BytesIO, StringIO

--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -110,7 +110,7 @@ class CloudWatchConnection(AWSQueryConnection):
         for dim_name in dimension:
             dim_value = dimension[dim_name]
             if dim_value:
-                if isinstance(dim_value, basestring):
+                if isinstance(dim_value, six.string_types):
                     dim_value = [dim_value]
                 for value in dim_value:
                     params['%s.%d.Name' % (prefix, i+1)] = dim_name
@@ -121,7 +121,7 @@ class CloudWatchConnection(AWSQueryConnection):
                 i += 1
 
     def build_list_params(self, params, items, label):
-        if isinstance(items, basestring):
+        if isinstance(items, six.string_types):
             items = [items]
         for index, item in enumerate(items):
             i = index + 1

--- a/boto/ec2/cloudwatch/alarm.py
+++ b/boto/ec2/cloudwatch/alarm.py
@@ -21,7 +21,6 @@
 #
 
 from datetime import datetime
-from boto.resultset import ResultSet
 from boto.ec2.cloudwatch.listelement import ListElement
 from boto.ec2.cloudwatch.dimension import Dimension
 from boto.compat import json
@@ -253,11 +252,11 @@ class MetricAlarm(object):
 
     def add_alarm_action(self, action_arn=None):
         """
-        Adds an alarm action, represented as an SNS topic, to this alarm. 
+        Adds an alarm action, represented as an SNS topic, to this alarm.
         What do do when alarm is triggered.
 
         :type action_arn: str
-        :param action_arn: SNS topics to which notification should be 
+        :param action_arn: SNS topics to which notification should be
                            sent if the alarm goes to state ALARM.
         """
         if not action_arn:
@@ -271,21 +270,21 @@ class MetricAlarm(object):
         this alarm. What to do when the insufficient_data state is reached.
 
         :type action_arn: str
-        :param action_arn: SNS topics to which notification should be 
+        :param action_arn: SNS topics to which notification should be
                            sent if the alarm goes to state INSUFFICIENT_DATA.
         """
         if not action_arn:
             return
         self.actions_enabled = 'true'
         self.insufficient_data_actions.append(action_arn)
-    
+
     def add_ok_action(self, action_arn=None):
         """
         Adds an ok action, represented as an SNS topic, to this alarm. What
         to do when the ok state is reached.
 
         :type action_arn: str
-        :param action_arn: SNS topics to which notification should be 
+        :param action_arn: SNS topics to which notification should be
                            sent if the alarm goes to state INSUFFICIENT_DATA.
         """
         if not action_arn:
@@ -321,4 +320,3 @@ class AlarmHistoryItem(object):
                                                    '%Y-%m-%dT%H:%M:%S.%fZ')
             except ValueError:
                 self.timestamp = datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
-

--- a/boto/ec2/cloudwatch/datapoint.py
+++ b/boto/ec2/cloudwatch/datapoint.py
@@ -37,4 +37,3 @@ class Datapoint(dict):
             self[name] = datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
         elif name != 'member':
             self[name] = value
-

--- a/boto/ec2/cloudwatch/dimension.py
+++ b/boto/ec2/cloudwatch/dimension.py
@@ -35,4 +35,3 @@ class Dimension(dict):
                 self[self._name] = [value]
         else:
             setattr(self, name, value)
-

--- a/boto/ec2/cloudwatch/listelement.py
+++ b/boto/ec2/cloudwatch/listelement.py
@@ -27,5 +27,3 @@ class ListElement(list):
     def endElement(self, name, value, connection):
         if name == 'member':
             self.append(value)
-    
-    

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -76,7 +76,7 @@ Currently Supported Services
 
 * **Monitoring**
 
-  * :doc:`CloudWatch <cloudwatch_tut>` -- (:doc:`API Reference <ref/cloudwatch>`)
+  * :doc:`CloudWatch <cloudwatch_tut>` -- (:doc:`API Reference <ref/cloudwatch>`) (Python 3)
   * CloudWatch Logs -- (:doc:`API Reference <ref/logs>`) (Python 3)
 
 * **Networking**

--- a/requirements-py26.txt
+++ b/requirements-py26.txt
@@ -1,1 +1,2 @@
 unittest2==0.5.1
+ordereddict==1.1

--- a/tests/integration/ec2/cloudwatch/test_cert_verification.py
+++ b/tests/integration/ec2/cloudwatch/test_cert_verification.py
@@ -24,11 +24,10 @@
 """
 Check that all of the certs on all service endpoints validate.
 """
-import unittest
-
 from tests.integration import ServiceCertVerificationTest
 
 import boto.ec2.cloudwatch
+from boto.compat import unittest
 
 
 class CloudWatchCertVerificationTest(unittest.TestCase, ServiceCertVerificationTest):

--- a/tests/integration/ec2/cloudwatch/test_connection.py
+++ b/tests/integration/ec2/cloudwatch/test_connection.py
@@ -25,11 +25,9 @@ Initial, and very limited, unit tests for CloudWatchConnection.
 """
 
 import datetime
-import time
-import unittest
 
 from boto.ec2.cloudwatch import CloudWatchConnection
-from boto.ec2.cloudwatch.metric import Metric
+from boto.compat import unittest, OrderedDict
 
 # HTTP response body for CloudWatchConnection.describe_alarms
 DESCRIBE_ALARMS_BODY = """<DescribeAlarmsResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">
@@ -160,7 +158,6 @@ class CloudWatchConnectionTest(unittest.TestCase):
         self.assertEqual(params, expected_params)
 
     def test_build_put_params_multiple_parameter_dimension(self):
-        from collections import OrderedDict
         self.maxDiff = None
         c = CloudWatchConnection()
         params = {}
@@ -180,7 +177,6 @@ class CloudWatchConnectionTest(unittest.TestCase):
         self.assertEqual(params, expected_params)
 
     def test_build_get_params_multiple_parameter_dimension1(self):
-        from collections import OrderedDict
         self.maxDiff = None
         c = CloudWatchConnection()
         params = {}
@@ -195,7 +191,6 @@ class CloudWatchConnectionTest(unittest.TestCase):
         self.assertEqual(params, expected_params)
 
     def test_build_get_params_multiple_parameter_dimension2(self):
-        from collections import OrderedDict
         self.maxDiff = None
         c = CloudWatchConnection()
         params = {}
@@ -225,14 +220,14 @@ class CloudWatchConnectionTest(unittest.TestCase):
     def test_get_metric_statistics(self):
         c = CloudWatchConnection()
         m = c.list_metrics()[0]
-        end = datetime.datetime.now()
+        end = datetime.datetime.utcnow()
         start = end - datetime.timedelta(hours=24*14)
         c.get_metric_statistics(
             3600*24, start, end, m.name, m.namespace, ['Average', 'Sum'])
 
     def test_put_metric_data(self):
         c = CloudWatchConnection()
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
         name, namespace = 'unit-test-metric', 'boto-unit-test'
         c.put_metric_data(namespace, name, 5, now, 'Bytes')
 
@@ -245,7 +240,7 @@ class CloudWatchConnectionTest(unittest.TestCase):
         # time.sleep(60)
         # l = metric.query(
         #     now - datetime.timedelta(seconds=60),
-        #     datetime.datetime.now(),
+        #     datetime.datetime.utcnow(),
         #     'Average')
         # assert l
         # for row in l:

--- a/tests/test.py
+++ b/tests/test.py
@@ -48,6 +48,7 @@ PY3_WHITELIST = (
     'tests/unit/glacier',
     'tests/unit/iam',
     'tests/unit/ec2/autoscale',
+    'tests/unit/ec2/cloudwatch',
     'tests/unit/ec2/elb',
     'tests/unit/manage',
     'tests/unit/provider',

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,10 @@ envlist = py26,py27,py33,py34
 skipsdist = True
 
 [testenv:py26]
-# Python 2.6 requires an extra test dependency
+# Python 2.6 requires two extra test dependencies
 deps =
     unittest2
+    ordereddict
     -rrequirements.txt
 # Some tests expect specific ordering, so we set the hash
 # seed for Python 2.x until all tests are updated for Python 3.


### PR DESCRIPTION
All tests passed.

I tried to avoid using OrderedDict in the tests here (because it's the only place where it's used) for compatibility with Python 2.6, but find it quite difficult to make the tests still readable without it. So I've added the backported ordereddict module as a test dependency for python 2.6, hope this is acceptable.
