### PR TITLE
Modify vpc attr

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1107,7 +1107,7 @@ class AWSQueryConnection(AWSAuthConnection):
                                                     self.host)
         if action:
             http_request.params['Action'] = action
-        if self.APIVersion and http_request.params.get('Version') is None:
+        if self.APIVersion and http_request.params.get('Version', None) is None:
             http_request.params['Version'] = self.APIVersion
         return self._mexe(http_request)
 

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -4462,12 +4462,12 @@ class EC2Connection(AWSQueryConnection):
 
     def modify_subnet_attribute(self, subnet_id, auto_assign_public_ip=None, dry_run=False):
         params = {'SubnetId': subnet_id}
+        params['Version'] = '2014-06-15'
         if auto_assign_public_ip is not None:
             if auto_assign_public_ip:
                 params['MapPublicIpOnLaunch.Value'] = 'true'
             else:
                 params['MapPublicIpOnLaunch.Value'] = 'false'
-        params['Version'] = '2014-06-15'
         if dry_run:
             params['DryRun'] = 'true'
         return self.get_status('ModifySubnetAttribute', params)


### PR DESCRIPTION
ModifySubnetAttribute implementation under boto/ec2.

As @markdoliner pointed out, this action was added in a newer version of AWS API thus I added the option to override the Version parameter explicitly. 
