### PR TITLE
Fix parsing of EMR step summary response.

### DIFF
--- a/boto/emr/emrobject.py
+++ b/boto/emr/emrobject.py
@@ -301,7 +301,7 @@ class ClusterSummaryList(EmrObject):
 
 class StepConfig(EmrObject):
     Fields = set([
-        'Jar'
+        'Jar',
         'MainClass'
     ])
 

--- a/tests/unit/emr/test_connection.py
+++ b/tests/unit/emr/test_connection.py
@@ -468,8 +468,20 @@ class TestListSteps(AWSMockServiceTestCase):
             'INTERRUPTED'
         ]
 
+        # Check for step states
         for step in response.steps:
             self.assertIn(step.status.state, valid_states)
+
+        # Check for step config
+        step = response.steps[0]
+        self.assertEqual(step.config.jar,
+            '/home/hadoop/lib/emr-s3distcp-1.0.jar')
+        self.assertEqual(len(step.config.args), 4)
+        self.assertEqual(step.config.args[0].value, '--src')
+        self.assertEqual(step.config.args[1].value, 'hdfs:///data/test/')
+
+        step = response.steps[1]
+        self.assertEqual(step.config.mainclass, 'my.main.SomeClass')
 
     def test_list_steps_with_states(self):
         self.set_http_response(200)


### PR DESCRIPTION
EMR step summaries can now contain a `<Config>` section that includes a list
of arguments. The argument list contains items wrapped in `<member>` and this
gets picked up by the step list parser to incorrectly create blank EMR step
objects. The fix is to parse the config and arguments so that they don't
bubble up to incorrectly become new step objects.

cc: @jamesls
