### PR TITLE
Fix Amazon Cognito links in docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,8 +73,8 @@ Currently Supported Services
   * :doc:`Simple Queue Service (SQS) <sqs_tut>` -- (:doc:`API Reference <ref/sqs>`) (Python 3)
   * Simple Notification Service (SNS) -- (:doc:`API Reference <ref/sns>`) (Python 3)
   * :doc:`Simple Email Service (SES) <ses_tut>` -- (:doc:`API Reference <ref/ses>`) (Python 3)
-  * Amazon Cognito Identity -- (:doc:`API Reference <ref/cognito-identity`) (Python 3)
-  * Amazon Cognito Sync -- (:doc:`API Reference <ref/cognito-sync`) (Python 3)
+  * Amazon Cognito Identity -- (:doc:`API Reference <ref/cognito-identity>`) (Python 3)
+  * Amazon Cognito Sync -- (:doc:`API Reference <ref/cognito-sync>`) (Python 3)
 
 * **Monitoring**
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,6 @@
 requests>=1.2.3,<=2.0.1
 rsa==3.1.4
-Sphinx==1.1.3
+Sphinx>=1.1.3,<1.3
 simplejson==3.5.2
 argparse==1.2.1
 paramiko>=1.10.0


### PR DESCRIPTION
This should fix the ReadTheDocs links. Also got rid of the `requirements-docs.txt` since we do not use it anymore.

@danielgtaylor @jamesls 
