### PR TITLE
glacier: forcing vault_name to be str, fixes #2603

### DIFF
--- a/boto/glacier/layer1.py
+++ b/boto/glacier/layer1.py
@@ -1273,7 +1273,7 @@ class Layer1(AWSAuthConnection):
                    'x-amz-sha256-tree-hash': tree_hash,
                    'Content-Range': 'bytes %d-%d/*' % byte_range}
         response_headers = [('x-amz-sha256-tree-hash', u'TreeHash')]
-        uri = 'vaults/%s/multipart-uploads/%s' % (vault_name, upload_id)
+        uri = 'vaults/%s/multipart-uploads/%s' % (str(vault_name), upload_id)
         return self.make_request('PUT', uri, headers=headers,
                                  data=part_data, ok_responses=(204,),
                                  response_headers=response_headers)


### PR DESCRIPTION
`vault_name` being `unicode` will make the whole `uri` an unicode in Python 2, thus `self._buffer` in httplib.py (around L842) will have an unicode element like this:
```
u'PUT /-/vaults/backups/multipart-uploads/<hidden> HTTP/1.1'
```
Which will make `msg` a unicode too, and that's why it fails.

To test with the problem, you need a large file (>100M) to trigger the routine, and the command line script `glacier` could be used. As far as I have tested, forcing `vault_name` a `str` will fix #2603 for me, and did not make Python 3's situation worse (it's still broken for Python 3, but that is a different issue).

I have tried to write a test case for this, but didn't understand quite well about how to mock and get the result. On the other hand, the problem is quite straightforward, so maybe it can be merged without a test?

Hope this helps :)