### PR TITLE
allowing address to use network_interface_id

### DIFF
--- a/boto/ec2/address.py
+++ b/boto/ec2/address.py
@@ -88,7 +88,7 @@ class Address(EC2Object):
 
     delete = release
 
-    def associate(self, instance_id=None, network_interface_id=None, allow_reassociation=False, dry_run=False):
+    def associate(self, instance_id=None, network_interface_id=None, private_ip_address=None, allow_reassociation=False, dry_run=False):
         """
         Associate this Elastic IP address with a currently running instance.
         :see: :meth:`boto.ec2.connection.EC2Connection.associate_address`
@@ -99,6 +99,7 @@ class Address(EC2Object):
                 public_ip=self.public_ip,
                 allocation_id=self.allocation_id,
                 network_interface_id=network_interface_id,
+                private_ip_address=private_ip_address,
                 allow_reassociation=allow_reassociation,
                 dry_run=dry_run
             )
@@ -106,6 +107,7 @@ class Address(EC2Object):
             instance_id=instance_id,
             public_ip=self.public_ip,
             network_interface_id=network_interface_id,
+            private_ip_address=private_ip_address,
             allow_reassociation=allow_reassociation,
             dry_run=dry_run
         )

--- a/tests/unit/ec2/test_address.py
+++ b/tests/unit/ec2/test_address.py
@@ -36,6 +36,7 @@ class AddressTest(unittest.TestCase):
             public_ip="192.168.1.1",
             allow_reassociation=False,
             network_interface_id=None,
+            private_ip_address=None,
             dry_run=False
         )
 
@@ -82,6 +83,7 @@ class AddressWithAllocationTest(unittest.TestCase):
             public_ip="192.168.1.1",
             allocation_id="aid1",
             network_interface_id=None,
+            private_ip_address=None,
             allow_reassociation=False,
             dry_run=False
         )
@@ -127,6 +129,7 @@ class AddressWithNetworkInterfaceTest(unittest.TestCase):
             instance_id=None,
             public_ip="192.168.1.1",
             network_interface_id=1,
+            private_ip_address=None,
             allocation_id="aid1",
             allow_reassociation=False,
             dry_run=False


### PR DESCRIPTION
Allow EIPs to be associated with an network_interface_id as well as instance_id
