### PR TITLE
Add pypy to tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34
+envlist = py26,py27,py33,py34,pypy
 
 # Comment to build sdist and install into virtualenv
 # This is helpful to test installation but takes extra time
@@ -20,6 +20,11 @@ setenv =
     PYTHONHASHSEED = 0
 
 [testenv:py27]
+# See comment above in py26 about hash seed.
+setenv =
+    PYTHONHASHSEED = 0
+
+[testenv:pypy]
 # See comment above in py26 about hash seed.
 setenv =
     PYTHONHASHSEED = 0


### PR DESCRIPTION
While we don't officially support pypy we updated the Travis config in #2440 to run our tests through it since they already pass. This updates the tox config to do the same with your local dev machine.

@cc jamesls
