### PR TITLE
Fix AttributeError: 'Provider' object has no attribute 'encode'

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -99,7 +99,7 @@ class HmacKeys(object):
 
     def __setstate__(self, dct):
         self.__dict__ = dct
-        self.update_provider(self._provider.encode('utf-8'))
+        self.update_provider(self._provider)
 
 
 class AnonAuthHandler(AuthHandler, HmacKeys):


### PR DESCRIPTION
Release 2.32.0 introduces this error - several updates in 
https://github.com/boto/boto/commit/614e844408c27cbdeebc1325030820e1ce78aaf0 
to encode self._provider.secret_key, but one that erroneously attempts to encode self._provider itself.

This raises the error:
  File "/usr/local/lib/python2.7/dist-packages/boto/auth.py", line 102, in **setstate**
    self.update_provider(self._provider.encode('utf-8'))
AttributeError: 'Provider' object has no attribute 'encode'
