### PR TITLE
remove obsolete md5 import routine

### DIFF
--- a/boto/gs/resumable_upload_handler.py
+++ b/boto/gs/resumable_upload_handler.py
@@ -26,16 +26,13 @@ import re
 import socket
 import time
 import urlparse
+from hashlib import md5
 from boto import config, UserAgent
 from boto.connection import AWSAuthConnection
 from boto.exception import InvalidUriError
 from boto.exception import ResumableTransferDisposition
 from boto.exception import ResumableUploadException
 from boto.s3.keyfile import KeyFile
-try:
-    from hashlib import md5
-except ImportError:
-    from md5 import md5
 
 """
 Handler for Google Cloud Storage resumable uploads. See

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -31,6 +31,7 @@ import re
 import base64
 import binascii
 import math
+from hashlib import md5
 import boto.utils
 from boto.compat import BytesIO, six, urllib
 
@@ -44,11 +45,6 @@ from boto import UserAgent
 from boto.utils import compute_md5, compute_hash
 from boto.utils import find_matching_headers
 from boto.utils import merge_headers_by_name
-
-try:
-    from hashlib import md5
-except ImportError:
-    from md5 import md5
 
 
 class Key(object):

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -64,18 +64,8 @@ from boto.compat import six, StringIO, urllib
 
 from contextlib import contextmanager
 
-try:
-    from hashlib import md5
-except ImportError:
-    from md5 import md5
-
-
-try:
-    import hashlib
-    _hashfn = hashlib.sha512
-except ImportError:
-    import md5
-    _hashfn = md5.md5
+from hashlib import md5, sha512
+_hashfn = sha512
 
 from boto.compat import json
 

--- a/tests/integration/s3/mock_storage_service.py
+++ b/tests/integration/s3/mock_storage_service.py
@@ -30,17 +30,13 @@ import copy
 import boto
 import base64
 import re
+from hashlib import md5
 
 from boto.utils import compute_md5
 from boto.utils import find_matching_headers
 from boto.utils import merge_headers_by_name
 from boto.s3.prefix import Prefix
 from boto.compat import six
-
-try:
-    from hashlib import md5
-except ImportError:
-    from md5 import md5
 
 NOT_IMPL = None
 


### PR DESCRIPTION
The old md5 module was deprecated since Python 2.5, and we even didn't
support that version already. The current implementation in
boto/utils.py will not even work under Python 2.4 because of the name
"md5" imported from md5 module was replaced by the md5 module in the
following routine, which will cause errors.

This PR just replaced the routine with a simple import from `hashlib`, which will work flawlessly in Python 2.5+ and 3.*.
