### PR TITLE
Fix s3 create multipart upload for sigv4

### DIFF
--- a/tests/integration/s3/test_multipart.py
+++ b/tests/integration/s3/test_multipart.py
@@ -173,8 +173,6 @@ class S3MultiPartUploadSigV4Test(unittest.TestCase):
     s3 = True
 
     def setUp(self):
-        copy_env = os.environ.copy()
-        copy_env['S3_USE_SIGV4'] = True
         self.env_patch = mock.patch('os.environ', {'S3_USE_SIGV4': True})
         self.env_patch.start()
         self.conn = boto.s3.connect_to_region('us-west-2')


### PR DESCRIPTION
Fixes https://github.com/boto/boto/issues/2609

The changes I made should only affect POST requests for s3 while using sigv4.  Behavior for other services will remain the same. I originally removed::

```
    if http_request.method == 'POST':
        return ""
```

in the `canonical_query_string` method. However, this cause integration test failures in services like `sqs`. So, I reverted and overwrote this method specifically for s3.  CreateMultipartUpload now works for s3-sigv4.

cc @danielgtaylor @jamesls 
