### PR TITLE
[Cloudwatch] Fix invalid param name

### DIFF
--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -343,7 +343,7 @@ class CloudWatchConnection(AWSQueryConnection):
         action.
 
         :type action_prefix: string
-        :param action_name: The action name prefix.
+        :param action_prefix: The action name prefix.
 
         :type alarm_name_prefix: string
         :param alarm_name_prefix: The alarm name prefix. AlarmNames cannot


### PR DESCRIPTION
Change param name from `action_name` to `action_prefix`.
(`action_name` is not found.)