### PR TITLE
VPCPeeringConnection: Added support for create_route / replace_route.

### DIFF
--- a/boto/vpc/__init__.py
+++ b/boto/vpc/__init__.py
@@ -390,6 +390,7 @@ class VPCConnection(EC2Connection):
 
     def create_route(self, route_table_id, destination_cidr_block,
                      gateway_id=None, instance_id=None, interface_id=None,
+                     vpc_peering_connection_id=None,
                      dry_run=False):
         """
         Creates a new route in the route table within a VPC. The route's target
@@ -412,6 +413,10 @@ class VPCConnection(EC2Connection):
         :type interface_id: str
         :param interface_id: Allows routing to network interface attachments.
 
+        :type vpc_peering_connection_id: str
+        :param vpc_peering_connection_id: Allows routing to VPC peering
+                                          connection.
+
         :type dry_run: bool
         :param dry_run: Set to True if the operation should not actually run.
 
@@ -429,6 +434,8 @@ class VPCConnection(EC2Connection):
             params['InstanceId'] = instance_id
         elif interface_id is not None:
             params['NetworkInterfaceId'] = interface_id
+        elif vpc_peering_connection_id is not None:
+            params['VpcPeeringConnectionId'] = vpc_peering_connection_id
         if dry_run:
             params['DryRun'] = 'true'
 
@@ -436,6 +443,7 @@ class VPCConnection(EC2Connection):
 
     def replace_route(self, route_table_id, destination_cidr_block,
                       gateway_id=None, instance_id=None, interface_id=None,
+                      vpc_peering_connection_id=None,
                       dry_run=False):
         """
         Replaces an existing route within a route table in a VPC.
@@ -456,6 +464,10 @@ class VPCConnection(EC2Connection):
         :type interface_id: str
         :param interface_id: Allows routing to network interface attachments.
 
+        :type vpc_peering_connection_id: str
+        :param vpc_peering_connection_id: Allows routing to VPC peering
+                                          connection.
+
         :type dry_run: bool
         :param dry_run: Set to True if the operation should not actually run.
 
@@ -473,6 +485,8 @@ class VPCConnection(EC2Connection):
             params['InstanceId'] = instance_id
         elif interface_id is not None:
             params['NetworkInterfaceId'] = interface_id
+        elif vpc_peering_connection_id is not None:
+            params['VpcPeeringConnectionId'] = vpc_peering_connection_id
         if dry_run:
             params['DryRun'] = 'true'
 

--- a/tests/unit/vpc/test_routetable.py
+++ b/tests/unit/vpc/test_routetable.py
@@ -310,6 +310,20 @@ class TestCreateRoute(AWSMockServiceTestCase):
                                   'Version'])
         self.assertEquals(api_response, True)
 
+    def test_create_route_vpc_peering_connection(self):
+        self.set_http_response(status_code=200)
+        api_response = self.service_connection.create_route(
+            'rtb-g8ff4ea2', '0.0.0.0/0', vpc_peering_connection_id='pcx-1a2b3c4d')
+        self.assert_request_parameters({
+            'Action': 'CreateRoute',
+            'RouteTableId': 'rtb-g8ff4ea2',
+            'DestinationCidrBlock': '0.0.0.0/0',
+            'VpcPeeringConnectionId': 'pcx-1a2b3c4d'},
+            ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
+                                  'SignatureVersion', 'Timestamp',
+                                  'Version'])
+        self.assertEquals(api_response, True)
+
 
 class TestReplaceRoute(AWSMockServiceTestCase):
 
@@ -360,6 +374,20 @@ class TestReplaceRoute(AWSMockServiceTestCase):
             'RouteTableId': 'rtb-g8ff4ea2',
             'DestinationCidrBlock': '0.0.0.0/0',
             'NetworkInterfaceId': 'eni-1a2b3c4d'},
+            ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
+                                  'SignatureVersion', 'Timestamp',
+                                  'Version'])
+        self.assertEquals(api_response, True)
+
+    def test_replace_route_vpc_peering_connection(self):
+        self.set_http_response(status_code=200)
+        api_response = self.service_connection.replace_route(
+            'rtb-g8ff4ea2', '0.0.0.0/0', vpc_peering_connection_id='pcx-1a2b3c4d')
+        self.assert_request_parameters({
+            'Action': 'ReplaceRoute',
+            'RouteTableId': 'rtb-g8ff4ea2',
+            'DestinationCidrBlock': '0.0.0.0/0',
+            'VpcPeeringConnectionId': 'pcx-1a2b3c4d'},
             ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
                                   'SignatureVersion', 'Timestamp',
                                   'Version'])


### PR DESCRIPTION
This resolves #2500 by adding a "vpc_peering_connection_id" kwarg to "create_route" and "replace_route" methods, along with updated unit tests which inspect the call argument list to confirm.
