### PR TITLE
[LaunchConfiguration] Fix user_data encoded Python 3.3+

### DIFF
--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -222,7 +222,10 @@ class AutoScaleConnection(AWSQueryConnection):
         if launch_config.key_name:
             params['KeyName'] = launch_config.key_name
         if launch_config.user_data:
-            params['UserData'] = base64.b64encode(launch_config.user_data).decode('utf-8')
+            user_data = launch_config.user_data
+            if isinstance(user_data, six.text_type):
+                user_data = user_data.encode('utf-8')
+            params['UserData'] = base64.b64encode(user_data).decode('utf-8')
         if launch_config.kernel_id:
             params['KernelId'] = launch_config.kernel_id
         if launch_config.ramdisk_id:

--- a/tests/unit/ec2/autoscale/test_group.py
+++ b/tests/unit/ec2/autoscale/test_group.py
@@ -27,6 +27,8 @@ from datetime import datetime
 from tests.unit import unittest
 from tests.unit import AWSMockServiceTestCase
 
+from boto.compat import six
+
 from boto.ec2.autoscale import AutoScaleConnection
 from boto.ec2.autoscale.group import AutoScalingGroup
 from boto.ec2.autoscale.policy import ScalingPolicy
@@ -385,7 +387,7 @@ class TestLaunchConfiguration(AWSMockServiceTestCase):
             'EbsOptimized': 'false',
             'LaunchConfigurationName': 'launch_config',
             'ImageId': '123456',
-            'UserData': base64.b64encode('#!/bin/bash').decode('utf-8'),
+            'UserData': base64.b64encode(six.b('#!/bin/bash')).decode('utf-8'),
             'InstanceMonitoring.Enabled': 'false',
             'InstanceType': 'm1.large',
             'SecurityGroups.member.1': 'group1',


### PR DESCRIPTION
Occurred the Error calling [`boto.ec2.autoscale.AutoScaleConnection.create_launch_configuration(...)`](https://github.com/boto/boto/blob/2.32.1/boto/ec2/autoscale/__init__.py#L212-260) with user_data (type str)

Hope to fix that behavior like [`boto.ec2.connection.run_instances`](https://github.com/boto/boto/blob/2.32.1/boto/ec2/connection.py#L929-931) :ramen: 

| category | boto | Python | module |
| --- | --- | --- | --- |
| bug | 2.32.1 | py33, py34 | autoscale |

**Traceback:** :broken_heart:

```
...
  File "xxx/lib/python3.4/site-packages/boto/ec2/autoscale/__init__.py", line 225, in create_launch_configuration
    params['UserData'] = base64.b64encode(launch_config.user_data).decode('utf-8')
  File "xxx/lib/python3.4/base64.py", line 62, in b64encode
    encoded = binascii.b2a_base64(s)[:-1]
TypeError: 'str' does not support the buffer interface
```

**Test Execution case 2.32.1:** :broken_heart:

``` sh
$ python3 tests/test.py tests/unit/ec2/autoscale/test_group.py
nose command: tests/test.py -a !notdefault tests/unit/ec2/autoscale/test_group.py
...............E.......
======================================================================
ERROR: test_launch_config (tests.unit.ec2.autoscale.test_group.TestLaunchConfiguration)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "xxx/boto/boto/tests/unit/ec2/autoscale/test_group.py", line 375, in test_launch_config
    response = self.service_connection.create_launch_configuration(lc)
  File "xxx/boto/boto/ec2/autoscale/__init__.py", line 225, in create_launch_configuration
    params['UserData'] = base64.b64encode(launch_config.user_data).decode('utf-8')
  File "xxx/.venv/boto.py34/lib/python3.4/base64.py", line 62, in b64encode
    encoded = binascii.b2a_base64(s)[:-1]
nose.proxy.TypeError: 'str' does not support the buffer interface
-------------------- >> begin captured logging << --------------------
boto: DEBUG: Using access key provided by client.
boto: DEBUG: Using secret key provided by client.
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 23 tests in 0.057s

FAILED (errors=1)
```

btw Travis's running test `python tests/test.py default` is without target `tests/unit/ec2/autoscale/test_group.py`?

---
#### References
- [19.6. base64 - docs.python.org](https://docs.python.org/3.4/library/base64.html)
- [2.4.1 String and Bytes literals - docs.python.org](https://docs.python.org/3.4/reference/lexical_analysis.html#string-and-bytes-literals)
- [six.text_type - pythonhosted.org](https://pythonhosted.org/six/#six.text_type)
