### PR TITLE
Make build_list_params() accept iterable object

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1113,8 +1113,8 @@ class AWSQueryConnection(AWSAuthConnection):
     def build_list_params(self, params, items, label):
         if isinstance(items, six.string_types):
             items = [items]
-        for i in range(1, len(items) + 1):
-            params['%s.%d' % (label, i)] = items[i - 1]
+        for i, item in enumerate(items, start=1):
+            params['%s.%d' % (label, i)] = item
 
     def build_complex_list_params(self, params, items, label, names):
         """Serialize a list of structures.

--- a/tests/integration/ec2/cloudwatch/test_connection.py
+++ b/tests/integration/ec2/cloudwatch/test_connection.py
@@ -103,15 +103,16 @@ class CloudWatchConnectionTest(unittest.TestCase):
 
     def test_build_list_params(self):
         c = CloudWatchConnection()
-        params = {}
-        c.build_list_params(
-            params, ['thing1', 'thing2', 'thing3'], 'ThingName%d')
-        expected_params = {
-            'ThingName1': 'thing1',
-            'ThingName2': 'thing2',
-            'ThingName3': 'thing3'
-        }
-        self.assertEqual(params, expected_params)
+        items = ['thing1', 'thing2', 'thing3']
+        for i in (items, iter(items)):
+            params = {}
+            c.build_list_params(params, i, 'ThingName%d')
+            expected_params = {
+                'ThingName1': 'thing1',
+                'ThingName2': 'thing2',
+                'ThingName3': 'thing3'
+            }
+            self.assertEqual(params, expected_params)
 
     def test_build_put_params_one(self):
         c = CloudWatchConnection()

--- a/tests/integration/ec2/elb/test_connection.py
+++ b/tests/integration/ec2/elb/test_connection.py
@@ -62,15 +62,16 @@ class ELBConnectionTest(unittest.TestCase):
         self.balancer.delete()
 
     def test_build_list_params(self):
-        params = {}
-        self.conn.build_list_params(
-            params, ['thing1', 'thing2', 'thing3'], 'ThingName%d')
-        expected_params = {
-            'ThingName1': 'thing1',
-            'ThingName2': 'thing2',
-            'ThingName3': 'thing3'
-        }
-        self.assertEqual(params, expected_params)
+        items = ['thing1', 'thing2', 'thing3']
+        for i in (items, iter(items)):
+            params = {}
+            self.conn.build_list_params(params, i, 'ThingName%d')
+            expected_params = {
+                'ThingName1': 'thing1',
+                'ThingName2': 'thing2',
+                'ThingName3': 'thing3'
+            }
+            self.assertEqual(params, expected_params)
 
     # TODO: for these next tests, consider sleeping until our load
     # balancer comes up, then testing for connectivity to

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -63,6 +63,16 @@ class TestListParamsSerialization(unittest.TestCase):
             'ParamName.member.3': 'baz',
         }, params)
 
+    def test_simple_iterable_serialization(self):
+        params = {}
+        self.connection.build_list_params(
+            params, iter(['foo', 'bar', 'baz']), 'ParamName.member')
+        self.assertDictEqual({
+            'ParamName.member.1': 'foo',
+            'ParamName.member.2': 'bar',
+            'ParamName.member.3': 'baz',
+        }, params)
+
 
 class MockAWSService(AWSQueryConnection):
     """


### PR DESCRIPTION
Previously, only a derivied method of special connection classes could accept an iterable object into `items` argument, whereas the base method `AWSQueryConnection.build_list_params()` depended on list type and couldn't handle an iterable object. This commit fixes this problem, and adds some corner cases about it in unit tests.
