### PR TITLE
update .travis.yml to add pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "pypy"
 before_install:
   - sudo apt-get update
   - sudo apt-get --reinstall install -qq language-pack-en language-pack-de


### PR DESCRIPTION
All current unit tests are already passing on pypy.

I know it may be something big to decide to support one more python variant, but I really think it worth adding as a test target. If there are pypy-specific problems in the future, I will be glad to help.
