### PR TITLE
Few typo in docstring

### DIFF
--- a/boto/ec2/autoscale/launchconfig.py
+++ b/boto/ec2/autoscale/launchconfig.py
@@ -128,8 +128,8 @@ class LaunchConfiguration(object):
         :type instance_type: str
         :param instance_type: The instance type
 
-        :type kern_id: str
-        :param kern_id: Kernel id for instance
+        :type kernel_id: str
+        :param kernel_id: Kernel id for instance
 
         :type ramdisk_id: str
         :param ramdisk_id: RAM disk id for instance


### PR DESCRIPTION
from `kern_id` to `kernel_id` in the docstring.
