### PR TITLE
Add ability to use PasswordResetRequired API param

### DIFF
--- a/boto/iam/connection.py
+++ b/boto/iam/connection.py
@@ -937,7 +937,8 @@ class IAMConnection(AWSQueryConnection):
         params = {'UserName': user_name}
         return self.get_response('GetLoginProfile', params)
 
-    def create_login_profile(self, user_name, password):
+    def create_login_profile(self, user_name, password,
+                             password_reset_required=False):
         """
         Creates a login profile for the specified user, give the user the
         ability to access AWS services and the AWS Management Console.
@@ -948,9 +949,14 @@ class IAMConnection(AWSQueryConnection):
         :type password: string
         :param password: The new password for the user
 
+        :type password_reset_required: bool
+        :param password_reset_required: Specifies whether the user is required
+        to set a new password on next sign-in.
+
         """
         params = {'UserName': user_name,
-                  'Password': password}
+                  'Password': password,
+                  'PasswordResetRequired': password_reset_required}
         return self.get_response('CreateLoginProfile', params)
 
     def delete_login_profile(self, user_name):


### PR DESCRIPTION
Unable to use PasswordResetRequired in creating a new IAM user. 
