### PR TITLE
support module: add backward-compatible support for Python 3.3+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ At the moment, boto supports:
 * Other
 
   * Marketplace Web Services (Python 3)
-  * AWS Support
+  * AWS Support (Python 3)
 
 The goal of boto is to support the full breadth and depth of Amazon
 Web Services.  In addition, boto provides support for other public

--- a/boto/support/layer1.py
+++ b/boto/support/layer1.py
@@ -20,16 +20,12 @@
 # IN THE SOFTWARE.
 #
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
 import boto
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.support import exceptions
+from boto.compat import json
 
 
 class SupportConnection(AWSQueryConnection):
@@ -577,7 +573,7 @@ class SupportConnection(AWSQueryConnection):
             headers=headers, data=body)
         response = self._mexe(http_request, sender=None,
                               override_num_retries=10)
-        response_body = response.read()
+        response_body = response.read().decode('utf-8')
         boto.log.debug(response_body)
         if response.status == 200:
             if response_body:
@@ -588,4 +584,3 @@ class SupportConnection(AWSQueryConnection):
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -103,7 +103,7 @@ Currently Supported Services
 * **Other**
 
   * Marketplace Web Services -- (:doc:`API Reference <ref/mws>`) (Python 3)
-  * :doc:`Support <support_tut>` -- (:doc:`API Reference <ref/support>`)
+  * :doc:`Support <support_tut>` -- (:doc:`API Reference <ref/support>`) (Python 3)
 
 Additional Resources
 --------------------


### PR DESCRIPTION
This module has no unit tests, and integration tests failed because my account is not eligible:

"AWS Premium Support Subscription is required to use this service."

But the changes are trivial and should work :)
