### PR TITLE
Route Tables: Update describe_route_tables to support additional route types (VPC peering connection, NIC).

### DIFF
--- a/boto/vpc/routetable.py
+++ b/boto/vpc/routetable.py
@@ -67,6 +67,8 @@ class Route(object):
         self.destination_cidr_block = None
         self.gateway_id = None
         self.instance_id = None
+        self.interface_id = None
+        self.vpc_peering_connection_id = None
         self.state = None
 
     def __repr__(self):
@@ -82,6 +84,10 @@ class Route(object):
             self.gateway_id = value
         elif name == 'instanceId':
             self.instance_id = value
+        elif name == 'networkInterfaceId':
+            self.interface_id = value
+        elif name == 'vpcPeeringConnectionId':
+            self.vpc_peering_connection_id = value
         elif name == 'state':
             self.state = value
 

--- a/tests/unit/vpc/test_routetable.py
+++ b/tests/unit/vpc/test_routetable.py
@@ -48,6 +48,18 @@ class TestDescribeRouteTables(AWSMockServiceTestCase):
                            <gatewayId>igw-eaad4883</gatewayId>
                            <state>active</state>
                         </item>
+                        <item>
+                            <destinationCidrBlock>10.0.0.0/21</destinationCidrBlock>
+                            <networkInterfaceId>eni-884ec1d1</networkInterfaceId>
+                            <state>blackhole</state>
+                            <origin>CreateRoute</origin>
+                        </item>
+                        <item>
+                            <destinationCidrBlock>11.0.0.0/22</destinationCidrBlock>
+                            <vpcPeeringConnectionId>pcx-efc52b86</vpcPeeringConnectionId>
+                            <state>blackhole</state>
+                            <origin>CreateRoute</origin>
+                        </item>
                      </routeSet>
                      <associationSet>
                         <item>
@@ -88,13 +100,19 @@ class TestDescribeRouteTables(AWSMockServiceTestCase):
         self.assertIsNone(api_response[0].associations[0].subnet_id)
         self.assertEquals(api_response[0].associations[0].main, True)
         self.assertEquals(api_response[1].id, 'rtb-f9ad4890')
-        self.assertEquals(len(api_response[1].routes), 2)
+        self.assertEquals(len(api_response[1].routes), 4)
         self.assertEquals(api_response[1].routes[0].destination_cidr_block, '10.0.0.0/22')
         self.assertEquals(api_response[1].routes[0].gateway_id, 'local')
         self.assertEquals(api_response[1].routes[0].state, 'active')
         self.assertEquals(api_response[1].routes[1].destination_cidr_block, '0.0.0.0/0')
         self.assertEquals(api_response[1].routes[1].gateway_id, 'igw-eaad4883')
         self.assertEquals(api_response[1].routes[1].state, 'active')
+        self.assertEquals(api_response[1].routes[2].destination_cidr_block, '10.0.0.0/21')
+        self.assertEquals(api_response[1].routes[2].interface_id, 'eni-884ec1d1')
+        self.assertEquals(api_response[1].routes[2].state, 'blackhole')
+        self.assertEquals(api_response[1].routes[3].destination_cidr_block, '11.0.0.0/22')
+        self.assertEquals(api_response[1].routes[3].vpc_peering_connection_id, 'pcx-efc52b86')
+        self.assertEquals(api_response[1].routes[3].state, 'blackhole')
         self.assertEquals(len(api_response[1].associations), 1)
         self.assertEquals(api_response[1].associations[0].id, 'rtbassoc-faad4893')
         self.assertEquals(api_response[1].associations[0].route_table_id, 'rtb-f9ad4890')


### PR DESCRIPTION
This resolves #2597 by adding "interface_id" and "vpc_peering_connection_id" properties to Route, and parsing the corresponding XML data for said properties.

(Note: Both property names were chosen to match the corresponding kwargs in create_route/delete_route, thus "interface_id" rather than "network_interface_id".)
