### PR TITLE
Added mock to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ httpretty>=0.7.0
 paramiko>=1.10.0
 PyYAML>=3.10
 coverage==3.7.1
+mock==1.0.1


### PR DESCRIPTION
Missing mock requirement fails the unit tests...

(venv)[kz9676@hp15 tests]$ python test.py unit
nose command: test.py -a !notdefault unit
# E
## ERROR: Failure: ImportError (No module named mock)

Traceback (most recent call last):
  File "/home/kz9676/Builds/kz9676/boto/venv/lib/python2.7/site-packages/nose/loader.py", line 414, in loadTestsFromName
    addr.filename, addr.module)
  File "/home/kz9676/Builds/kz9676/boto/venv/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/home/kz9676/Builds/kz9676/boto/venv/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/kz9676/Builds/kz9676/boto/tests/unit/**init**.py", line 2, in <module>
    from tests.compat import mock, unittest
  File "/home/kz9676/Builds/kz9676/boto/tests/compat.py", line 38, in <module>
    import mock
ImportError: No module named mock

---

Ran 1 test in 0.001s

FAILED (errors=1)
