### PR TITLE
Fix bug where headers were presigned incorrectly.

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -705,6 +705,10 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         if self._provider.security_token:
             params['X-Amz-Security-Token'] = self._provider.security_token
 
+        headers_to_sign = self.headers_to_sign(req)
+        l = sorted(['%s' % n.lower().strip() for n in headers_to_sign])
+        params['X-Amz-SignedHeaders'] = ';'.join(l)
+ 
         req.params.update(params)
 
         cr = self.canonical_request(req)

--- a/tests/unit/s3/test_connection.py
+++ b/tests/unit/s3/test_connection.py
@@ -135,6 +135,26 @@ class TestSigV4Presigned(MockServiceWithConfigTestCase):
         self.assertIn('VersionId=2', url)
         self.assertIn('X-Amz-Security-Token=token', url)
 
+    def test_sigv4_presign_headers(self):
+        self.config = {
+            's3': {
+                'use-sigv4': True,
+            }
+        }
+
+        conn = self.connection_class(
+            aws_access_key_id='less',
+            aws_secret_access_key='more',
+            host='s3.amazonaws.com'
+        )
+
+        headers = {'x-amz-meta-key': 'val'}
+        url = conn.generate_url_sigv4(86400, 'GET', bucket='examplebucket',
+                                      key='test.txt', headers=headers)
+
+        self.assertIn('host', url)
+        self.assertIn('x-amz-meta-key', url)
+
 
 class TestUnicodeCallingFormat(AWSMockServiceTestCase):
     connection_class = S3Connection


### PR DESCRIPTION
For Sigv4 urls, custom metadata headers were not being presigned correctly.

cc @danielgtaylor @jamesls 
