### PR TITLE
Add ConnectionSettings attribute, alias of ConnectingSettings

### DIFF
--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -438,6 +438,10 @@ class ELBConnection(AWSQueryConnection):
             params['LoadBalancerAttributes.ConnectionDraining.Timeout'] = \
                 value.timeout
         elif attribute.lower() == 'connectingsettings':
+            boto.log.warn('ConnectingSettings will be deprecated soon. Please use ConnectionSettings')
+            params['LoadBalancerAttributes.ConnectionSettings.IdleTimeout'] = \
+                value.idle_timeout
+        elif attribute.lower() == 'connectionsettings':
             params['LoadBalancerAttributes.ConnectionSettings.IdleTimeout'] = \
                 value.idle_timeout
         else:
@@ -487,7 +491,10 @@ class ELBConnection(AWSQueryConnection):
         if attribute.lower() == 'connectiondraining':
             return attributes.connection_draining
         if attribute.lower() == 'connectingsettings':
+            boto.log.warn('ConnectingSettings will be deprecated soon. Please use ConnectionSettings')
             return attributes.connecting_settings
+        if attribute.lower() == 'connectionsettings':
+            return attributes.connection_settings
         return None
 
     def register_instances(self, load_balancer_name, instances):

--- a/boto/ec2/elb/attributes.py
+++ b/boto/ec2/elb/attributes.py
@@ -132,13 +132,14 @@ class LbAttributes(object):
         self.access_log = AccessLogAttribute(self.connection)
         self.connection_draining = ConnectionDrainingAttribute(self.connection)
         self.connecting_settings = ConnectionSettingAttribute(self.connection)
+        self.connection_settings = self.connecting_settings
 
     def __repr__(self):
         return 'LbAttributes(%s, %s, %s, %s)' % (
             repr(self.cross_zone_load_balancing),
             repr(self.access_log),
             repr(self.connection_draining),
-            repr(self.connecting_settings))
+            repr(self.connection_settings))
 
     def startElement(self, name, attrs, connection):
         if name == 'CrossZoneLoadBalancing':


### PR DESCRIPTION
Follow-up pull request of #2602 .

This will give users a chance to migrate to `ConnectionSettings` attribute, before we eventually deprecate `ConnectingSettings`.