### PR TITLE
Cloudsearch2 IP access policy statement is missing a Principal 

### DIFF
--- a/boto/cloudsearch2/optionstatus.py
+++ b/boto/cloudsearch2/optionstatus.py
@@ -139,7 +139,8 @@ class ServicePoliciesStatus(OptionStatus):
         """
         return {
             "Effect": "Allow",
-            "Action": "*",  # Docs say use GET, but denies unless *
+            "Action": "cloudsearch:*",
+            "Principal": {"AWS": "*"},
             "Resource": arn,
             "Condition": {
                 "IpAddress": {


### PR DESCRIPTION
Per the CloudSearch docs (http://docs.aws.amazon.com/cloudsearch/latest/developerguide/configuring-access.html):

> For anonymous access from the specified IP address or address range, must be set to "Principal":{"AWS":["*"]}.

The new_statement template is missing the Principal statement, so policy updates using Boto are accepted by the CloudSearch2 API, but the queries are denied. Creating a policy using the CloudSearch Web Console adds in the correct Principal.

Here's the policy as generated by boto (denies queries):

```
{'Statement': [{'Action': '*',
                'Condition': {'IpAddress': {'aws:SourceIp': 'x.x.x.x/32'}},
                'Effect': 'Allow',
                'Resource': 'arn:aws:cloudsearch:us-west-1:12345:domain/test',
                'Sid': ''}],
 'Version': '2008-10-17'}
```

Same policy as generated by the web console (allows queries):

```
{'Statement': [{'Action': '*',
                'Condition': {'IpAddress': {'aws:SourceIp': 'x.x.x.x/32'}},
                'Effect': 'Allow',
                'Principal': {'AWS': '*'},
                'Resource': 'arn:aws:cloudsearch:us-west-1:12345:domain/test',
                'Sid': ''}],
 'Version': '2008-10-17'}
```
