### PR TITLE
logs module: enable unit tests in python 3

### DIFF
--- a/boto/logs/layer1.py
+++ b/boto/logs/layer1.py
@@ -20,16 +20,12 @@
 # IN THE SOFTWARE.
 #
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
 import boto
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.logs import exceptions
+from boto.compat import json
 
 
 class CloudWatchLogsConnection(AWSQueryConnection):
@@ -579,4 +575,3 @@ class CloudWatchLogsConnection(AWSQueryConnection):
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)
-

--- a/tests/test.py
+++ b/tests/test.py
@@ -50,6 +50,7 @@ PY3_WHITELIST = (
     'tests/unit/glacier',
     'tests/unit/iam',
     'tests/unit/ec2',
+    'tests/unit/logs',
     'tests/unit/manage',
     'tests/unit/mws',
     'tests/unit/provider',

--- a/tests/unit/logs/test_layer1.py
+++ b/tests/unit/logs/test_layer1.py
@@ -13,7 +13,7 @@ class TestDescribeLogs(AWSMockServiceTestCase):
     def test_describe(self):
         self.set_http_response(status_code=200)
         api_response = self.service_connection.describe_log_groups()
-        
+
         self.assertEqual(0, len(api_response['logGroups']))
 
         self.assert_request_parameters({})


### PR DESCRIPTION
The module is already marked as Python 3 compatible, but the unit tests were not enabled for python 3. This PR fixed it, with one minor improvement for json import.
