### PR TITLE
Better S3 key repr support for unicode

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -130,9 +130,15 @@ class Key(object):
 
     def __repr__(self):
         if self.bucket:
-            return '<Key: %s,%s>' % (self.bucket.name, self.name)
+            name = u'<Key: %s,%s>' % (self.bucket.name, self.name)
         else:
-            return '<Key: None,%s>' % self.name
+            name = u'<Key: None,%s>' % self.name
+
+        # Encode to bytes for Python 2 to prevent display decoding issues
+        if not isinstance(name, str):
+            name = name.encode('utf-8')
+
+        return name
 
     def __iter__(self):
         return self

--- a/tests/unit/s3/test_key.py
+++ b/tests/unit/s3/test_key.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # Copyright (c) 2012 Amazon.com, Inc. or its affiliates.  All Rights Reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -38,6 +39,11 @@ class TestS3Key(AWSMockServiceTestCase):
 
     def default_body(self):
         return "default body"
+
+    def test_unicode_name(self):
+        k = Key()
+        k.name = u'Österreich'
+        print(repr(k))
 
     def test_when_no_restore_header_present(self):
         self.set_http_response(status_code=200)


### PR DESCRIPTION
This ensures that S3 `Key` objects always return a `str` type from the
`__repr__` method. On Python 3 this is essentially a no-op, but on Python
2 this means encoding the unicode characters before display. It fixes
the exception raised in #2516.

cc @jamesls, @kyleknap
