### PR TITLE
Fix VPCPeeringConnection 'delete()' to call 'delete_vpc_peering_connection()'.

### DIFF
--- a/boto/vpc/vpc_peering_connection.py
+++ b/boto/vpc/vpc_peering_connection.py
@@ -145,7 +145,7 @@ class VpcPeeringConnection(TaggedEC2Object):
             setattr(self, name, value)
 
     def delete(self):
-        return self.connection.delete_vpc(self.id)
+        return self.connection.delete_vpc_peering_connection(self.id)
 
     def _update(self, updated):
         self.__dict__.update(updated.__dict__)

--- a/tests/unit/vpc/test_vpc_peering_connection.py
+++ b/tests/unit/vpc/test_vpc_peering_connection.py
@@ -19,7 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-from tests.unit import unittest
+from tests.unit import mock, unittest
 from tests.unit import AWSMockServiceTestCase
 
 from boto.vpc import VpcPeeringConnection, VPCConnection, Subnet
@@ -158,6 +158,58 @@ class TestDeleteVpcPeeringConnection(AWSMockServiceTestCase):
     def test_delete_vpc_peering_connection(self):
         self.set_http_response(status_code=200)
         self.assertEquals(self.service_connection.delete_vpc_peering_connection('pcx-12345678'), True)
+
+class TestDeleteVpcPeeringConnectionShortForm(unittest.TestCase):
+    DESCRIBE_VPC_PEERING_CONNECTIONS= b"""<?xml version="1.0" encoding="UTF-8"?>
+<DescribeVpcPeeringConnectionsResponse xmlns="http://ec2.amazonaws.com/doc/2014-05-01/">
+   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
+   <vpcPeeringConnectionSet>
+      <item>
+         <vpcPeeringConnectionId>pcx-111aaa22</vpcPeeringConnectionId>
+         <requesterVpcInfo>
+            <ownerId>777788889999</ownerId>
+            <vpcId>vpc-1a2b3c4d</vpcId>
+            <cidrBlock>172.31.0.0/16</cidrBlock>
+         </requesterVpcInfo>
+         <accepterVpcInfo>
+            <ownerId>111122223333</ownerId>
+            <vpcId>vpc-aa22cc33</vpcId>
+         </accepterVpcInfo>
+         <status>
+            <code>pending-acceptance</code>
+            <message>Pending Acceptance by 111122223333</message>
+         </status>
+         <expirationTime>2014-02-17T16:00:50.000Z</expirationTime>
+      </item>
+   </vpcPeeringConnectionSet>
+</DescribeVpcPeeringConnectionsResponse>"""
+
+    DELETE_VPC_PEERING_CONNECTION= b"""<DeleteVpcPeeringConnectionResponse xmlns="http://ec2.amazonaws.com/doc/2014-05-01/">
+  <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
+  <return>true</return>
+</DeleteVpcPeeringConnectionResponse>"""
+
+    def test_delete_vpc_peering_connection(self):
+        vpc_conn = VPCConnection(aws_access_key_id='aws_access_key_id',
+                                 aws_secret_access_key='aws_secret_access_key')
+
+        mock_response = mock.Mock()
+        mock_response.read.return_value = self.DESCRIBE_VPC_PEERING_CONNECTIONS
+        mock_response.status = 200
+        vpc_conn.make_request = mock.Mock(return_value=mock_response)
+        vpc_peering_connections = vpc_conn.get_all_vpc_peering_connections()
+
+        self.assertEquals(1, len(vpc_peering_connections))
+        vpc_peering_connection = vpc_peering_connections[0]
+
+        mock_response = mock.Mock()
+        mock_response.read.return_value = self.DELETE_VPC_PEERING_CONNECTION
+        mock_response.status = 200
+        vpc_conn.make_request = mock.Mock(return_value=mock_response)
+        self.assertEquals(True, vpc_peering_connection.delete())
+
+        self.assertIn('DeleteVpcPeeringConnection', vpc_conn.make_request.call_args_list[0][0])
+        self.assertNotIn('DeleteVpc', vpc_conn.make_request.call_args_list[0][0])
 
 class TestRejectVpcPeeringConnection(AWSMockServiceTestCase):
     REJECT_VPC_PEERING_CONNECTION= b"""<RejectVpcPeeringConnectionResponse xmlns="http://ec2.amazonaws.com/doc/2014-05-01/">


### PR DESCRIPTION
This resolves #2474 by replacing "self.connection.delete_vpc(self.id)" with "self.connection.delete_vpc_peering_connection(self.id)" in VpcPeeringConnection's delete() method, along with updated unit test which inspects the call argument list to confirm.
