### PR TITLE
removed support for billingProducts in ec2.image and updated docs

### DIFF
--- a/boto/ec2/image.py
+++ b/boto/ec2/image.py
@@ -33,18 +33,32 @@ class ProductCodes(list):
             self.append(value)
 
 
-class BillingProducts(list):
-    def startElement(self, name, attrs, connection):
-        pass
-
-    def endElement(self, name, value, connection):
-        if name == 'billingProduct':
-            self.append(value)
-
-
 class Image(TaggedEC2Object):
     """
     Represents an EC2 Image
+
+    :ivar architecture: The architecture of the image (i386 or x86_64) 
+    :ivar block_device_mapping: The Block Device Mapping for the image.
+    :ivar description: The description of the Image, provided during image creation.
+    :ivar hypervisor: The Hypervisor type (xen or ovm).
+    :ivar id: The unique ID of this Image.
+    :ivar is_public: Whether or not the image is publicly visible.
+    :ivar kernel_id: The unique ID of the kernal associated with the Image.
+    :ivar location: The location of the Image manifest.
+    :ivar name: The name of the Image, provided during image creation.
+    :ivar ownerId: The unique ID of the owner of the Image.
+    :ivar owner_alias: The AWS account alias for the owner_id.
+    :ivar owner_id: The unique ID of the owner of the Image.
+    :ivar platform: The platform of the image.
+    :ivar product_codes: The product codes, if any, attached to the Image.
+    :ivar ramdisk_id: The unique ID of the ramdisk associated with the Image.
+    :ivar root_device_name: The name of the root device volume.
+    :ivar root_device_type: The type of the root device volume (ebs or instance-store).
+    :ivar sriov_net_support: Whether enhanced networking is enabled (simple or None).
+    :ivar state: The string representation of the image's current state.
+    :ivar type: The image type (machine, kernel, or ramdisk).
+    :ivar virtualization_type: The virtualization type (paravirtual or hvm).
+
     """
 
     def __init__(self, connection=None):
@@ -64,13 +78,11 @@ class Image(TaggedEC2Object):
         self.name = None
         self.description = None
         self.product_codes = ProductCodes()
-        self.billing_products = BillingProducts()
         self.block_device_mapping = None
         self.root_device_type = None
         self.root_device_name = None
         self.virtualization_type = None
         self.hypervisor = None
-        self.instance_lifecycle = None
         self.sriov_net_support = None
 
     def __repr__(self):
@@ -85,8 +97,6 @@ class Image(TaggedEC2Object):
             return self.block_device_mapping
         elif name == 'productCodes':
             return self.product_codes
-        elif name == 'billingProducts':
-            return self.billing_products
         else:
             return None
 

--- a/boto/ec2/instance.py
+++ b/boto/ec2/instance.py
@@ -201,7 +201,6 @@ class Instance(TaggedEC2Object):
     :ivar root_device_type: The root device type (ebs|instance-store).
     :ivar block_device_mapping: The Block Device Mapping for the instance.
     :ivar state_reason: The reason for the most recent state transition.
-    :ivar groups: List of security Groups associated with the instance.
     :ivar interfaces: List of Elastic Network Interfaces associated with
         this instance.
     :ivar ebs_optimized: Whether instance is using optimized EBS volumes

--- a/tests/unit/ec2/test_connection.py
+++ b/tests/unit/ec2/test_connection.py
@@ -742,11 +742,6 @@ class TestGetAllImages(TestEC2ConnectionBase):
             <viridianEnabled>true</viridianEnabled>
             <name>Windows Test</name>
             <description>Windows Test Description</description>
-            <billingProducts>
-                        <item>
-                                <billingProduct>bp-6ba54002</billingProduct>
-                        </item>
-                        </billingProducts>
             <rootDeviceType>ebs</rootDeviceType>
             <rootDeviceName>/dev/sda1</rootDeviceName>
             <blockDeviceMapping>
@@ -805,10 +800,6 @@ class TestGetAllImages(TestEC2ConnectionBase):
         self.assertEquals("hvm", parsed[0].virtualization_type)
         self.assertEquals("xen", parsed[0].hypervisor)
         self.assertEquals(None, parsed[0].instance_lifecycle)
-
-        # 1 billing product parsed into a list
-        self.assertEquals(1, len(parsed[0].billing_products))
-        self.assertEquals("bp-6ba54002", parsed[0].billing_products[0])
 
         # Just verify length, there is already a block_device_mapping test
         self.assertEquals(5, len(parsed[0].block_device_mapping))


### PR DESCRIPTION
- removed references to billingProducts in ec2.image and associated tests because despite the discussion in #1703, I cannot find references in any of the AWS EC2 wsdls supplied here (https://aws.amazon.com/releasenotes/Amazon-EC2) which contain a billingProducts element.
- removed references to instanceLifecycle in ec2.image for reasons similar to above
- added class variable documentation to ec2.image
- removed duplicate entry for groups in class variable documentation for ec2.instance
