### PR TITLE
Stop abusing socket global timeouts.

### DIFF
--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -272,7 +272,20 @@ class TestLazyLoadMetadata(unittest.TestCase):
 
         boto.utils.retry_url.assert_called_with(
             'http://169.254.169.254/latest/user-data',
-            retry_on_404=False)
+            retry_on_404=False,
+            num_retries=5, timeout=None)
+
+    def test_user_data_timeout(self):
+        self.set_normal_response(['foo'])
+
+        userdata = get_instance_userdata(timeout=1, num_retries=2)
+
+        self.assertEqual('foo', userdata)
+
+        boto.utils.retry_url.assert_called_with(
+            'http://169.254.169.254/latest/user-data',
+            retry_on_404=False,
+            num_retries=2, timeout=1)
 
 
 class TestStringToDatetimeParsing(unittest.TestCase):


### PR DESCRIPTION
This is a fix for the long-standing #1935.

Now that `boto` requires Python 2.6+ (see #96cd2800b6db067e503ef499486adf50ee9ca928), we can rely on the `timeout` parameter of `urllib.request.build_opener` instead of hacking the global socket timeout.

We have ran into a lot of issues because of this on a `gevent` based application that integrates with S3 using instance credentials: when two S3 requests come at roughly the same time the the global socket timeout will be forever set to 1.0s because the way the global timeout is messed with is racy.
