### PR TITLE
Client side encryption

### DIFF
--- a/boto/gs/connection.py
+++ b/boto/gs/connection.py
@@ -39,12 +39,13 @@ class GSConnection(S3Connection):
                  proxy_user=None, proxy_pass=None,
                  host=DefaultHost, debug=0, https_connection_factory=None,
                  calling_format=SubdomainCallingFormat(), path='/',
-                 suppress_consec_slashes=True):
+                 suppress_consec_slashes=True, client_side_encryption_key=None):
         super(GSConnection, self).__init__(gs_access_key_id, gs_secret_access_key,
                  is_secure, port, proxy, proxy_port, proxy_user, proxy_pass,
                  host, debug, https_connection_factory, calling_format, path,
                  "google", Bucket,
-                 suppress_consec_slashes=suppress_consec_slashes)
+                 suppress_consec_slashes=suppress_consec_slashes,
+                 client_side_encryption_key=client_side_encryption_key)
 
     def create_bucket(self, bucket_name, headers=None,
                       location=Location.DEFAULT, policy=None,

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -171,7 +171,7 @@ class S3Connection(AWSAuthConnection):
                  calling_format=DefaultCallingFormat, path='/',
                  provider='aws', bucket_class=Bucket, security_token=None,
                  suppress_consec_slashes=True, anon=False,
-                 validate_certs=None, profile_name=None):
+                 validate_certs=None, profile_name=None, client_side_encryption_key=None):
         no_host_provided = False
         if host is NoHostProvided:
             no_host_provided = True
@@ -181,6 +181,7 @@ class S3Connection(AWSAuthConnection):
         self.calling_format = calling_format
         self.bucket_class = bucket_class
         self.anon = anon
+        self.client_side_encryption_key = client_side_encryption_key
         super(S3Connection, self).__init__(host,
                 aws_access_key_id, aws_secret_access_key,
                 is_secure, port, proxy, proxy_port, proxy_user, proxy_pass,
@@ -663,3 +664,4 @@ class S3Connection(AWSAuthConnection):
             override_num_retries=override_num_retries,
             retry_handler=retry_handler
         )
+

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -757,6 +757,7 @@ class Key(object):
             spos = None
             self.read_from_stream = False
 
+        size = size or self.size or None
         # If hash_algs is unset and the MD5 hasn't already been computed,
         # default to an MD5 hash_alg to hash the data on-the-fly.
         if hash_algs is None and not self.md5:
@@ -929,7 +930,7 @@ class Key(object):
             #if not self.base64md5:
             #    headers['Trailer'] = "Content-MD5"
         else:
-            headers['Content-Length'] = str(self.size)
+            headers['Content-Length'] = str(size)
         # This is terrible. We need a SHA256 of the body for SigV4, but to do
         # the chunked ``sender`` behavior above, the ``fp`` isn't available to
         # the auth mechanism (because closures). Detect if it's SigV4 & embelish

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -775,6 +775,7 @@ class Key(object):
                 # avoid setting bad data.
                 raise provider.storage_data_error(
                     'Cannot retry failed request. fp does not support seeking.')
+            sender_fp = fp
 
             # If the caller explicitly specified host header, tell putrequest
             # not to add a second host header. Similarly for accept-encoding.
@@ -821,9 +822,9 @@ class Key(object):
 
             bytes_togo = size
             if bytes_togo and bytes_togo < self.BufferSize:
-                chunk = fp.read(bytes_togo)
+                chunk = sender_fp.read(bytes_togo)
             else:
-                chunk = fp.read(self.BufferSize)
+                chunk = sender_fp.read(self.BufferSize)
 
             if not isinstance(chunk, bytes):
                 chunk = chunk.encode('utf-8')
@@ -852,9 +853,9 @@ class Key(object):
                         cb(data_len, cb_size)
                         i = 0
                 if bytes_togo and bytes_togo < self.BufferSize:
-                    chunk = fp.read(bytes_togo)
+                    chunk = sender_fp.read(bytes_togo)
                 else:
-                    chunk = fp.read(self.BufferSize)
+                    chunk = sender_fp.read(self.BufferSize)
 
                 if not isinstance(chunk, bytes):
                     chunk = chunk.encode('utf-8')

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -930,7 +930,7 @@ class Key(object):
             spos = None
             self.read_from_stream = False
 
-        size = size or self.size or None
+        size = size or self.size
         md5, base64md5 = self.md5, self.base64md5
         iv, envelope_key, master_key = None, None, self.bucket.connection.client_side_encryption_key
         self.delete_metadata('x-amz-iv')
@@ -961,7 +961,7 @@ class Key(object):
 
             # Adjust the size to take the padding into account
             # If the size is a multiple of the block size (16 bytes), a full block will be added
-            if size and not chunked_transfer:
+            if size is not None and not chunked_transfer:
                 size += 16 - size % 16
 
         # If hash_algs is unset and the MD5 hasn't already been computed,

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -561,6 +561,9 @@ class Key(object):
     def update_metadata(self, d):
         self.metadata.update(d)
 
+    def delete_metadata(self, name):
+        self.metadata.pop(name, None)
+
     # convenience methods for setting/getting ACL
     def set_acl(self, acl_str, headers=None):
         if self.bucket is not None:

--- a/boto/s3/multipart.py
+++ b/boto/s3/multipart.py
@@ -252,6 +252,8 @@ class MultiPartUpload(object):
         """
         if part_num < 1:
             raise ValueError('Part numbers must be greater than zero')
+        if self.bucket.connection.client_side_encryption_key:
+            raise ValueError('Multipart upload with client-side encryption is not yet supported.')
         query_args = 'uploadId=%s&partNumber=%d' % (self.id, part_num)
         key = self.bucket.new_key(self.key_name)
         key.set_contents_from_file(fp, headers=headers, replace=replace,
@@ -289,6 +291,8 @@ class MultiPartUpload(object):
         """
         if part_num < 1:
             raise ValueError('Part numbers must be greater than zero')
+        if self.bucket.connection.client_side_encryption_key:
+            raise ValueError('Multipart upload with client-side encryption is not yet supported.')
         query_args = 'uploadId=%s&partNumber=%d' % (self.id, part_num)
         if start is not None and end is not None:
             rng = 'bytes=%s-%s' % (start, end)

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -994,7 +994,7 @@ def compute_md5(fp, buf_size=8192, size=None):
 def compute_hash(fp, buf_size=8192, size=None, hash_algorithm=md5):
     hash_obj = hash_algorithm()
     spos = fp.tell()
-    if size and size < buf_size:
+    if size is not None and size < buf_size:
         s = fp.read(size)
     else:
         s = fp.read(buf_size)

--- a/tests/integration/s3/test_client_side_encryption.java
+++ b/tests/integration/s3/test_client_side_encryption.java
@@ -1,0 +1,49 @@
+import py4j.GatewayServer;
+import com.amazonaws.services.s3.AmazonS3EncryptionClient;
+import com.amazonaws.util.Base64;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import com.amazonaws.services.s3.model.EncryptionMaterials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import org.apache.commons.io.IOUtils;
+import java.nio.charset.StandardCharsets;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import java.io.FileInputStream;
+
+public class BotoS3Gateway {
+
+    public AmazonS3EncryptionClient getClient(String accessKey, String secretKey, String base64EncryptionKey) throws Exception {
+        SecretKey encryptionKey = new SecretKeySpec(Base64.decode(base64EncryptionKey), "AES");
+        EncryptionMaterials encryptionMaterials = new EncryptionMaterials(encryptionKey);
+
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        AmazonS3EncryptionClient s3 = new AmazonS3EncryptionClient(credentials, encryptionMaterials);
+
+        return s3;
+    }
+
+    public void putString(String accessKey, String secretKey, String base64EncryptionKey, String bucketName, String key, String content) throws Exception {
+        AmazonS3EncryptionClient s3 = getClient(accessKey, secretKey, base64EncryptionKey);
+        s3.putObject(bucketName, key, IOUtils.toInputStream(content, StandardCharsets.UTF_8.name()), new ObjectMetadata());
+    }
+
+    public void putFile(String accessKey, String secretKey, String base64EncryptionKey, String bucketName, String key, String filename) throws Exception {
+        AmazonS3EncryptionClient s3 = getClient(accessKey, secretKey, base64EncryptionKey);
+        FileInputStream fileInputStream = new FileInputStream(filename);
+        s3.putObject(bucketName, key, fileInputStream, new ObjectMetadata());
+        fileInputStream.close();
+    }
+
+    public String getString(String accessKey, String secretKey, String base64EncryptionKey, String bucketName, String key) throws Exception {
+        AmazonS3EncryptionClient s3 = getClient(accessKey, secretKey, base64EncryptionKey);
+        S3Object obj = s3.getObject(bucketName, key);
+        return IOUtils.toString(obj.getObjectContent(), StandardCharsets.UTF_8.name());
+    }
+
+    public static void main(String[] args) {
+        System.out.println("Starting gateway...");
+        GatewayServer gatewayServer = new GatewayServer(new BotoS3Gateway());
+        gatewayServer.start();
+    }
+}

--- a/tests/integration/s3/test_client_side_encryption.py
+++ b/tests/integration/s3/test_client_side_encryption.py
@@ -54,11 +54,11 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
         for encryption_key_index, encryption_key in enumerate(client_side_encryption_keys):
             encryption_key_hex = binascii.b2a_hex(encryption_key)
             encryption_key_base64 = binascii.b2a_base64(encryption_key)
-            print 'Key of size {}, hex={}, base64={}'.format(
+            print('Key of size {}, hex={}, base64={}'.format(
                 8 * len(encryption_key),
                 encryption_key_hex,
                 encryption_key_base64
-            )
+            ))
 
             encrypted_connection = S3Connection(client_side_encryption_key=encryption_key)
             encrypted_bucket = encrypted_connection.get_bucket(self.bucket_name)
@@ -75,7 +75,7 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
                 '0123456801234567' * 2**6 + '0',  # 1Kb content, needs padding
             ]
             for key_content_index, key_content in enumerate(key_contents):
-                print '\tTest using content {}'.format(key_content_index)
+                print('\tTest using content {}'.format(key_content_index))
 
                 methods = [
                     lambda key, content, filename, fp: key.set_contents_from_string(content),
@@ -85,7 +85,7 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
                     # lambda key, content, filename, fp: key.set_contents_from_stream(fp),
                 ]
                 for method_index, method in enumerate(methods):
-                    print '\t\tTest using method {}'.format(method_index)
+                    print('\t\tTest using method {}'.format(method_index))
 
                     key_size = len(key_content)
                     key_name = key_name_base.format(key_content_index=key_content_index,
@@ -190,7 +190,7 @@ class _TestWithJavaS3GatewayMixin(object):
                 url = base_url.format(base_package=base_package, package=package, version=version)
                 jar = '/tmp/{package}-{version}.jar'.format(package=package, version=version)
                 if not os.path.isfile(jar):
-                    print 'Downloading {}'.format(url)
+                    print('Downloading {}'.format(url))
                     urllib.URLopener().retrieve(url, jar)
                 jars.append(jar)
 
@@ -207,7 +207,7 @@ class _TestWithJavaS3GatewayMixin(object):
                 url = base_url.format(path=path, name=name, version=version)
                 jar = '/tmp/{name}-{version}.jar'.format(name=name, version=version)
                 if not os.path.isfile(jar):
-                    print 'Downloading {}'.format(url)
+                    print('Downloading {}'.format(url))
                     urllib.URLopener().retrieve(url, jar)
                 jars.append(jar)
 
@@ -220,7 +220,7 @@ class _TestWithJavaS3GatewayMixin(object):
         import psutil
         for process in psutil.process_iter():
             if 'BotoS3Gateway' in process.cmdline():
-                print 'Stopping gateway...'
+                print('Stopping gateway...')
                 process.kill()
                 time.sleep(1)
 
@@ -297,11 +297,11 @@ class S3ClientSideEncryptionTestJavaImplementationCompatibility(_TestWithJavaS3G
         for encryption_key_index, encryption_key in enumerate(client_side_encryption_keys):
             encryption_key_hex = binascii.b2a_hex(encryption_key)
             encryption_key_base64 = binascii.b2a_base64(encryption_key)
-            print 'Key of size {}, hex={}, base64={}'.format(
+            print('Key of size {}, hex={}, base64={}'.format(
                 8 * len(encryption_key),
                 encryption_key_hex,
                 encryption_key_base64
-            ).replace('\n', '')
+            ).replace('\n', ''))
 
             encrypted_connection = S3Connection(client_side_encryption_key=encryption_key)
             encrypted_bucket = encrypted_connection.get_bucket(self.bucket_name)
@@ -318,7 +318,7 @@ class S3ClientSideEncryptionTestJavaImplementationCompatibility(_TestWithJavaS3G
                 '0123456701234567' * 2**6 + '0',  # 1Kb content, needs padding
             ]
             for key_content_index, key_content in enumerate(key_contents):
-                print '\tTest using content {}'.format(key_content_index)
+                print('\tTest using content {}'.format(key_content_index))
 
                 methods = [
                     lambda a, b, c, d, e, content, filename: self.gateway.entry_point.putString(a, b, c, d,
@@ -327,7 +327,7 @@ class S3ClientSideEncryptionTestJavaImplementationCompatibility(_TestWithJavaS3G
                                                                                               e, filename),
                 ]
                 for method_index, method in enumerate(methods):
-                    print '\t\tTest using method {}'.format(method_index)
+                    print('\t\tTest using method {}'.format(method_index))
 
                     key_size = len(key_content)
                     key_name = key_name_base.format(key_content_index=key_content_index,

--- a/tests/integration/s3/test_client_side_encryption.py
+++ b/tests/integration/s3/test_client_side_encryption.py
@@ -12,6 +12,7 @@ import urllib2
 from pip.vendor.distlib.version import NormalizedVersion
 
 from boto.s3.connection import S3Connection
+from boto.s3.multipart import MultiPartUpload
 
 try:
     import psutil
@@ -148,6 +149,18 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
                         self.assertEqual(encrypted_key2.size, key_size)
 
         print('--- {} tests completed ---'.format(self.__class__.__name__))
+
+    def test_client_side_encryption_multipart(self):
+        print('--- running {} multipart tests ---'.format(self.__class__.__name__))
+
+        connection = S3Connection(client_side_encryption_key=os.urandom(256 / 8))
+        bucket = connection.get_bucket(self.bucket_name)
+
+        multipart_upload = MultiPartUpload(bucket)  # does not create an upload, so there's nothing to clean
+        self.assertRaises(ValueError, multipart_upload.upload_part_from_file, None, None)
+        self.assertRaises(ValueError, multipart_upload.copy_part_from_key, None, None, None)
+
+        print('--- tests {} multipart tests completed ---'.format(self.__class__.__name__))
 
 
 class _TestWithJavaS3GatewayMixin(object):

--- a/tests/integration/s3/test_client_side_encryption.py
+++ b/tests/integration/s3/test_client_side_encryption.py
@@ -9,6 +9,7 @@ import time
 import urllib
 import binascii
 import urllib2
+from StringIO import StringIO
 from pip.vendor.distlib.version import NormalizedVersion
 
 from boto.s3.connection import S3Connection
@@ -77,10 +78,18 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
             for key_content_index, key_content in enumerate(key_contents):
                 print('\tTest using content {}'.format(key_content_index))
 
+                def set_content_from_file_with_too_much_content(key, content, filename, fp):
+                    """
+                    Add extra content add the end of the file to make sure that the size parameter works properly
+                    """
+                    content = fp.read()
+                    key.set_contents_from_file(StringIO(content + 'abcde'), size=len(content))
+
                 methods = [
                     lambda key, content, filename, fp: key.set_contents_from_string(content),
                     lambda key, content, filename, fp: key.set_contents_from_filename(filename),
                     lambda key, content, filename, fp: key.set_contents_from_file(fp),
+                    set_content_from_file_with_too_much_content,
                     # BotoClientError: s3 does not support chunked transfer
                     # lambda key, content, filename, fp: key.set_contents_from_stream(fp),
                 ]

--- a/tests/integration/s3/test_client_side_encryption.py
+++ b/tests/integration/s3/test_client_side_encryption.py
@@ -9,8 +9,19 @@ import time
 import urllib
 import binascii
 import urllib2
+from pip.vendor.distlib.version import NormalizedVersion
 
 from boto.s3.connection import S3Connection
+
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
+try:
+    import py4j
+except ImportError:
+    py4j = None
 
 
 class S3ClientSideEncryptionTest(unittest.TestCase):
@@ -135,5 +146,213 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
                         encrypted_key2 = encrypted_bucket.new_key(key_name)
                         decrypted_content2 = encrypted_key2.get_contents_as_string()
                         self.assertEqual(encrypted_key2.size, key_size)
+
+        print('--- {} tests completed ---'.format(self.__class__.__name__))
+
+
+class _TestWithJavaS3GatewayMixin(object):
+    jars = None
+    gateway = None
+
+    @classmethod
+    def _get_classpath(cls):
+
+        if not cls.jars:
+            aws_java_sdk_version = '1.8.11'
+
+            manifest_url = 'https://raw.githubusercontent.com/aws/aws-sdk-java/{}/META-INF/MANIFEST.MF'.format(aws_java_sdk_version)
+            manifest_lines = urllib2.urlopen(manifest_url).read().split('\n')
+            bundle_lines = [line for line in manifest_lines if 'bundle-version' in line]
+            bundles = [(line.split(';')[0].split(' ')[-1], line.split('"')[1]) for line in bundle_lines]
+
+            jars = []
+            for package, version in bundles:
+                base_package = package.rsplit('.', 1)[0]
+                if 'jackson' in package:
+                    version = '2.0.2'
+                if 'javax.mail' in package:
+                    base_package = package
+                base_url = "http://repository.springsource.com/ivy/bundles/external/{base_package}/com.springsource.{package}/{version}/com.springsource.{package}-{version}.jar"
+                url = base_url.format(base_package=base_package, package=package, version=version)
+                jar = '/tmp/{package}-{version}.jar'.format(package=package, version=version)
+                if not os.path.isfile(jar):
+                    print 'Downloading {}'.format(url)
+                    urllib.URLopener().retrieve(url, jar)
+                jars.append(jar)
+
+            mvn_bundles = [
+                ('net/sf/py4j', 'py4j', '0.8.2'),
+                ('com/amazonaws', 'aws-java-sdk', aws_java_sdk_version),
+                ('org/apache/commons', 'commons-io', '1.3.2'),
+                ('joda-time', 'joda-time', '2.2'),
+            ]
+            if NormalizedVersion(aws_java_sdk_version) >= NormalizedVersion('1.8.10'):
+                mvn_bundles.append(('com/amazonaws', 'aws-java-sdk-core', aws_java_sdk_version))
+            for path, name, version in mvn_bundles:
+                base_url = "http://central.maven.org/maven2/{path}/{name}/{version}/{name}-{version}.jar"
+                url = base_url.format(path=path, name=name, version=version)
+                jar = '/tmp/{name}-{version}.jar'.format(name=name, version=version)
+                if not os.path.isfile(jar):
+                    print 'Downloading {}'.format(url)
+                    urllib.URLopener().retrieve(url, jar)
+                jars.append(jar)
+
+            cls.jars = jars
+
+        return ':'.join(['.'] + cls.jars)
+
+    @classmethod
+    def _stop_gateway(cls):
+        import psutil
+        for process in psutil.process_iter():
+            if 'BotoS3Gateway' in process.cmdline():
+                print 'Stopping gateway...'
+                process.kill()
+                time.sleep(1)
+
+    @classmethod
+    def _build_gateway(cls):
+        src_filename = __file__.replace('.pyc', '.java').replace('.py', '.java')
+        dst_filename = '/tmp/BotoS3Gateway.java'
+        if os.path.isfile(dst_filename):
+            os.remove(dst_filename)
+        shutil.copy(src_filename, dst_filename)
+        subprocess.check_output(
+            [
+                'javac',
+                '-cp',
+                cls._get_classpath(),
+                dst_filename
+            ],
+            cwd='/tmp',
+        )
+
+    @classmethod
+    def _start_gateway(cls):
+        subprocess.Popen(
+            [
+                'java',
+                '-cp',
+                cls._get_classpath(),
+                'BotoS3Gateway',
+            ],
+            cwd='/tmp',
+        )
+        time.sleep(3)
+        from py4j.java_gateway import JavaGateway
+        cls.gateway = JavaGateway()
+
+    def setUp(self):
+        super(_TestWithJavaS3GatewayMixin, self).setUp()
+        self._stop_gateway()
+        self._build_gateway()
+        self._start_gateway()
+
+    def tearDown(self):
+        self._stop_gateway()
+        super(_TestWithJavaS3GatewayMixin, self).tearDown()
+
+
+class S3ClientSideEncryptionTestJavaImplementationCompatibility(_TestWithJavaS3GatewayMixin, unittest.TestCase):
+    s3 = True
+
+    def setUp(self):
+        super(S3ClientSideEncryptionTestJavaImplementationCompatibility, self).setUp()
+        self.conn = S3Connection()
+        self.bucket_name = 'client-side-encryption-%d' % int(time.time())
+        self.bucket = self.conn.create_bucket(self.bucket_name)
+
+    def tearDown(self):
+        for key in self.bucket:
+            key.delete()
+        self.bucket.delete()
+        super(S3ClientSideEncryptionTestJavaImplementationCompatibility, self).setUp()
+
+    @unittest.skipIf(not psutil or not py4j, "Please install psutil and py4j to run this test")
+    def test_client_side_encryption_java_compatibility(self):
+        print('--- running {} tests ---'.format(self.__class__.__name__))
+
+        client_side_encryption_keys = [
+            ''.join([chr(0)] * (128 / 8)),  # Zero-key, AES 128
+            ''.join([chr(0)] * (192 / 8)),  # Zero-key, AES 192
+            ''.join([chr(0)] * (256 / 8)),  # Zero-key, AES 256
+            os.urandom(128 / 8),  # Random-key, AES 128
+            os.urandom(192 / 8),  # Random-key, AES 192
+            os.urandom(256 / 8),  # Random-key, AES 256
+        ]
+        for encryption_key_index, encryption_key in enumerate(client_side_encryption_keys):
+            encryption_key_hex = binascii.b2a_hex(encryption_key)
+            encryption_key_base64 = binascii.b2a_base64(encryption_key)
+            print 'Key of size {}, hex={}, base64={}'.format(
+                8 * len(encryption_key),
+                encryption_key_hex,
+                encryption_key_base64
+            ).replace('\n', '')
+
+            encrypted_connection = S3Connection(client_side_encryption_key=encryption_key)
+            encrypted_bucket = encrypted_connection.get_bucket(self.bucket_name)
+
+            unencrypted_connection = S3Connection()
+            unencrypted_bucket = unencrypted_connection.get_bucket(self.bucket_name)
+
+            key_name_base = 'foo-{key_content_index}-encrypted-using-key-{encryption_key_index}'
+            key_contents = [
+                '0123456701234567',   # Small content, multiple of the block size (16)
+                '0123456701234567' + '0',  # Small content, needs padding
+                '0123456701234567' * 2**6,        # 1Kb content, multiple of the block size (16)
+                '0123456701234567' * 2**6 + '0',  # 1Kb content, needs padding
+            ]
+            for key_content_index, key_content in enumerate(key_contents):
+                print '\tTest using content {}'.format(key_content_index)
+
+                methods = [
+                    lambda a, b, c, d, e, content, filename: self.gateway.entry_point.putString(a, b, c, d,
+                                                                                                e, content),
+                    lambda a, b, c, d, e, content, filename: self.gateway.entry_point.putFile(a, b, c, d,
+                                                                                              e, filename),
+                ]
+                for method_index, method in enumerate(methods):
+                    print '\t\tTest using method {}'.format(method_index)
+
+                    key_size = len(key_content)
+                    key_name = key_name_base.format(key_content_index=key_content_index,
+                                                    encryption_key_index=encryption_key_index)
+                    encrypted_key = encrypted_bucket.new_key(key_name)
+                    unencrypted_key = unencrypted_bucket.new_key(key_name)
+
+                    key_content_filename = '/tmp/{}'.format(key_name)
+                    with open(key_content_filename, 'w') as key_content_fp:
+                        key_content_fp.write(key_content)
+
+                    access_key = unencrypted_connection.provider.access_key
+                    secret_key = unencrypted_connection.provider.secret_key
+
+                    # To make debugging easier if something fails later, test the java encryption
+                    method(access_key, secret_key, encryption_key_base64,
+                           self.bucket_name, key_name,
+                           key_content, key_content_filename)
+                    raw_content = unencrypted_key.get_contents_as_string()
+                    self.assertNotEqual(key_content, raw_content)
+                    decrypted_content = self.gateway.entry_point.getString(access_key, secret_key,
+                                                                           encryption_key_base64,
+                                                                           self.bucket_name, key_name)
+                    self.assertEqual(key_content, decrypted_content)
+
+                    # Encrypt with python, decrypt with java
+                    encrypted_key.set_contents_from_string(key_content)
+                    decrypted_content = self.gateway.entry_point.getString(access_key, secret_key, encryption_key_base64,
+                                                                           self.bucket_name, key_name)
+                    self.assertEqual(key_content, decrypted_content)
+
+                    # Encrypt with java, decrypt with python
+                    method(access_key, secret_key, encryption_key_base64,
+                           self.bucket_name, key_name,
+                           key_content, key_content_filename)
+                    decrypted_content = encrypted_key.get_contents_as_string()
+                    self.assertEqual(key_content, decrypted_content)
+                    # When sending the size in java like in these tests, the original size
+                    # of the file won't be set. Test that it's handled properly
+                    self.assertEqual(key_content, decrypted_content)
+                    self.assertEqual(encrypted_key.size, key_size)
 
         print('--- {} tests completed ---'.format(self.__class__.__name__))

--- a/tests/integration/s3/test_client_side_encryption.py
+++ b/tests/integration/s3/test_client_side_encryption.py
@@ -68,6 +68,7 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
 
             key_name_base = 'foo-{key_content_index}-encrypted-using-key-{encryption_key_index}-method-{method_index}'
             key_contents = [
+                '',   # Empty content, edge case
                 '0123456701234567',   # Small content, multiple of the block size (16)
                 '0123456701234567' + '0',  # Small content, needs padding
                 '0123456701234567' * 2**6,        # 1Kb content, multiple of the block size (16)
@@ -310,6 +311,7 @@ class S3ClientSideEncryptionTestJavaImplementationCompatibility(_TestWithJavaS3G
 
             key_name_base = 'foo-{key_content_index}-encrypted-using-key-{encryption_key_index}'
             key_contents = [
+                '',   # Empty content, edge case
                 '0123456701234567',   # Small content, multiple of the block size (16)
                 '0123456701234567' + '0',  # Small content, needs padding
                 '0123456701234567' * 2**6,        # 1Kb content, multiple of the block size (16)

--- a/tests/integration/s3/test_client_side_encryption.py
+++ b/tests/integration/s3/test_client_side_encryption.py
@@ -1,0 +1,139 @@
+"""
+Some unit tests for the S3 Client Side Encryption
+"""
+import os
+import shutil
+import subprocess
+import unittest
+import time
+import urllib
+import binascii
+import urllib2
+
+from boto.s3.connection import S3Connection
+
+
+class S3ClientSideEncryptionTest(unittest.TestCase):
+    s3 = True
+
+    def setUp(self):
+        super(S3ClientSideEncryptionTest, self).setUp()
+        self.conn = S3Connection()
+        self.bucket_name = 'client-side-encryption-%d' % int(time.time())
+        self.bucket = self.conn.create_bucket(self.bucket_name)
+
+    def tearDown(self):
+        for key in self.bucket:
+            key.delete()
+        self.bucket.delete()
+        super(S3ClientSideEncryptionTest, self).tearDown()
+
+    def test_client_side_encryption(self):
+        print('--- running {} tests ---'.format(self.__class__.__name__))
+
+        client_side_encryption_keys = [
+            ''.join([chr(0)] * (128 / 8)),  # Zero-key, AES 128
+            ''.join([chr(0)] * (192 / 8)),  # Zero-key, AES 192
+            ''.join([chr(0)] * (256 / 8)),  # Zero-key, AES 256
+            os.urandom(128 / 8),  # Random-key, AES 128
+            os.urandom(192 / 8),  # Random-key, AES 192
+            os.urandom(256 / 8),  # Random-key, AES 256
+        ]
+        for encryption_key_index, encryption_key in enumerate(client_side_encryption_keys):
+            encryption_key_hex = binascii.b2a_hex(encryption_key)
+            encryption_key_base64 = binascii.b2a_base64(encryption_key)
+            print 'Key of size {}, hex={}, base64={}'.format(
+                8 * len(encryption_key),
+                encryption_key_hex,
+                encryption_key_base64
+            )
+
+            encrypted_connection = S3Connection(client_side_encryption_key=encryption_key)
+            encrypted_bucket = encrypted_connection.get_bucket(self.bucket_name)
+
+            unencrypted_connection = S3Connection()
+            unencrypted_bucket = unencrypted_connection.get_bucket(self.bucket_name)
+
+            key_name_base = 'foo-{key_content_index}-encrypted-using-key-{encryption_key_index}-method-{method_index}'
+            key_contents = [
+                '0123456701234567',   # Small content, multiple of the block size (16)
+                '0123456701234567' + '0',  # Small content, needs padding
+                '0123456701234567' * 2**6,        # 1Kb content, multiple of the block size (16)
+                '0123456801234567' * 2**6 + '0',  # 1Kb content, needs padding
+            ]
+            for key_content_index, key_content in enumerate(key_contents):
+                print '\tTest using content {}'.format(key_content_index)
+
+                methods = [
+                    lambda key, content, filename, fp: key.set_contents_from_string(content),
+                    lambda key, content, filename, fp: key.set_contents_from_filename(filename),
+                    lambda key, content, filename, fp: key.set_contents_from_file(fp),
+                    # BotoClientError: s3 does not support chunked transfer
+                    # lambda key, content, filename, fp: key.set_contents_from_stream(fp),
+                ]
+                for method_index, method in enumerate(methods):
+                    print '\t\tTest using method {}'.format(method_index)
+
+                    key_size = len(key_content)
+                    key_name = key_name_base.format(key_content_index=key_content_index,
+                                                    encryption_key_index=encryption_key_index,
+                                                    method_index=method_index)
+
+                    key_content_filename = '/tmp/{}'.format(key_name)
+                    with open(key_content_filename, 'w') as key_content_fp:
+                        key_content_fp.write(key_content)
+
+                    # Encrypted content shouldn't be readable
+                    with open(key_content_filename, 'r') as key_content_fp:
+                        encrypted_key = encrypted_bucket.new_key(key_name)
+                        unencrypted_key = unencrypted_bucket.new_key(key_name)
+                        method(encrypted_key, key_content, key_content_filename, key_content_fp)
+                        raw_content = unencrypted_key.get_contents_as_string()
+                        decrypted_content = encrypted_key.get_contents_as_string()
+                        self.assertNotEqual(key_content, raw_content)
+                        self.assertEqual(key_content, decrypted_content)
+
+                    # Unencrypted content should still be readable
+                    # (files stored in clear can still be read)
+                    with open(key_content_filename, 'r') as key_content_fp:
+                        encrypted_key = encrypted_bucket.new_key(key_name)
+                        unencrypted_key = unencrypted_bucket.new_key(key_name)
+                        method(unencrypted_key, key_content, key_content_filename, key_content_fp)
+                        raw_content = unencrypted_key.get_contents_as_string()
+                        decrypted_content = encrypted_key.get_contents_as_string()
+                        self.assertEqual(key_content, raw_content)
+                        self.assertEqual(key_content, decrypted_content)
+
+                    # Successive GET should return the same value (checks internal state/caching)
+                    with open(key_content_filename, 'r') as key_content_fp:
+                        encrypted_key = encrypted_bucket.new_key(key_name)
+                        method(encrypted_key, key_content, key_content_filename, key_content_fp)
+                        decrypted_content1 = encrypted_key.get_contents_as_string()
+                        decrypted_content2 = encrypted_key.get_contents_as_string()
+                        self.assertEqual(key_content, decrypted_content1)
+                        self.assertEqual(key_content, decrypted_content2)
+
+                    # PUT/GET x2 using the same key object
+                    # This checks if the iv and the key are updated properly
+                    encrypted_key = encrypted_bucket.new_key(key_name)
+                    with open(key_content_filename, 'r') as key_content_fp:
+                        method(encrypted_key, key_content, key_content_filename, key_content_fp)
+                        decrypted_content1 = encrypted_key.get_contents_as_string()
+                    with open(key_content_filename, 'r') as key_content_fp:
+                        method(encrypted_key, key_content, key_content_filename, key_content_fp)
+                        decrypted_content2 = encrypted_key.get_contents_as_string()
+                    self.assertEqual(key_content, decrypted_content1)
+                    self.assertEqual(key_content, decrypted_content2)
+
+                    # Check that the size is correct
+                    with open(key_content_filename, 'r') as key_content_fp:
+                        # The size should be set after an upload
+                        encrypted_key1 = encrypted_bucket.new_key(key_name)
+                        method(encrypted_key1, key_content, key_content_filename, key_content_fp)
+                        self.assertEqual(encrypted_key1.size, key_size)
+                        # The size should be set after a download
+                        encrypted_key2 = encrypted_bucket.new_key(key_name)
+                        decrypted_content2 = encrypted_key2.get_contents_as_string()
+                        self.assertEqual(encrypted_key2.size, key_size)
+
+        print('--- {} tests completed ---'.format(self.__class__.__name__))

--- a/tests/unit/s3/test_key.py
+++ b/tests/unit/s3/test_key.py
@@ -86,6 +86,7 @@ class TestS3Key(AWSMockServiceTestCase):
         # Mock out the bucket object - we really only care about calls
         # to list.
         k.bucket = mock.MagicMock()
+        k.bucket.connection.client_side_encryption_key = None
 
         # Default behavior doesn't call list
         k.set_contents_from_string('test')


### PR DESCRIPTION
## Overview

This pull request adds client-side encryption in boto using AES 256 in CBC mode.

It uses a process called [envelope encryption](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html) (Each file is encrypted using a different envelope key. The envelope key is encrypted with the master key and stored in the metadata. The master key can be rotated.). It is meant to be compatible with the [implementation provided in the AWS SDK for Java](http://aws.amazon.com/articles/2850096021478074) (this means that you can encrypt with java and decrypt with python or the other way around).

Some functionalities are voluntarily left out for further pull requests:
- Key pairs. At the moment, only AES symmetric keys  of 128, 192 and 256 bits are supported. This wouldn't be a big change but it will require some extra compatibility testing with the java implementation.
- Multipart upload. Some extra code and tests have to be added to handle the padding properly. Please note that CBC is not suitable for parallel uploading.
- [Client-Side Authenticated Encryption](http://java.awsblog.com/post/Tx3305Q4J6AVNQK/Amazon-S3-Client-Side-Authenticated-Encryption). This uses AES-GCM. Besides from the extra integrity check, I think this could be used to for parallel uploading.

There's one related pull-request,  #1453. 
## Usage

To enable the feature, you just need to instantiate you connection with your key. That's it.

``` python
# Zero-key, please use your own key
encryption_key = ''.join([chr(0)] * (256 / 8))

connection = S3Connection(client_side_encryption_key=encryption_key)
bucket = connection.get_bucket('your-bucket')
key = bucket.new_key('your-key')
key.set_contents_from_filename('your-file')
# Thi file is now in S3, encrypted

content = key.get_contents_as_string()

```

Your buckets can contain encrypted and plain text files. The unencrypted files will be accessible as usual. Any new or updated file will be transparently encrypted when sent to S3.

The encryption is transparent. For example, the attributes `key.md5` and `key.size` won't change (even if the encrypted file will be up to 16 bytes larger)

It is also efficient:
- The file will be process at most onet extra time to get it's encrypted md5.
- And it's processed on-the-fly, which will greatly limit the memory usage of the encryption.
## Implementation

The encryption is done using `pycrypto` which it already a requirement of boto (indirectly, via `paramiko`).

I added two private classes, `_AESEncryptor` and `_AESDecryptor` that implement partially the interface of [`RawIOBase`](https://docs.python.org/2/library/io.html#io.RawIOBase). They are used:
- to replace the file pointer when sending a file
- in conjunction with `_Delegator` to replace the response when receiving a file

As AES is operating in blocks of 16 bytes, some padding bytes have to be added at the end of the files. Each byte of the padding will contain it's size. The size of the padding will always be `16 - len(file) % 16` (so always at least one byte). This is the convention followed by the java implementation.
## Testing

I added two kinds of integration tests:
- Correctness tests (`S3ClientSideEncryptionTest`). They test what's described above with different key sizes, different content (to force the encryption in one or many `read()`, to use different sizes of padding), and different methods of the `Key` object.
- Cross-compatibility tests (`S3ClientSideEncryptionTestJavaImplementationCompatibility`). They test that files encrypted with java can be downloaded with python and vice versa. They use the same combinations of keys and contents as the correctness tests. Tu run these tests, you need to install `psutil` and `py4j`. I added some code to download the AWS SDK for java and it's dependencies. And a java file...

I tested on Linux Mint Debian using python 2.7.5. The code hasn't been tested with Google Cloud Storage.
