### PR TITLE
import json from boto.compat for several modules

### DIFF
--- a/boto/cloudtrail/layer1.py
+++ b/boto/cloudtrail/layer1.py
@@ -20,16 +20,12 @@
 # IN THE SOFTWARE.
 #
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
 import boto
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.cloudtrail import exceptions
+from boto.compat import json
 
 
 class CloudTrailConnection(AWSQueryConnection):

--- a/boto/kinesis/layer1.py
+++ b/boto/kinesis/layer1.py
@@ -20,11 +20,6 @@
 # IN THE SOFTWARE.
 #
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
 import base64
 import boto
 
@@ -32,6 +27,7 @@ from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.kinesis import exceptions
+from boto.compat import json
 
 
 class KinesisConnection(AWSQueryConnection):

--- a/boto/rds2/layer1.py
+++ b/boto/rds2/layer1.py
@@ -20,16 +20,12 @@
 # IN THE SOFTWARE.
 #
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
 import boto
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.rds2 import exceptions
+from boto.compat import json
 
 
 class RDSConnection(AWSQueryConnection):


### PR DESCRIPTION
This is a fairly small PR. While boto.compat is the preferred way to import json, several modules (including some that are already ported) still using the try-except block. This PR just fixes these.
