### PR TITLE
Singapore, Sydney and Tokyo are missing in Kinesis Region

### DIFF
--- a/boto/endpoints.json
+++ b/boto/endpoints.json
@@ -190,7 +190,10 @@
     "kinesis": {
         "us-east-1": "kinesis.us-east-1.amazonaws.com",
         "us-west-2": "kinesis.us-west-2.amazonaws.com",
-        "eu-west-1": "kinesis.eu-west-1.amazonaws.com"
+        "eu-west-1": "kinesis.eu-west-1.amazonaws.com",
+        "ap-southeast-1": "kinesis.ap-southeast-1.amazonaws.com",
+        "ap-southeast-2": "kinesis.ap-southeast-2.amazonaws.com",
+        "ap-northeast-1": "kinesis.ap-northeast-1.amazonaws.com"
     },
     "logs": {
         "us-east-1": "logs.us-east-1.amazonaws.com"


### PR DESCRIPTION
Kinesis  has now been rollout to Asia pacific regions.
http://docs.aws.amazon.com/general/latest/gr/rande.html#ak_region

Can we update the endpoints config ASAP ?

Cheers.
