### PR TITLE
Update wheel to be universal for py2/py3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-python-tag = py2
+universal = 1


### PR DESCRIPTION
Right now the wheel is marked as Python 2 only on the downloads listed at https://pypi.python.org/pypi/boto.

This change matches the way we do it for [Botocore](https://github.com/boto/botocore/blob/develop/setup.cfg)

cc @jamesls, @kyleknap
