### PR TITLE
do not parse XML reports in MWS; fixes #2660

### DIFF
--- a/boto/mws/connection.py
+++ b/boto/mws/connection.py
@@ -310,6 +310,9 @@ class MWSConnection(AWSQueryConnection):
             response = self._mexe(request, override_num_retries=None)
         except BotoServerError as bs:
             raise self._response_error_factor(bs.status, bs.reason, bs.body)
+        return self._process_response(parser, response)
+
+    def _process_response(self, parser, response):
         body = response.read()
         boto.log.debug(body)
         if not body:
@@ -329,6 +332,8 @@ class MWSConnection(AWSQueryConnection):
         return self._parse_response(parser, contenttype, body)
 
     def _parse_response(self, parser, contenttype, body):
+        if not contenttype.startswith('text/xml'):
+            return body
         handler = XmlHandler(parser, self)
         xml.sax.parseString(body, handler)
         return parser

--- a/boto/mws/connection.py
+++ b/boto/mws/connection.py
@@ -324,12 +324,11 @@ class MWSConnection(AWSQueryConnection):
         digest = response.getheader('Content-MD5')
         if digest is not None:
             assert content_md5(body) == digest
+            return body
         contenttype = response.getheader('Content-Type')
         return self._parse_response(parser, contenttype, body)
 
     def _parse_response(self, parser, contenttype, body):
-        if not contenttype.startswith('text/xml'):
-            return body
         handler = XmlHandler(parser, self)
         xml.sax.parseString(body, handler)
         return parser

--- a/tests/unit/mws/test_connection.py
+++ b/tests/unit/mws/test_connection.py
@@ -20,7 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-from boto.mws.connection import MWSConnection, api_call_map, destructure_object
+from boto.mws.connection import (MWSConnection, api_call_map,
+                                 destructure_object, content_md5)
 from boto.mws.response import (ResponseElement, GetFeedSubmissionListResult,
                                ResponseFactory)
 from tests.compat import unittest
@@ -50,6 +51,19 @@ doc/2009-01-01/">
     <RequestId>1105b931-6f1c-4480-8e97-f3b467840a9e</RequestId>
   </ResponseMetadata>
 </GetFeedSubmissionListResponse>"""
+
+    def test_report_response(self):
+        # Test that we don't attempt to parse reports
+        connection = self.service_connection
+        report = "a sample report"
+        headers = {
+            'Content-Type': 'text/xml',
+            'Content-MD5': content_md5(report),
+        }
+        response = self.create_response(200, 'Ok!', header=headers, body=report)
+        parser = connection._response_factory('GetReport', connection=connection)
+        result = connection._process_response(parser, response)
+        self.assertEqual(result, report)
 
     def test_destructure_object(self):
         # Test that parsing of user input to Amazon input works.


### PR DESCRIPTION
I ended up restoring the check for `text/xml` bodies because it doesn't make much sense to attempt to parse non-XML content, and this might catch some esoteric scenario that I've overlooked among the older API calls.
