### PR TITLE
opsworks module: add backward-compatible support for Python 3.3+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ At the moment, boto supports:
   * AWS Elastic Beanstalk
   * AWS CloudFormation (Python 3)
   * AWS Data Pipeline (Python 3)
-  * AWS Opsworks
+  * AWS Opsworks (Python 3)
   * AWS CloudTrail (Python 3)
 
 * Identity & Access

--- a/boto/opsworks/layer1.py
+++ b/boto/opsworks/layer1.py
@@ -20,16 +20,13 @@
 # IN THE SOFTWARE.
 #
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
 
 import boto
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.opsworks import exceptions
+from boto.compat import json
 
 
 class OpsWorksConnection(AWSQueryConnection):
@@ -2580,7 +2577,7 @@ class OpsWorksConnection(AWSQueryConnection):
             headers=headers, data=body)
         response = self._mexe(http_request, sender=None,
                               override_num_retries=10)
-        response_body = response.read()
+        response_body = response.read().decode('utf-8')
         boto.log.debug(response_body)
         if response.status == 200:
             if response_body:
@@ -2591,4 +2588,3 @@ class OpsWorksConnection(AWSQueryConnection):
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,7 +56,7 @@ Currently Supported Services
   * CloudFormation -- (:doc:`API Reference <ref/cloudformation>`) (Python 3)
   * Elastic Beanstalk -- (:doc:`API Reference <ref/beanstalk>`)
   * Data Pipeline -- (:doc:`API Reference <ref/datapipeline>`) (Python 3)
-  * Opsworks -- (:doc:`API Reference <ref/opsworks>`)
+  * Opsworks -- (:doc:`API Reference <ref/opsworks>`) (Python 3)
   * CloudTrail -- (:doc:`API Reference <ref/cloudtrail>`) (Python 3)
 
 * **Identity & Access**

--- a/tests/integration/opsworks/test_layer1.py
+++ b/tests/integration/opsworks/test_layer1.py
@@ -19,11 +19,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-import unittest
 
 from boto.exception import JSONResponseError
 from boto.opsworks import connect_to_region, regions, RegionInfo
 from boto.opsworks.layer1 import OpsWorksConnection
+from boto.compat import unittest
 
 
 class TestOpsWorksConnection(unittest.TestCase):


### PR DESCRIPTION
No unit tests to test with, all integration tests passed.
