### PR TITLE
Updated endpoints.json for cloudwatch logs to support more regions

### DIFF
--- a/boto/endpoints.json
+++ b/boto/endpoints.json
@@ -205,7 +205,9 @@
         "ap-northeast-1": "kinesis.ap-northeast-1.amazonaws.com"
     },
     "logs": {
-        "us-east-1": "logs.us-east-1.amazonaws.com"
+        "us-east-1": "logs.us-east-1.amazonaws.com",
+        "us-west-2": "logs.us-west-2.amazonaws.com",
+        "eu-west-1": "logs.eu-west-1.amazonaws.com"
     },
     "opsworks": {
         "us-east-1": "opsworks.us-east-1.amazonaws.com"


### PR DESCRIPTION
Amazon now support `us-east-1`, `us-west-2` and `eu-west-1` for cloudwatch logs, but BOTO currently doesn't support these regions.

See https://aws.amazon.com/cloudwatch/faqs/ under "Log Monitoring" for supported regions
