### PR TITLE
Prevent exceptions from being masked in get_contents_to_filename

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1706,7 +1706,9 @@ class Key(object):
                                           res_download_handler=res_download_handler,
                                           response_headers=response_headers)
         except Exception:
-            os.remove(filename)
+            if os.path.exists(filename):
+                # If open fails, then filename doesn't exist.
+                os.remove(filename)
             raise
         # if last_modified date was sent from s3, try to set file's timestamp
         if self.last_modified is not None:


### PR DESCRIPTION
If opening the file fails, there is the potential for the following call to `os.remove` to fail, suppressing the actual error.
