### PR TITLE
Support auth when headers contains bytes

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -317,6 +317,8 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         for name, value in http_request.headers.items():
             lname = name.lower()
             if lname.startswith('x-amz'):
+                if isinstance(value, bytes):
+                    value = value.decode('utf-8')
                 headers_to_sign[name] = value
         return headers_to_sign
 

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -251,6 +251,17 @@ class TestSigV4Handler(unittest.TestCase):
         auth2 = pickle.loads(pickled)
         self.assertEqual(auth.host, auth2.host)
 
+    def test_bytes_header(self):
+        auth = HmacAuthV4Handler('glacier.us-east-1.amazonaws.com',
+                                 mock.Mock(), self.provider)
+        request = HTTPRequest(
+            'GET', 'http', 'glacier.us-east-1.amazonaws.com', 80,
+            'x/./././x .html', None, {},
+            {'x-amz-glacier-version': '2012-06-01', 'x-amz-hash': b'f00'}, '')
+        canonical = auth.canonical_request(request)
+
+        self.assertIn('f00', canonical)
+
 
 class TestS3HmacAuthV4Handler(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This fixes #2520 by checking whether headers are `bytes` and decoding
them before performing string operations. It adds a new test covering
this functionality which now passes on all supported Python versions.

cc @jamesls, @kyleknap
