### PR TITLE
cloudsearch module: add backward-compatible support for Python 3.3+

### DIFF
--- a/boto/cloudsearch/document.py
+++ b/boto/cloudsearch/document.py
@@ -221,13 +221,15 @@ class CommitResponse(object):
         self.doc_service = doc_service
         self.sdf = sdf
 
+        _body = response.content.decode('utf-8')
+
         try:
-            self.content = json.loads(response.content)
+            self.content = json.loads(_body)
         except:
             boto.log.error('Error indexing documents.\nResponse Content:\n{0}\n\n'
-                'SDF:\n{1}'.format(response.content, self.sdf))
+                'SDF:\n{1}'.format(_body, self.sdf))
             raise boto.exception.BotoServerError(self.response.status_code, '',
-                body=response.content)
+                body=_body)
 
         self.status = self.content['status']
         if self.status == 'error':

--- a/boto/cloudsearch/domain.py
+++ b/boto/cloudsearch/domain.py
@@ -36,7 +36,7 @@ def handle_bool(value):
         return True
     return False
 
-            
+
 class Domain(object):
     """
     A Cloudsearch domain.
@@ -118,7 +118,7 @@ class Domain(object):
     @created.setter
     def created(self, value):
         self._created = handle_bool(value)
-            
+
     @property
     def deleted(self):
         return self._deleted
@@ -126,7 +126,7 @@ class Domain(object):
     @deleted.setter
     def deleted(self, value):
         self._deleted = handle_bool(value)
-            
+
     @property
     def processing(self):
         return self._processing
@@ -134,7 +134,7 @@ class Domain(object):
     @processing.setter
     def processing(self, value):
         self._processing = handle_bool(value)
-            
+
     @property
     def requires_index_documents(self):
         return self._requires_index_documents
@@ -142,7 +142,7 @@ class Domain(object):
     @requires_index_documents.setter
     def requires_index_documents(self, value):
         self._requires_index_documents = handle_bool(value)
-            
+
     @property
     def search_partition_count(self):
         return self._search_partition_count
@@ -150,7 +150,7 @@ class Domain(object):
     @search_partition_count.setter
     def search_partition_count(self, value):
         self._search_partition_count = int(value)
-            
+
     @property
     def search_instance_count(self):
         return self._search_instance_count
@@ -158,7 +158,7 @@ class Domain(object):
     @search_instance_count.setter
     def search_instance_count(self, value):
         self._search_instance_count = int(value)
-            
+
     @property
     def num_searchable_docs(self):
         return self._num_searchable_docs
@@ -166,7 +166,7 @@ class Domain(object):
     @num_searchable_docs.setter
     def num_searchable_docs(self, value):
         self._num_searchable_docs = int(value)
-            
+
     @property
     def name(self):
         return self.domain_name

--- a/boto/cloudsearch/layer1.py
+++ b/boto/cloudsearch/layer1.py
@@ -680,7 +680,7 @@ class Layer1(AWSQueryConnection):
                     'update_stemming_options_result',
                     'stems')
         params = {'DomainName': domain_name,
-                 'Stems': stems}
+                  'Stems': stems}
         return self.get_response(doc_path, 'UpdateStemmingOptions',
                                  params, verb='POST')
 

--- a/boto/cloudsearch/search.py
+++ b/boto/cloudsearch/search.py
@@ -286,19 +286,20 @@ class SearchConnection(object):
         params = query.to_params()
 
         r = requests.get(url, params=params)
+        body = r.content.decode('utf-8')
         try:
-            data = json.loads(r.content)
+            data = json.loads(body)
         except ValueError as e:
             if r.status_code == 403:
                 msg = ''
                 import re
-                g = re.search('<html><body><h1>403 Forbidden</h1>([^<]+)<', r.content)
+                g = re.search('<html><body><h1>403 Forbidden</h1>([^<]+)<', body)
                 try:
                     msg = ': %s' % (g.groups()[0].strip())
                 except AttributeError:
                     pass
                 raise SearchServiceException('Authentication error from Amazon%s' % msg)
-            raise SearchServiceException("Got non-json response from Amazon. %s" % r.content, query)
+            raise SearchServiceException("Got non-json response from Amazon. %s" % body, query)
 
         if 'messages' in data and 'error' in data:
             for m in data['messages']:

--- a/boto/cloudsearch/sourceattribute.py
+++ b/boto/cloudsearch/sourceattribute.py
@@ -72,4 +72,3 @@ class SourceAttribute(object):
             valid = '|'.join(self.ValidDataFunctions)
             raise ValueError('data_function must be one of: %s' % valid)
         self._data_function = value
-

--- a/tests/test.py
+++ b/tests/test.py
@@ -40,6 +40,7 @@ PY3_WHITELIST = (
     'tests/unit/beanstalk',
     'tests/unit/cloudformation',
     'tests/unit/cloudfront',
+    'tests/unit/cloudsearch',
     'tests/unit/cloudtrail',
     'tests/unit/directconnect',
     'tests/unit/ecs',

--- a/tests/unit/cloudsearch/test_connection.py
+++ b/tests/unit/cloudsearch/test_connection.py
@@ -5,13 +5,11 @@ from tests.unit import AWSMockServiceTestCase
 from boto.cloudsearch.domain import Domain
 from boto.cloudsearch.layer1 import Layer1
 
-import json
-
 class TestCloudSearchCreateDomain(AWSMockServiceTestCase):
     connection_class = Layer1
 
     def default_body(self):
-        return """
+        return b"""
 <CreateDomainResponse xmlns="http://cloudsearch.amazonaws.com/doc/2011-02-01">
   <CreateDomainResult>
     <DomainStatus>
@@ -115,7 +113,7 @@ class CloudSearchConnectionDeletionTest(AWSMockServiceTestCase):
     connection_class = Layer1
 
     def default_body(self):
-        return """
+        return b"""
 <DeleteDomainResponse xmlns="http://cloudsearch.amazonaws.com/doc/2011-02-01">
   <DeleteDomainResult>
     <DomainStatus>
@@ -163,7 +161,7 @@ class CloudSearchConnectionIndexDocumentTest(AWSMockServiceTestCase):
     connection_class = Layer1
 
     def default_body(self):
-        return """
+        return b"""
 <IndexDocumentsResponse xmlns="http://cloudsearch.amazonaws.com/doc/2011-02-01">
   <IndexDocumentsResult>
     <FieldNames>

--- a/tests/unit/cloudsearch/test_document.py
+++ b/tests/unit/cloudsearch/test_document.py
@@ -4,7 +4,6 @@ from tests.unit import unittest
 from httpretty import HTTPretty
 from mock import MagicMock
 
-import urlparse
 import json
 
 from boto.cloudsearch.document import DocumentServiceConnection
@@ -20,7 +19,7 @@ class CloudSearchDocumentTest(unittest.TestCase):
             HTTPretty.POST,
             ("http://doc-demo-userdomain.us-east-1.cloudsearch.amazonaws.com/"
              "2011-02-01/documents/batch"),
-            body=json.dumps(self.response),
+            body=json.dumps(self.response).encode('utf-8'),
             content_type="application/json")
 
     def tearDown(self):
@@ -45,7 +44,7 @@ class CloudSearchDocumentSingleTest(CloudSearchDocumentTest):
                                   "category": ["cat_a", "cat_b", "cat_c"]})
         document.commit()
 
-        args = json.loads(HTTPretty.last_request.body)[0]
+        args = json.loads(HTTPretty.last_request.body.decode('utf-8'))[0]
 
         self.assertEqual(args['lang'], 'en')
         self.assertEqual(args['type'], 'add')
@@ -61,7 +60,7 @@ class CloudSearchDocumentSingleTest(CloudSearchDocumentTest):
                                   "category": ["cat_a", "cat_b", "cat_c"]})
         document.commit()
 
-        args = json.loads(HTTPretty.last_request.body)[0]
+        args = json.loads(HTTPretty.last_request.body.decode('utf-8'))[0]
 
         self.assertEqual(args['id'], '1234')
         self.assertEqual(args['version'], 10)
@@ -77,7 +76,7 @@ class CloudSearchDocumentSingleTest(CloudSearchDocumentTest):
                                   "category": ["cat_a", "cat_b", "cat_c"]})
         document.commit()
 
-        args = json.loads(HTTPretty.last_request.body)[0]
+        args = json.loads(HTTPretty.last_request.body.decode('utf-8'))[0]
 
         self.assertEqual(args['fields']['category'], ['cat_a', 'cat_b',
                                                       'cat_c'])
@@ -133,7 +132,7 @@ class CloudSearchDocumentMultipleAddTest(CloudSearchDocumentTest):
             document.add(key, obj['version'], obj['fields'])
         document.commit()
 
-        args = json.loads(HTTPretty.last_request.body)
+        args = json.loads(HTTPretty.last_request.body.decode('utf-8'))
 
         for arg in args:
             self.assertTrue(arg['id'] in self.objs)
@@ -177,7 +176,7 @@ class CloudSearchDocumentDelete(CloudSearchDocumentTest):
             endpoint="doc-demo-userdomain.us-east-1.cloudsearch.amazonaws.com")
         document.delete("5", "10")
         document.commit()
-        args = json.loads(HTTPretty.last_request.body)[0]
+        args = json.loads(HTTPretty.last_request.body.decode('utf-8'))[0]
 
         self.assertEqual(args['version'], '10')
         self.assertEqual(args['type'], 'delete')
@@ -210,7 +209,7 @@ class CloudSearchDocumentDeleteMultiple(CloudSearchDocumentTest):
         document.delete("5", "10")
         document.delete("6", "11")
         document.commit()
-        args = json.loads(HTTPretty.last_request.body)
+        args = json.loads(HTTPretty.last_request.body.decode('utf-8'))
 
         self.assertEqual(len(args), 2)
         for arg in args:

--- a/tests/unit/cloudsearch/test_exceptions.py
+++ b/tests/unit/cloudsearch/test_exceptions.py
@@ -19,7 +19,7 @@ def fake_loads_json_error(content, *args, **kwargs):
 
 
 class CloudSearchJSONExceptionTest(CloudSearchSearchBaseTest):
-    response = '{}'
+    response = b'{}'
 
     def test_no_simplejson_value_error(self):
         with mock.patch.object(json, 'loads', fake_loads_value_error):

--- a/tests/unit/cloudsearch/test_search.py
+++ b/tests/unit/cloudsearch/test_search.py
@@ -3,7 +3,6 @@
 from tests.unit import unittest
 from httpretty import HTTPretty
 
-import urlparse
 import json
 import mock
 import requests
@@ -52,17 +51,17 @@ class CloudSearchSearchBaseTest(unittest.TestCase):
     response_status = 200
 
     def get_args(self, requestline):
-        (_, request, _) = requestline.split(" ")
-        (_, request) = request.split("?", 1)
-        args = urlparse.parse_qs(request)
+        (_, request, _) = requestline.split(b" ")
+        (_, request) = request.split(b"?", 1)
+        args = six.moves.urllib.parse.parse_qs(request)
         return args
 
     def setUp(self):
         HTTPretty.enable()
         body = self.response
 
-        if not isinstance(body, basestring):
-            body = json.dumps(body)
+        if not isinstance(body, bytes):
+            body = json.dumps(body).encode('utf-8')
 
         HTTPretty.register_uri(HTTPretty.GET, FULL_URL,
                                body=body,
@@ -75,14 +74,14 @@ class CloudSearchSearchBaseTest(unittest.TestCase):
 class CloudSearchSearchTest(CloudSearchSearchBaseTest):
     response = {
         'rank': '-text_relevance',
-        'match-expr':"Test",
+        'match-expr': "Test",
         'hits': {
             'found': 30,
             'start': 0,
-            'hit':CloudSearchSearchBaseTest.hits
+            'hit': CloudSearchSearchBaseTest.hits
             },
         'info': {
-            'rid':'b7c167f6c2da6d93531b9a7b314ad030b3a74803b4b7797edb905ba5a6a08',
+            'rid': 'b7c167f6c2da6d93531b9a7b314ad030b3a74803b4b7797edb905ba5a6a08',
             'time-ms': 2,
             'cpu-time-ms': 0
         }
@@ -96,9 +95,9 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['q'], ["Test"])
-        self.assertEqual(args['start'], ["0"])
-        self.assertEqual(args['size'], ["10"])
+        self.assertEqual(args[b'q'], [b"Test"])
+        self.assertEqual(args[b'start'], [b"0"])
+        self.assertEqual(args[b'size'], [b"10"])
 
     def test_cloudsearch_bqsearch(self):
         search = SearchConnection(endpoint=HOSTNAME)
@@ -107,7 +106,7 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['bq'], ["'Test'"])
+        self.assertEqual(args[b'bq'], [b"'Test'"])
 
     def test_cloudsearch_search_details(self):
         search = SearchConnection(endpoint=HOSTNAME)
@@ -116,9 +115,9 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['q'], ["Test"])
-        self.assertEqual(args['size'], ["50"])
-        self.assertEqual(args['start'], ["20"])
+        self.assertEqual(args[b'q'], [b"Test"])
+        self.assertEqual(args[b'size'], [b"50"])
+        self.assertEqual(args[b'start'], [b"20"])
 
     def test_cloudsearch_facet_single(self):
         search = SearchConnection(endpoint=HOSTNAME)
@@ -127,7 +126,7 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['facet'], ["Author"])
+        self.assertEqual(args[b'facet'], [b"Author"])
 
     def test_cloudsearch_facet_multiple(self):
         search = SearchConnection(endpoint=HOSTNAME)
@@ -136,7 +135,7 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['facet'], ["author,cat"])
+        self.assertEqual(args[b'facet'], [b"author,cat"])
 
     def test_cloudsearch_facet_constraint_single(self):
         search = SearchConnection(endpoint=HOSTNAME)
@@ -147,8 +146,8 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['facet-author-constraints'],
-                         ["'John Smith','Mark Smith'"])
+        self.assertEqual(args[b'facet-author-constraints'],
+                         [b"'John Smith','Mark Smith'"])
 
     def test_cloudsearch_facet_constraint_multiple(self):
         search = SearchConnection(endpoint=HOSTNAME)
@@ -160,10 +159,10 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['facet-author-constraints'],
-                         ["'John Smith','Mark Smith'"])
-        self.assertEqual(args['facet-category-constraints'],
-                         ["'News','Reviews'"])
+        self.assertEqual(args[b'facet-author-constraints'],
+                         [b"'John Smith','Mark Smith'"])
+        self.assertEqual(args[b'facet-category-constraints'],
+                         [b"'News','Reviews'"])
 
     def test_cloudsearch_facet_sort_single(self):
         search = SearchConnection(endpoint=HOSTNAME)
@@ -172,7 +171,7 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['facet-author-sort'], ['alpha'])
+        self.assertEqual(args[b'facet-author-sort'], [b'alpha'])
 
     def test_cloudsearch_facet_sort_multiple(self):
         search = SearchConnection(endpoint=HOSTNAME)
@@ -182,8 +181,8 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['facet-author-sort'], ['alpha'])
-        self.assertEqual(args['facet-cat-sort'], ['count'])
+        self.assertEqual(args[b'facet-author-sort'], [b'alpha'])
+        self.assertEqual(args[b'facet-cat-sort'], [b'count'])
 
     def test_cloudsearch_top_n_single(self):
         search = SearchConnection(endpoint=HOSTNAME)
@@ -192,7 +191,7 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['facet-author-top-n'], ['5'])
+        self.assertEqual(args[b'facet-author-top-n'], [b'5'])
 
     def test_cloudsearch_top_n_multiple(self):
         search = SearchConnection(endpoint=HOSTNAME)
@@ -201,8 +200,8 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['facet-author-top-n'], ['5'])
-        self.assertEqual(args['facet-cat-top-n'], ['10'])
+        self.assertEqual(args[b'facet-author-top-n'], [b'5'])
+        self.assertEqual(args[b'facet-cat-top-n'], [b'10'])
 
     def test_cloudsearch_rank_single(self):
         search = SearchConnection(endpoint=HOSTNAME)
@@ -211,7 +210,7 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['rank'], ['date'])
+        self.assertEqual(args[b'rank'], [b'date'])
 
     def test_cloudsearch_rank_multiple(self):
         search = SearchConnection(endpoint=HOSTNAME)
@@ -220,7 +219,7 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['rank'], ['date,score'])
+        self.assertEqual(args[b'rank'], [b'date,score'])
 
     def test_cloudsearch_result_fields_single(self):
         search = SearchConnection(endpoint=HOSTNAME)
@@ -229,7 +228,7 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['return-fields'], ['author'])
+        self.assertEqual(args[b'return-fields'], [b'author'])
 
     def test_cloudsearch_result_fields_multiple(self):
         search = SearchConnection(endpoint=HOSTNAME)
@@ -238,28 +237,26 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['return-fields'], ['author,title'])
-
+        self.assertEqual(args[b'return-fields'], [b'author,title'])
 
     def test_cloudsearch_t_field_single(self):
         search = SearchConnection(endpoint=HOSTNAME)
 
-        search.search(q='Test', t={'year':'2001..2007'})
+        search.search(q='Test', t={'year': '2001..2007'})
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['t-year'], ['2001..2007'])
+        self.assertEqual(args[b't-year'], [b'2001..2007'])
 
     def test_cloudsearch_t_field_multiple(self):
         search = SearchConnection(endpoint=HOSTNAME)
 
-        search.search(q='Test', t={'year':'2001..2007', 'score':'10..50'})
+        search.search(q='Test', t={'year': '2001..2007', 'score': '10..50'})
 
         args = self.get_args(HTTPretty.last_request.raw_requestline)
 
-        self.assertEqual(args['t-year'], ['2001..2007'])
-        self.assertEqual(args['t-score'], ['10..50'])
-
+        self.assertEqual(args[b't-year'], [b'2001..2007'])
+        self.assertEqual(args[b't-score'], [b'10..50'])
 
     def test_cloudsearch_results_meta(self):
         """Check returned metadata is parsed correctly"""
@@ -340,20 +337,20 @@ class CloudSearchSearchTest(CloudSearchSearchBaseTest):
 class CloudSearchSearchFacetTest(CloudSearchSearchBaseTest):
     response = {
         'rank': '-text_relevance',
-        'match-expr':"Test",
+        'match-expr': "Test",
         'hits': {
             'found': 30,
             'start': 0,
-            'hit':CloudSearchSearchBaseTest.hits
+            'hit': CloudSearchSearchBaseTest.hits
             },
         'info': {
-            'rid':'b7c167f6c2da6d93531b9a7b314ad030b3a74803b4b7797edb905ba5a6a08',
+            'rid': 'b7c167f6c2da6d93531b9a7b314ad030b3a74803b4b7797edb905ba5a6a08',
             'time-ms': 2,
             'cpu-time-ms': 0
         },
         'facets': {
             'tags': {},
-            'animals': {'constraints': [{'count': '2', 'value': 'fish'}, {'count': '1', 'value':'lions'}]},
+            'animals': {'constraints': [{'count': '2', 'value': 'fish'}, {'count': '1', 'value': 'lions'}]},
         }
     }
 
@@ -369,7 +366,7 @@ class CloudSearchSearchFacetTest(CloudSearchSearchBaseTest):
 
 
 class CloudSearchNonJsonTest(CloudSearchSearchBaseTest):
-    response = '<html><body><h1>500 Internal Server Error</h1></body></html>'
+    response = b'<html><body><h1>500 Internal Server Error</h1></body></html>'
     response_status = 500
     content_type = 'text/xml'
 
@@ -381,7 +378,7 @@ class CloudSearchNonJsonTest(CloudSearchSearchBaseTest):
 
 
 class CloudSearchUnauthorizedTest(CloudSearchSearchBaseTest):
-    response = '<html><body><h1>403 Forbidden</h1>foo bar baz</body></html>'
+    response = b'<html><body><h1>403 Forbidden</h1>foo bar baz</body></html>'
     response_status = 403
     content_type = 'text/html'
 
@@ -394,7 +391,7 @@ class CloudSearchUnauthorizedTest(CloudSearchSearchBaseTest):
 
 class FakeResponse(object):
     status_code = 405
-    content = ''
+    content = b''
 
 
 class CloudSearchConnectionTest(unittest.TestCase):
@@ -409,7 +406,7 @@ class CloudSearchConnectionTest(unittest.TestCase):
     def test_expose_additional_error_info(self):
         mpo = mock.patch.object
         fake = FakeResponse()
-        fake.content = 'Nopenopenope'
+        fake.content = b'Nopenopenope'
 
         # First, in the case of a non-JSON, non-403 error.
         with mpo(requests, 'get', return_value=fake) as mock_request:
@@ -422,7 +419,7 @@ class CloudSearchConnectionTest(unittest.TestCase):
         # Then with JSON & an 'error' key within.
         fake.content = json.dumps({
             'error': "Something went wrong. Oops."
-        })
+        }).encode('utf-8')
 
         with mpo(requests, 'get', return_value=fake) as mock_request:
             with self.assertRaises(SearchServiceException) as cm:


### PR DESCRIPTION
Unit tests passed.

Integration tests return a 401 Unauthorized error here for current develop branch already, and my port get the same errors across all support python versions.

I didn't mark the module as (Python 3) on docs because the cloudsearch2 module is not ported yet :)
