### PR TITLE
Parse ClusterStatus’es StateChangeReason.

### DIFF
--- a/boto/emr/emrobject.py
+++ b/boto/emr/emrobject.py
@@ -201,6 +201,11 @@ class ClusterTimeline(EmrObject):
         'EndDateTime'
     ])
 
+class ClusterStateChangeReason(EmrObject):
+    Fields = set([
+        'Code',
+        'Message'
+    ])
 
 class ClusterStatus(EmrObject):
     Fields = set([
@@ -217,6 +222,9 @@ class ClusterStatus(EmrObject):
         if name == 'Timeline':
             self.timeline = ClusterTimeline()
             return self.timeline
+        elif name == 'StateChangeReason':
+            self.statechangereason = ClusterStateChangeReason()
+            return self.statechangereason
         else:
             return None
 

--- a/tests/unit/emr/test_connection.py
+++ b/tests/unit/emr/test_connection.py
@@ -27,7 +27,7 @@ from tests.unit import AWSMockServiceTestCase
 
 from boto.emr.connection import EmrConnection
 from boto.emr.emrobject import BootstrapAction, BootstrapActionList, \
-                               ClusterStatus, ClusterSummaryList, \
+                               ClusterStateChangeReason, ClusterStatus, ClusterSummaryList, \
                                ClusterSummary, ClusterTimeline, InstanceInfo, \
                                InstanceList, InstanceGroupInfo, \
                                InstanceGroup, InstanceGroupList, JobFlow, \
@@ -110,6 +110,9 @@ class TestListClusters(AWSMockServiceTestCase):
         self.assertEqual(response.clusters[0].status.timeline.readydatetime, '2014-01-24T01:25:26Z')
         self.assertEqual(response.clusters[0].status.timeline.enddatetime, '2014-01-24T02:19:46Z')
 
+        self.assertTrue(isinstance(response.clusters[0].status.statechangereason, ClusterStateChangeReason))
+        self.assertEqual(response.clusters[0].status.statechangereason.code, 'USER_REQUEST')
+        self.assertEqual(response.clusters[0].status.statechangereason.message, 'Terminated by user request')
 
     def test_list_clusters_created_before(self):
         self.set_http_response(status_code=200)


### PR DESCRIPTION
I've ran into this issue when writing code to detect the EMR cluster's demise reason. Turns out Boto wasn't parsing [**it.**](http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_ClusterStateChangeReason.html)

Here's the patch. And here it is in action:

```
>>> import boto, boto.emr
>>> emr = boto.emr.connect_to_region('us-east-1')
>>> cs=emr.list_clusters().clusters
>>> cs[0]
<boto.emr.emrobject.ClusterSummary object at 0x106829790>
>>> cs[0].status
<boto.emr.emrobject.ClusterStatus object at 0x106829710>
>>> cs[0].status.state
u'TERMINATED'
>>> cs[0].status.statechangereason
<boto.emr.emrobject.ClusterStateChangeReason object at 0x10688e490>
>>> cs[0].status.statechangereason.code
u'USER_REQUEST'
>>> cs[0].status.statechangereason.message
u'Terminated by user request'
```
