### PR TITLE
Fix S3 mock encoding bug

### DIFF
--- a/tests/integration/s3/mock_storage_service.py
+++ b/tests/integration/s3/mock_storage_service.py
@@ -196,7 +196,10 @@ class MockKey(object):
         contents of mock key.
         """
         m = md5()
-        m.update(self.data.encode('utf-8'))
+        if not isinstance(self.data, bytes):
+            m.update(self.data.encode('utf-8'))
+        else:
+            m.update(self.data)
         hex_md5 = m.hexdigest()
         self.etag = hex_md5
 

--- a/tests/unit/s3/test_keyfile.py
+++ b/tests/unit/s3/test_keyfile.py
@@ -99,3 +99,16 @@ class KeyfileTest(unittest.TestCase):
         self.keyfile.seek(1, os.SEEK_CUR)
         self.assertEqual(self.keyfile.tell(), 2)
         self.assertEqual(self.keyfile.read(4), self.contents[2:6])
+
+    def testSetEtag(self):
+        # Make sure both bytes and strings work as contents. This is one of the
+        # very few places Boto uses the mock key object.
+        # https://github.com/GoogleCloudPlatform/gsutil/issues/214#issuecomment-49906044
+        self.keyfile.key.data = b'test'
+        self.keyfile.key.set_etag()
+        self.assertEqual(self.keyfile.key.etag, '098f6bcd4621d373cade4e832627b4f6')
+
+        self.keyfile.key.etag = None
+        self.keyfile.key.data = 'test'
+        self.keyfile.key.set_etag()
+        self.assertEqual(self.keyfile.key.etag, '098f6bcd4621d373cade4e832627b4f6')


### PR DESCRIPTION
This fixes a bug in our test mock S3 service as reported in https://github.com/GoogleCloudPlatform/gsutil/issues/214 (part of #2437) where we were attempting incorrectly to encode a `bytes` object.

It also adds a new unit test to ensure the new behavior works for both bytes and strings in all supported Python versions. It seems like our `KeyFile` tests are the only place these mocks are used within Boto, so I've added a quick test there that should prevent regressions in the future.

@jamesls, @mfschwartz please take a look.
