### PR TITLE
Fixed api response of attach_volume and detach_volume methods according to aws api docs.

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -2352,15 +2352,17 @@ class EC2Connection(AWSQueryConnection):
         :type dry_run: bool
         :param dry_run: Set to True if the operation should not actually run.
 
-        :rtype: bool
-        :return: True if successful
+        :rtype: AttachmentSet
+        :return: Attribute status of returned object will be 'attached'
+        in case of success
         """
         params = {'InstanceId': instance_id,
                   'VolumeId': volume_id,
                   'Device': device}
         if dry_run:
             params['DryRun'] = 'true'
-        return self.get_status('AttachVolume', params, verb='POST')
+        return self.get_object('AttachVolume', params, AttachmentSet,
+                               verb = 'POST')
 
     def detach_volume(self, volume_id, instance_id=None,
                       device=None, force=False, dry_run=False):
@@ -2391,8 +2393,9 @@ class EC2Connection(AWSQueryConnection):
         :type dry_run: bool
         :param dry_run: Set to True if the operation should not actually run.
 
-        :rtype: bool
-        :return: True if successful
+        :rtype: AttachmentSet
+        :return: Attribute status of returned object will be 'detached'
+        in case of success
         """
         params = {'VolumeId': volume_id}
         if instance_id:
@@ -2403,7 +2406,8 @@ class EC2Connection(AWSQueryConnection):
             params['Force'] = 'true'
         if dry_run:
             params['DryRun'] = 'true'
-        return self.get_status('DetachVolume', params, verb='POST')
+        return self.get_object('DetachVolume', params, AttachmentSet,
+                                   verb = 'POST')
 
     # Snapshot methods
 


### PR DESCRIPTION
Fixed api response of ec2 attach_volume and detach_volume methods according to aws api docs.
http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-AttachVolume.html
http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DetachVolume.html
