### PR TITLE
Fix a typo in MWS: _response_error_factor -> _response_error_factory

### DIFF
--- a/boto/mws/connection.py
+++ b/boto/mws/connection.py
@@ -309,7 +309,7 @@ class MWSConnection(AWSQueryConnection):
         try:
             response = self._mexe(request, override_num_retries=None)
         except BotoServerError as bs:
-            raise self._response_error_factor(bs.status, bs.reason, bs.body)
+            raise self._response_error_factory(bs.status, bs.reason, bs.body)
         body = response.read()
         boto.log.debug(body)
         if not body:


### PR DESCRIPTION
A simple typo fix, just as the title says.
