### PR TITLE
Prevent an infinite loop.

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -191,8 +191,9 @@ class Key(object):
         if self._storage_class is None and self.bucket:
             # Attempt to fetch storage class
             list_items = list(self.bucket.list(self.name.encode('utf-8')))
-            if len(list_items):
-                self._storage_class = list_items[0].storage_class
+            if len(list_items) and getattr(list_items[0], '_storage_class',
+                                           None):
+                self._storage_class = list_items[0]._storage_class
             else:
                 # Key is not yet saved? Just use default...
                 self._storage_class = 'STANDARD'


### PR DESCRIPTION
Fixes the issue observed in the Google Storage integration tests
from #2462. The problem was introduced in f3e5d11. This only uses
the internal cached value instead of potentially triggering infinite
list bucket calls.

This also makes sure that the Google Storage behavior remains
backward compatible.

cc @jamesls, @kyleknap
