### PR TITLE
added sig v4 to ec2.elb.ELBConnection via detect_potential_sigv4 

### DIFF
--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -25,6 +25,7 @@
 This module provides an interface to the Elastic Compute Cloud (EC2)
 load balancing service from AWS.
 """
+from boto.auth import detect_potential_sigv4
 from boto.connection import AWSQueryConnection
 from boto.ec2.instanceinfo import InstanceInfo
 from boto.ec2.elb.loadbalancer import LoadBalancer, LoadBalancerZones
@@ -97,6 +98,7 @@ class ELBConnection(AWSQueryConnection):
                                             validate_certs=validate_certs,
                                             profile_name=profile_name)
 
+    @detect_potential_sigv4
     def _required_auth_capability(self):
         return ['ec2']
 


### PR DESCRIPTION
ELBConnection._required_auth_capability() is not decorated with
boto.auth.detect_potential_sigv4.  This caused the potential
for pre-v4 signature versions to be used for eu-central-1 and
cn-north-1 which require 4 or greater

Using python 2.7.3 and boto 2.34.0 reproducing can be done via the following.  

*note: my .boto file only contains a [Credentials] section - no other parameters are set.

```
Python 2.7.3 (default, Dec 14 2012, 18:47:02) 
Type "copyright", "credits" or "license" for more information.

IPython 0.13.1 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: from boto.ec2 import elb 
In [2]: conn = elb.connect_to_region(region_name='eu-central-1')
In [3]: conn.get_all_load_balancers()
---------------------------------------------------------------------------
BotoServerError                           Traceback (most recent call last)
<ipython-input-3-753a9c58bd2c> in <module>()
----> 1 conn.get_all_load_balancers()

/usr/local/lib/python2.7/site-packages/boto/ec2/elb/__init__.py in get_all_load_balancers(self, load_balancer_names, marker)
    133 
    134         return self.get_list('DescribeLoadBalancers', params,
--> 135                              [('member', LoadBalancer)])
    136 
    137     def create_load_balancer(self, name, zones, listeners=None, subnets=None,

/usr/local/lib/python2.7/site-packages/boto/connection.pyc in get_list(self, action, params, markers, path, parent, verb)
   1180             boto.log.error('%s %s' % (response.status, response.reason))
   1181             boto.log.error('%s' % body)
-> 1182             raise self.ResponseError(response.status, response.reason, body)
   1183 
   1184     def get_object(self, action, params, cls, path='/',

BotoServerError: BotoServerError: 403 Forbidden
<ErrorResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
  <Error>
    <Type>Sender</Type>
    <Code>MissingAuthenticationToken</Code>
    <Message>Missing Authentication Token</Message>
  </Error>
  <RequestId>5d5521e5-5da3-11e4-abd1-b91f6ed0ee93</RequestId>
</ErrorResponse>

In [4]: import boto
In [5]: print boto.Version
2.34.0
```

---

post patch the correct signature is used by default:

```
Do you really want to exit ([y]/n)? y
[chenry@p-nagios01-1b.use01.plat.priv tmp]$ ipython
Python 2.7.3 (default, Dec 14 2012, 18:47:02) 
Type "copyright", "credits" or "license" for more information.

IPython 0.13.1 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: from boto.ec2 import elb

In [2]: conn = elb.connect_to_region(region_name='eu-central-1')

In [3]: conn.get_all_load_balancers()
Out[3]: []
```
