### PR TITLE
alarm.py - Fixed typo

### DIFF
--- a/boto/ec2/cloudwatch/alarm.py
+++ b/boto/ec2/cloudwatch/alarm.py
@@ -91,7 +91,7 @@ class MetricAlarm(object):
                           is compared.
 
         :type period: int
-        :param period: The period in seconds over which teh specified
+        :param period: The period in seconds over which the specified
                        statistic is applied.
 
         :type evaluation_periods: int


### PR DESCRIPTION
A minor typo I noticed when working with the library.
