### PR TITLE
fix ELB ConnectionSettings values in documentation

### DIFF
--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -400,7 +400,7 @@ class ELBConnection(AWSQueryConnection):
         :param attribute: The attribute you wish to change.
 
         * crossZoneLoadBalancing - Boolean (true)
-        * connectionSettings - :py:class:`ConnectionSettingAttribute` instance
+        * connectingSettings - :py:class:`ConnectionSettingAttribute` instance
         * accessLog - :py:class:`AccessLogAttribute` instance
         * connectionDraining - :py:class:`ConnectionDrainingAttribute` instance
 
@@ -472,7 +472,7 @@ class ELBConnection(AWSQueryConnection):
 
           * accessLog - :py:class:`AccessLogAttribute` instance
           * crossZoneLoadBalancing - Boolean
-          * connectionSettings - :py:class:`ConnectionSettingAttribute` instance
+          * connectingSettings - :py:class:`ConnectionSettingAttribute` instance
           * connectionDraining - :py:class:`ConnectionDrainingAttribute`
             instance
 


### PR DESCRIPTION
While elb.attributes.ConnectionSettingAttribute is the name of the class, the get_ and modify_ classes sniff for "connectingsettings" (note 'ing' and plural 's' at end). The safest thing to do is to make the documentation correct. Another possibility would be to add an 'or' to the conditionals.
