### PR TITLE
Fix dynamodb.types.Binary non-ASCII handling

### DIFF
--- a/boto/dynamodb/types.py
+++ b/boto/dynamodb/types.py
@@ -148,10 +148,10 @@ def dynamize_value(val):
 if six.PY2:
     class Binary(object):
         def __init__(self, value):
-            if isinstance(value, six.text_type):  # Support only PY2 for backward compatibility.
-                value = value.encode('utf-8')
-            elif not isinstance(value, bytes):
+            if not isinstance(value, (bytes, six.text_type)):
                 raise TypeError('Value must be a string of binary data!')
+            if not isinstance(value, bytes):
+                value = value.encode("utf-8")
 
             self.value = value
 
@@ -171,7 +171,7 @@ if six.PY2:
             return 'Binary(%r)' % self.value
 
         def __str__(self):
-            return self.value.decode('utf-8')
+            return self.value
 
         def __hash__(self):
             return hash(self.value)

--- a/tests/unit/dynamodb/test_types.py
+++ b/tests/unit/dynamodb/test_types.py
@@ -86,6 +86,12 @@ class TestBinary(unittest.TestCase):
         self.assertEqual(b'\x01', data)
         self.assertEqual(b'\x01', bytes(data))
 
+    def test_non_ascii_good_input(self):
+        # Binary data that is out of ASCII range
+        data = types.Binary(b'\x88')
+        self.assertEqual(b'\x88', data)
+        self.assertEqual(b'\x88', bytes(data))
+
     @unittest.skipUnless(six.PY2, "Python 2 only")
     def test_bad_input(self):
         with self.assertRaises(TypeError):
@@ -107,6 +113,9 @@ class TestBinary(unittest.TestCase):
         # Delegate to built-in b'\x01' == u'\x01'
         # In Python 2.x these are considered equal
         self.assertEqual(data, u'\x01')
+
+        # Check that the value field is of type bytes
+        self.assertEqual(type(data.value), bytes)
 
     @unittest.skipUnless(six.PY3, "Python 3 only")
     def test_unicode_py3(self):


### PR DESCRIPTION
Make dynamodb.types.Binary use a raw string as the internal representation, instead of trying to UTF-8 encode and decode binary data. Fixes #2491
