### PR TITLE
Strip leading / from key names when listing bucket

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -184,7 +184,8 @@ class Key(object):
     def _get_storage_class(self):
         if self._storage_class is None and self.bucket:
             # Attempt to fetch storage class
-            list_items = list(self.bucket.list(self.name.encode('utf-8')))
+            list_items = list(self.bucket.list(
+                self.name.lstrip('/').encode('utf-8')))
             if len(list_items) and getattr(list_items[0], '_storage_class',
                                            None):
                 self._storage_class = list_items[0]._storage_class

--- a/tests/unit/s3/test_key.py
+++ b/tests/unit/s3/test_key.py
@@ -97,6 +97,21 @@ class TestS3Key(AWSMockServiceTestCase):
         k.set_contents_from_string('test')
         k.bucket.list.assert_not_called()
 
+    def test_storage_class_slash(self):
+        self.set_http_response(status_code=200)
+        b = Bucket(self.service_connection, 'mybucket')
+        k = b.get_key('/fookey.txt')
+
+        # Mock out the bucket object - we really only care about calls
+        # to list.
+        k.bucket = mock.MagicMock()
+
+        # Test getting storage class, which should NOT ever begin
+        # with a slash.
+        sc_value = k.storage_class
+        self.assertEqual(sc_value, 'STANDARD')
+        k.bucket.list.assert_called_with(b'fookey.txt')
+
 
 def counter(fn):
     def _wrapper(*args, **kwargs):


### PR DESCRIPTION
Fixes an issue with #2404 discovered by @kingb by making sure that key
names do not start with a leading `/` when calling list on a bucket.
This fixes the incorrect storage class being set when you fetch a key
like this:

``` python
b = s3.get_bucket('foo-bucket')
k = b.get_key('/some/path.txt')
print(k.storage_class)
```

cc @jamesls, @kyleknap
