### PR TITLE
Include test_endpoints.json in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,5 +8,5 @@ include boto/pyami/copybot.cfg
 include boto/services/sonofmmm.cfg
 include boto/mturk/test/*.doctest
 include boto/mturk/test/.gitignore
-recursive-include tests *.py *.txt
+recursive-include tests *.json *.py *.txt
 recursive-include docs *


### PR DESCRIPTION
MANIFEST.in recursively includes .py and .txt files for tests in source distributions, but not .json files, causing unit tests to fail when run outside of a git checkout.  This commit fixes that issue.

Downstream bug:  https://bugzilla.redhat.com/show_bug.cgi?id=1072925
