### PR TITLE
Route53 TCP healthcheck bug

### DIFF
--- a/boto/route53/healthcheck.py
+++ b/boto/route53/healthcheck.py
@@ -56,7 +56,7 @@ class HealthCheck(object):
             %(ip_addr_part)s
             <Port>%(port)s</Port>
             <Type>%(type)s</Type>
-            <ResourcePath>%(resource_path)s</ResourcePath>
+            %(resource_path_part)s
             %(fqdn_part)s
             %(string_match_part)s
             %(request_interval)s
@@ -66,6 +66,8 @@ class HealthCheck(object):
 
     XMLIpAddrPart = """<IPAddress>%(ip_addr)s</IPAddress>"""
 
+    XMLResourcePathPart = """<ResourcePath>%(resource_path)s</ResourcePath>"""
+
     XMLFQDNPart = """<FullyQualifiedDomainName>%(fqdn)s</FullyQualifiedDomainName>"""
 
     XMLStringMatchPart = """<SearchString>%(string_match)s</SearchString>"""
@@ -74,7 +76,7 @@ class HealthCheck(object):
 
     valid_request_intervals = (10, 30)
 
-    def __init__(self, ip_addr, port, hc_type, resource_path, fqdn=None, string_match=None, request_interval=30, failure_threshold=3):
+    def __init__(self, ip_addr, port, hc_type, resource_path=None, fqdn=None, string_match=None, request_interval=30, failure_threshold=3):
         """
         HealthCheck object
 
@@ -127,13 +129,17 @@ class HealthCheck(object):
             'ip_addr_part': '',
             'port': self.port,
             'type': self.hc_type,
-            'resource_path': self.resource_path,
+            'resource_path': '',
             'fqdn_part': "",
             'string_match_part': "",
             'request_interval': (self.XMLRequestIntervalPart %
                                  {'request_interval': self.request_interval}),
             'failure_threshold': self.failure_threshold,
         }
+
+        if self.resource_path:
+            params['resource_path_part'] = self.XMLResourcePathPart % {'resource_path': self.resource_path}
+
         if self.fqdn is not None:
             params['fqdn_part'] = self.XMLFQDNPart % {'fqdn': self.fqdn}
 

--- a/boto/route53/healthcheck.py
+++ b/boto/route53/healthcheck.py
@@ -129,7 +129,7 @@ class HealthCheck(object):
             'ip_addr_part': '',
             'port': self.port,
             'type': self.hc_type,
-            'resource_path': '',
+            'resource_path_part': '',
             'fqdn_part': "",
             'string_match_part': "",
             'request_interval': (self.XMLRequestIntervalPart %

--- a/tests/unit/route53/test_connection.py
+++ b/tests/unit/route53/test_connection.py
@@ -561,6 +561,45 @@ class TestCreateHealthCheckRoute53FQDN(AWSMockServiceTestCase):
 
 
 @attr(route53=True)
+class TestCreateHealthCheckRoute53TCP(AWSMockServiceTestCase):
+    connection_class = Route53Connection
+
+    def setUp(self):
+        super(TestCreateHealthCheckRoute53TCP, self).setUp()
+
+    def default_body(self):
+        return b"""
+<CreateHealthCheckResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+   <HealthCheck>
+      <Id>34778cf8-e31e-4974-bad0-b108bd1623d3</Id>
+      <CallerReference>2fa48c8f-76ef-4253-9874-8bcb2b0d7694</CallerReference>
+      <HealthCheckConfig>
+         <IPAddress>74.125.228.81</IPAddress>
+         <Port>80</Port>
+         <Type>TCP</Type>
+         <RequestInterval>30</RequestInterval>
+         <FailureThreshold>3</FailureThreshold>
+      </HealthCheckConfig>
+   </HealthCheck>
+</CreateHealthCheckResponse>
+        """
+
+    def test_create_health_check_tcp(self):
+        self.set_http_response(status_code=201)
+        hc = HealthCheck(ip_addr='74.125.228.81', port=80, hc_type='TCP')
+        hc_xml = hc.to_xml()
+        self.assertFalse('<ResourcePath>' in hc_xml)
+        self.assertTrue('<IPAddress>' in hc_xml)
+
+        response = self.service_connection.create_health_check(hc)
+        hc_resp = response['CreateHealthCheckResponse']['HealthCheck']['HealthCheckConfig']
+        self.assertEqual(hc_resp['IPAddress'], '74.125.228.81')
+        self.assertEqual(hc_resp['Type'], 'TCP')
+        self.assertEqual(hc_resp['Port'], '80')
+        self.assertEqual(response['CreateHealthCheckResponse']['HealthCheck']['Id'], '34778cf8-e31e-4974-bad0-b108bd1623d3')
+
+
+@attr(route53=True)
 class TestChangeResourceRecordSetsRoute53(AWSMockServiceTestCase):
     connection_class = Route53Connection
 


### PR DESCRIPTION
When creating a TCP health check the Route53 API requires that resource path is omitted. Currently, boto requires the resource path to be specified. This returns the following error from the API

```
<ErrorResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
    <Error><Type>Sender</Type><Code>InvalidInput</Code><Message>TCP health checks must not have a resource path specificed.</Message></Error><RequestId>4bf97687-c58c-11e3-9c4f-b18f7840909a</RequestId>
</ErrorResponse>
```

The fix is to default resource path to none and exclude the element from the request if not set.
