### PR TITLE
Pass along params in make_request for elastic transcoder api.

### DIFF
--- a/boto/elastictranscoder/layer1.py
+++ b/boto/elastictranscoder/layer1.py
@@ -922,7 +922,7 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         if headers is None:
             headers = {}
         response = super(ElasticTranscoderConnection, self).make_request(
-            verb, resource, headers=headers, data=data)
+            verb, resource, headers=headers, data=data, params=params)
         body = json.loads(response.read().decode('utf-8'))
         if response.status == expected_status:
             return body


### PR DESCRIPTION
Currently params are dropped in elastic transcoder requests.  This breaks things like paged GETs such as list_presets that need to pass a PageToken.  This change fixes this.
