### PR TITLE
Support for query_args in bucket creation and multipart upload init

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -1689,7 +1689,7 @@ class Bucket(object):
     def initiate_multipart_upload(self, key_name, headers=None,
                                   reduced_redundancy=False,
                                   metadata=None, encrypt_key=False,
-                                  policy=None):
+                                  policy=None, query_args=None):
         """
         Start a multipart upload operation.
 
@@ -1731,8 +1731,12 @@ class Bucket(object):
         :type policy: :class:`boto.s3.acl.CannedACLStrings`
         :param policy: A canned ACL policy that will be applied to the
             new key (once completed) in S3.
+
+        :type query_args: string
+        :param query_args: A string of additional querystring arguments
+            to append to the request
         """
-        query_args = 'uploads'
+        query_args = 'uploads&{0}'.format(query_args) if query_args is not None else 'uploads'
         provider = self.connection.provider
         headers = headers or {}
         if policy:

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -574,7 +574,7 @@ class S3Connection(AWSAuthConnection):
         return bucket
 
     def create_bucket(self, bucket_name, headers=None,
-                      location=Location.DEFAULT, policy=None):
+                      location=Location.DEFAULT, policy=None, query_args=None):
         """
         Creates a new located bucket. By default it's in the USA. You can pass
         Location.EU to create a European bucket (S3) or European Union bucket
@@ -595,6 +595,10 @@ class S3Connection(AWSAuthConnection):
         :param policy: A canned ACL policy that will be applied to the
             new key in S3.
 
+        :type query_args: string
+        :param query_args: A string of additional querystring arguments
+            to append to the request
+
         """
         check_lowercase_bucketname(bucket_name)
 
@@ -609,7 +613,7 @@ class S3Connection(AWSAuthConnection):
             data = '<CreateBucketConfiguration><LocationConstraint>' + \
                     location + '</LocationConstraint></CreateBucketConfiguration>'
         response = self.make_request('PUT', bucket_name, headers=headers,
-                data=data)
+                data=data, query_args=query_args)
         body = response.read()
         if response.status == 409:
             raise self.provider.storage_create_error(

--- a/tests/unit/s3/test_bucket.py
+++ b/tests/unit/s3/test_bucket.py
@@ -64,6 +64,11 @@ class TestS3Bucket(AWSMockServiceTestCase):
         with self.assertRaises(TypeError):
             bucket.get_all_keys(delimeter='foo')
 
+    def test_bucket_create_bucket_query_args(self):
+        self.set_http_response(status_code=200)
+        bucket = self.service_connection.create_bucket('mybucket_create', query_args="rgwx-uid=testuser")
+        self.assertEqual(bucket.name, 'mybucket_create')
+
     def test__get_all_query_args(self):
         bukket = Bucket()
 
@@ -227,3 +232,20 @@ class TestS3Bucket(AWSMockServiceTestCase):
         document = xml.dom.minidom.parseString(xml_policy)
         namespace = document.documentElement.namespaceURI
         self.assertEqual(namespace, 'http://s3.amazonaws.com/doc/2006-03-01/')
+
+    def initiate_multipart_upload(self):
+        return """<?xml version="1.0" encoding="UTF-8"?>
+        <InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+            <Bucket>example-bucket</Bucket>
+            <Key>example-key</Key>
+            <UploadId>2/-yPRkYqqIXBZhaVF0bGkrQceLtStPQc</UploadId>
+        </InitiateMultipartUploadResult>"""
+
+    def test_bucket_initiate_multipart_upload(self):
+        self.set_http_response(status_code=200)
+        bucket = self.service_connection.create_bucket('example-bucket')
+        self.assertEqual(bucket.name, 'example-bucket')
+
+        self.set_http_response(status_code=200, body=self.initiate_multipart_upload())
+        mp = bucket.initiate_multipart_upload('example-key', query_args="rgwx-uid=testuser")
+        self.assertIsInstance(mp, MultiPartUpload)


### PR DESCRIPTION
Currently if someone wants to add some custom query arguments in bucket creation or initiating the multipart upload, he/she has to subclass S3Connection or Bucket and copy-paste the whole method, which is ugly.

My proposal is to simply add one more argument, just like in other boto methods.
