### PR TITLE
Support EBS encryption in BlockDeviceType.

### DIFF
--- a/boto/ec2/blockdevicemapping.py
+++ b/boto/ec2/blockdevicemapping.py
@@ -38,7 +38,8 @@ class BlockDeviceType(object):
                  delete_on_termination=False,
                  size=None,
                  volume_type=None,
-                 iops=None):
+                 iops=None,
+                 encrypted=None):
         self.connection = connection
         self.ephemeral_name = ephemeral_name
         self.no_device = no_device
@@ -50,6 +51,7 @@ class BlockDeviceType(object):
         self.size = size
         self.volume_type = volume_type
         self.iops = iops
+        self.encrypted = encrypted
 
     def startElement(self, name, attrs, connection):
         pass
@@ -76,6 +78,8 @@ class BlockDeviceType(object):
             self.volume_type = value
         elif lname == 'iops':
             self.iops = int(value)
+        elif lname == 'encrypted':
+            self.encrypted = (value == 'true')
         else:
             setattr(self, name, value)
 
@@ -150,4 +154,12 @@ class BlockDeviceMapping(dict):
                         params['%s.Ebs.VolumeType' % pre] = block_dev.volume_type
                     if block_dev.iops is not None:
                         params['%s.Ebs.Iops' % pre] = block_dev.iops
+                    # The encrypted flag (even if False) cannot be specified for the root EBS
+                    # volume.
+                    if block_dev.encrypted is not None:
+                        if block_dev.encrypted:
+                            params['%s.Ebs.Encrypted' % pre] = 'true'
+                        else:
+                            params['%s.Ebs.Encrypted' % pre] = 'false'
+
             i += 1

--- a/tests/unit/ec2/test_blockdevicemapping.py
+++ b/tests/unit/ec2/test_blockdevicemapping.py
@@ -41,6 +41,14 @@ class BlockDeviceTypeTests(unittest.TestCase):
         self.block_device_type.endElement("deleteOnTermination", 'something else', None)
         self.assertEqual(self.block_device_type.delete_on_termination, False)
 
+    def test_endElement_with_name_encrypted_value_true(self):
+        self.block_device_type.endElement("Encrypted", "true", None)
+        self.assertEqual(self.block_device_type.encrypted, True)
+
+    def test_endElement_with_name_Encrypted_value_other(self):
+        self.block_device_type.endElement("Encrypted", 'something else', None)
+        self.assertEqual(self.block_device_type.encrypted, False)
+
 
 class BlockDeviceMappingTests(unittest.TestCase):
     def setUp(self):
@@ -56,7 +64,8 @@ class BlockDeviceMappingTests(unittest.TestCase):
                         b1.status == b2.status,
                         b1.attach_time == b2.attach_time,
                         b1.delete_on_termination == b2.delete_on_termination,
-                        b1.size == b2.size])
+                        b1.size == b2.size,
+                        b1.encrypted == b2.encrypted])
 
     def test_startElement_with_name_ebs_sets_and_returns_current_value(self):
         retval = self.block_device_mapping.startElement("ebs", None, None)
@@ -97,7 +106,7 @@ class TestLaunchConfiguration(AWSMockServiceTestCase):
         # Autoscaling).
         self.set_http_response(status_code=200)
         dev_sdf = BlockDeviceType(snapshot_id='snap-12345')
-        dev_sdg = BlockDeviceType(snapshot_id='snap-12346', delete_on_termination=True)
+        dev_sdg = BlockDeviceType(snapshot_id='snap-12346', delete_on_termination=True, encrypted=True)
 
         class OrderedBlockDeviceMapping(OrderedDict, BlockDeviceMapping):
             pass
@@ -120,6 +129,7 @@ class TestLaunchConfiguration(AWSMockServiceTestCase):
             'BlockDeviceMapping.2.DeviceName': '/dev/sdg',
             'BlockDeviceMapping.2.Ebs.DeleteOnTermination': 'true',
             'BlockDeviceMapping.2.Ebs.SnapshotId': 'snap-12346',
+            'BlockDeviceMapping.2.Ebs.Encrypted': 'true',
             'ImageId': '123456',
             'InstanceType': 'm1.large',
             'MaxCount': 1,


### PR DESCRIPTION
Support an optional configuration of ebs encryption in the
BlockDeviceType (which is used to build a BlockDeviceMapping).

The encrypted flag is optional (defaulting to `None`), as the AWS
API doesn't support any value for this flag for the root device
of a new instance.

Related to: https://github.com/boto/boto/pull/2480
