### PR TITLE
Use ConfigParser for Python 3 and SafeConfigParser for Python 2 (#2497)

### DIFF
--- a/bin/launch_instance
+++ b/bin/launch_instance
@@ -33,7 +33,7 @@ f.close()
 import boto.pyami.config
 import boto.utils
 import re, os
-import ConfigParser
+from boto.compat import ConfigParser
 
 class Config(boto.pyami.config.Config):
     """A special config class that also adds import abilities
@@ -43,7 +43,7 @@ class Config(boto.pyami.config.Config):
     """
 
     def __init__(self):
-        ConfigParser.SafeConfigParser.__init__(self, {'working_dir' : '/mnt/pyami', 'debug' : '0'})
+        ConfigParser.__init__(self, {'working_dir' : '/mnt/pyami', 'debug' : '0'})
 
     def add_config(self, file_url):
         """Add a config file to this configuration

--- a/boto/compat.py
+++ b/boto/compat.py
@@ -52,7 +52,6 @@ from boto.vendored.six import BytesIO, StringIO
 from boto.vendored.six.moves import filter, http_client, map, _thread, \
                                     urllib, zip
 from boto.vendored.six.moves.queue import Queue
-from boto.vendored.six.moves.configparser import SafeConfigParser
 from boto.vendored.six.moves.urllib.parse import parse_qs, quote, unquote, \
                                                  urlparse, urlsplit
 from boto.vendored.six.moves.urllib.request import urlopen
@@ -61,6 +60,8 @@ if six.PY3:
     # StandardError was removed, so use the base exception type instead
     StandardError = Exception
     long_type = int
+    from configparser import ConfigParser
 else:
     StandardError = StandardError
     long_type = long
+    from ConfigParser import SafeConfigParser as ConfigParser

--- a/boto/pyami/config.py
+++ b/boto/pyami/config.py
@@ -26,7 +26,7 @@ import warnings
 
 import boto
 
-from boto.compat import expanduser, SafeConfigParser, StringIO
+from boto.compat import expanduser, ConfigParser, StringIO
 
 
 # By default we use two locations for the boto configurations,
@@ -49,12 +49,12 @@ elif 'BOTO_PATH' in os.environ:
         BotoConfigLocations.append(expanduser(path))
 
 
-class Config(SafeConfigParser):
+class Config(ConfigParser):
 
     def __init__(self, path=None, fp=None, do_load=True):
         # We don't use ``super`` here, because ``ConfigParser`` still uses
         # old-style classes.
-        SafeConfigParser.__init__(self, {'working_dir': '/mnt/pyami',
+        ConfigParser.__init__(self, {'working_dir': '/mnt/pyami',
                                          'debug': '0'})
         if do_load:
             if path:
@@ -95,7 +95,7 @@ class Config(SafeConfigParser):
         Replace any previous value.  If the path doesn't exist, create it.
         Also add the option the the in-memory config.
         """
-        config = SafeConfigParser()
+        config = ConfigParser()
         config.read(path)
         if not config.has_section(section):
             config.add_section(section)
@@ -139,21 +139,21 @@ class Config(SafeConfigParser):
 
     def get(self, section, name, default=None):
         try:
-            val = SafeConfigParser.get(self, section, name)
+            val = ConfigParser.get(self, section, name)
         except:
             val = default
         return val
 
     def getint(self, section, name, default=0):
         try:
-            val = SafeConfigParser.getint(self, section, name)
+            val = ConfigParser.getint(self, section, name)
         except:
             val = int(default)
         return val
 
     def getfloat(self, section, name, default=0.0):
         try:
-            val = SafeConfigParser.getfloat(self, section, name)
+            val = ConfigParser.getfloat(self, section, name)
         except:
             val = float(default)
         return val

--- a/boto/pyami/installers/ubuntu/mysql.py
+++ b/boto/pyami/installers/ubuntu/mysql.py
@@ -31,7 +31,7 @@ from boto.pyami.installers.ubuntu.installer import Installer
 import os
 import boto
 from boto.utils import ShellCommand
-from ConfigParser import SafeConfigParser
+from boto.compat import ConfigParser
 import time
 
 ConfigSection = """
@@ -89,7 +89,7 @@ class MySQL(Installer):
             self.start('mysql')
         else:
             #get the password ubuntu expects to use:
-            config_parser = SafeConfigParser()
+            config_parser = ConfigParser()
             config_parser.read('/etc/mysql/debian.cnf')
             password = config_parser.get('client', 'password')
             # start the mysql deamon, then mysql with the required grant statement piped into it:


### PR DESCRIPTION
SafeConfigParser was already imported through boto.compat module, but six just provided import compatibility. We actually need to use the ConfigParser class instead to get rid of the warning (http://hg.python.org/cpython/file/a64806257119/Lib/configparser.py#l1177).
