### PR TITLE
Added detach_instances function for ec2 Auto Scaling group

### DIFF
--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -192,6 +192,27 @@ class AutoScaleConnection(AWSQueryConnection):
         self.build_list_params(params, instance_ids, 'InstanceIds')
         return self.get_status('AttachInstances', params)
 
+    def detach_instances(self, name, instance_ids, decrement_capacity=True):
+        """
+        Detach instances from an Auto Scaling group.
+
+        :type name: str
+        :param name: The name of the Auto Scaling group from which to detach instances.
+
+        :type instance_ids: list
+        :param instance_ids: Instance ids to be detached from the Auto Scaling group.
+
+        :type decrement_capacity: bool
+        :param decrement_capacity: Whether to decrement the size of the
+            Auto Scaling group or not.
+        """
+
+        params = {'AutoScalingGroupName': name}
+        params['ShouldDecrementDesiredCapacity'] = 'true' if decrement_capacity else 'false'
+
+        self.build_list_params(params, instance_ids, 'InstanceIds')
+        return self.get_status('DetachInstances', params)
+
     def create_auto_scaling_group(self, as_group):
         """
         Create auto scaling group.

--- a/tests/unit/ec2/autoscale/test_group.py
+++ b/tests/unit/ec2/autoscale/test_group.py
@@ -623,6 +623,69 @@ class TestAttachInstances(AWSMockServiceTestCase):
         }, ignore_params_values=['Version'])
 
 
+class TestDetachInstances(AWSMockServiceTestCase):
+    connection_class = AutoScaleConnection
+
+    def setUp(self):
+        super(TestDetachInstances, self).setUp()
+
+    def default_body(self):
+        return b"""
+            <DetachInstancesResponse>
+              <ResponseMetadata>
+                <RequestId>requestid</RequestId>
+              </ResponseMetadata>
+            </DetachInstancesResponse>
+        """
+
+    def test_detach_instances(self):
+        self.set_http_response(status_code=200)
+        self.service_connection.detach_instances(
+            'autoscale',
+            ['inst2', 'inst1', 'inst4']
+        )
+        self.assert_request_parameters({
+            'Action': 'DetachInstances',
+            'AutoScalingGroupName': 'autoscale',
+            'InstanceIds.member.1': 'inst2',
+            'InstanceIds.member.2': 'inst1',
+            'InstanceIds.member.3': 'inst4',
+            'ShouldDecrementDesiredCapacity': 'true',
+        }, ignore_params_values=['Version'])
+
+    def test_detach_instances_with_decrement_desired_capacity(self):
+        self.set_http_response(status_code=200)
+        self.service_connection.detach_instances(
+            'autoscale',
+            ['inst2', 'inst1', 'inst4'],
+            True
+        )
+        self.assert_request_parameters({
+            'Action': 'DetachInstances',
+            'AutoScalingGroupName': 'autoscale',
+            'InstanceIds.member.1': 'inst2',
+            'InstanceIds.member.2': 'inst1',
+            'InstanceIds.member.3': 'inst4',
+            'ShouldDecrementDesiredCapacity': 'true',
+        }, ignore_params_values=['Version'])
+
+    def test_detach_instances_without_decrement_desired_capacity(self):
+        self.set_http_response(status_code=200)
+        self.service_connection.detach_instances(
+            'autoscale',
+            ['inst2', 'inst1', 'inst4'],
+            False
+        )
+        self.assert_request_parameters({
+            'Action': 'DetachInstances',
+            'AutoScalingGroupName': 'autoscale',
+            'InstanceIds.member.1': 'inst2',
+            'InstanceIds.member.2': 'inst1',
+            'InstanceIds.member.3': 'inst4',
+            'ShouldDecrementDesiredCapacity': 'false',
+        }, ignore_params_values=['Version'])
+
+
 class TestGetAccountLimits(AWSMockServiceTestCase):
     connection_class = AutoScaleConnection
 


### PR DESCRIPTION
Default value for ```decrement_capacity``` is True to be consistent with terminate_instance function.