### PR TITLE
Added account password policy calls

### DIFF
--- a/boto/iam/connection.py
+++ b/boto/iam/connection.py
@@ -1525,5 +1525,82 @@ class IAMConnection(AWSQueryConnection):
         return self.get_response('GetCredentialReport', params)
 
     def get_account_password_policy(self):
+        """
+        Retrieves the password policy for the account.
+        """
         params = {}
         return self.get_response('GetAccountPasswordPolicy', params)
+
+    def delete_account_password_policy(self):
+        """
+        delete the password policy associated
+        with the account
+        """
+        params = {}
+        return self.get_response('DeleteAccountPasswordPolicy', params)
+
+    def update_account_password_policy(self,
+                                       allow_users_to_change_password=None,
+                                       hard_expiry=None,
+                                       max_password_age=None,
+                                       minimum_password_length=None,
+                                       password_reuse_prevention=None,
+                                       require_lowercase_characters=None,
+                                       require_numbers=None,
+                                       require_symbols=None,
+                                       require_uppercase_characters=None,
+                                       ):
+        """
+        Update/Create an account password policy
+
+        :type allow_users_to_change_password: bool
+        :param allow_users_to_change_password:
+
+        :type hard_expiry: bool
+        :param hard_expiry:
+
+        :type max_password_age: int
+        :param max_password_age:
+
+        :type minimum_password_length: int
+        :param minimum_password_length:
+
+        :type password_reuse_prevention: bool
+        :param password_reuse_prevention:
+
+        :type require_lowercase_characters: int
+        :param require_lowercase_characters:
+
+        :type require_numbers: int
+        :param require_numbers:
+
+        :type require_symbols: bool
+        :param require_symbols:
+
+        :type require_uppercase_characters: bool
+        :param require_uppercase_characters:
+        """
+        mapping = {
+            "AllowUsersToChangePassword" : allow_users_to_change_password,
+            "HardExpiry" : hard_expiry,
+            "MaxPasswordAge" : max_password_age,
+            "MinimumPasswordLength" : minimum_password_length,
+            "PasswordReusePrevention" : password_reuse_prevention,
+            "RequireLowercaseCharacters" : require_lowercase_characters,
+            "RequireNumbers" : require_numbers,
+            "RequireSymbols" : require_symbols,
+            "RequireUppercaseCharacters" : require_uppercase_characters
+        }
+        params = {}
+        for param, value in mapping.items():
+            if value is not None:
+                if isinstance(value, bool):
+                    #map boolean values to text format
+                    #should certainly be moved to request builder ?
+                    params[param] = 'true' if value else 'false'
+                else:
+                    params[param] = value
+
+        return self.get_response('UpdateAccountPasswordPolicy', params)
+
+

--- a/tests/unit/iam/test_connection.py
+++ b/tests/unit/iam/test_connection.py
@@ -360,3 +360,96 @@ class TestGetCredentialReport(AWSMockServiceTestCase):
         b64decode(response['get_credential_report_response']
                           ['get_credential_report_result']
                           ['content'])
+
+
+class TestGetAccountPasswordPolicy(AWSMockServiceTestCase):
+    connection_class = IAMConnection
+
+    def default_body(self):
+        return b"""
+          <GetAccountPasswordPolicyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+            <GetAccountPasswordPolicyResult>
+              <PasswordPolicy>
+                <AllowUsersToChangePassword>true</AllowUsersToChangePassword>
+                <RequireUppercaseCharacters>true</RequireUppercaseCharacters>
+                <RequireSymbols>true</RequireSymbols>
+                <ExpirePasswords>false</ExpirePasswords>
+                <PasswordReusePrevention>12</PasswordReusePrevention>
+                <RequireLowercaseCharacters>true</RequireLowercaseCharacters>
+                <MaxPasswordAge>90</MaxPasswordAge>
+                <HardExpiry>false</HardExpiry>
+                <RequireNumbers>true</RequireNumbers>
+                <MinimumPasswordLength>12</MinimumPasswordLength>
+              </PasswordPolicy>
+            </GetAccountPasswordPolicyResult>
+            <ResponseMetadata>
+              <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
+            </ResponseMetadata>
+          </GetAccountPasswordPolicyResponse>
+        """
+
+    def test_get_account_password_policy(self):
+        self.set_http_response(status_code=200)
+        response = self.service_connection.get_account_password_policy()
+        self.assertEqual(response['get_account_password_policy_response']
+                                 ['get_account_password_policy_result']
+                                 ['password_policy']
+                                 ['allow_users_to_change_password'],
+                                 'true')
+
+
+class TestDeleteAccountPasswordPolicy(AWSMockServiceTestCase):
+    connection_class = IAMConnection
+
+    def default_body(self):
+            return b"""
+                  <DeleteAccountPasswordPolicyResponse>
+                    <ResponseMetadata>
+                        <RequestId>EXAMPLE</RequestId>
+                    </ResponseMetadata>
+                  </DeleteAccountPasswordPolicyResponse>
+                  """
+
+    def test_delete_account_password_policy(self):
+        self.set_http_response(status_code=200)
+        response = self.service_connection.delete_account_password_policy()
+        self.assertEqual(response['delete_account_password_policy_response']
+                                 ['response_metadata']
+                                 ['request_id'],
+                                 'EXAMPLE')
+
+class TestUpdateAccountPasswordPolicy(AWSMockServiceTestCase):
+    connection_class = IAMConnection
+
+    def default_body(self):
+            return b"""
+                <UpdateAccountPasswordPolicyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+                 <ResponseMetadata>
+                    <RequestId>EXAMPLE</RequestId>
+                 </ResponseMetadata>
+                </UpdateAccountPasswordPolicyResponse>
+                """
+
+    def test_boolean_parameter_true(self):
+        self.set_http_response(status_code=200)
+        response = self.service_connection.update_account_password_policy(allow_users_to_change_password=True)
+        self.assertEqual(response['update_account_password_policy_response']
+                                 ['response_metadata']
+                                 ['request_id'],
+                                 'EXAMPLE')
+
+    def test_boolean_parameter_text_true(self):
+        self.set_http_response(status_code=200)
+        response = self.service_connection.update_account_password_policy(allow_users_to_change_password='true')
+        self.assertEqual(response['update_account_password_policy_response']
+                                 ['response_metadata']
+                                 ['request_id'],
+                                 'EXAMPLE')
+
+    def test_integer_parameter(self):
+        self.set_http_response(status_code=200)
+        response = self.service_connection.update_account_password_policy(minimum_password_length=10)
+        self.assertEqual(response['update_account_password_policy_response']
+                                 ['response_metadata']
+                                 ['request_id'],
+                                 'EXAMPLE')


### PR DESCRIPTION
This patch add the calls for handling Account Password Policy.
It Add ability to Update/Add, Delete and retrieve the password policy associated with the account.
