### PR TITLE
Fix typo in ELB ConnectionSettings attribute

### DIFF
--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -437,7 +437,7 @@ class ELBConnection(AWSQueryConnection):
                 value.enabled and 'true' or 'false'
             params['LoadBalancerAttributes.ConnectionDraining.Timeout'] = \
                 value.timeout
-        elif attribute.lower() == 'connectionsettings':
+        elif attribute.lower() == 'connectingsettings':
             params['LoadBalancerAttributes.ConnectionSettings.IdleTimeout'] = \
                 value.idle_timeout
         else:


### PR DESCRIPTION
Change `connectingsettings` to `connectionsettings`. Also add missing `()`.
