### PR TITLE
Client side encryption 2: multipart upload

### DIFF
--- a/boto/gs/connection.py
+++ b/boto/gs/connection.py
@@ -39,12 +39,13 @@ class GSConnection(S3Connection):
                  proxy_user=None, proxy_pass=None,
                  host=DefaultHost, debug=0, https_connection_factory=None,
                  calling_format=SubdomainCallingFormat(), path='/',
-                 suppress_consec_slashes=True):
+                 suppress_consec_slashes=True, client_side_encryption_key=None):
         super(GSConnection, self).__init__(gs_access_key_id, gs_secret_access_key,
                  is_secure, port, proxy, proxy_port, proxy_user, proxy_pass,
                  host, debug, https_connection_factory, calling_format, path,
                  "google", Bucket,
-                 suppress_consec_slashes=suppress_consec_slashes)
+                 suppress_consec_slashes=suppress_consec_slashes,
+                 client_side_encryption_key=client_side_encryption_key)
 
     def create_bucket(self, bucket_name, headers=None,
                       location=Location.DEFAULT, policy=None,

--- a/boto/gs/connection.py
+++ b/boto/gs/connection.py
@@ -39,13 +39,15 @@ class GSConnection(S3Connection):
                  proxy_user=None, proxy_pass=None,
                  host=DefaultHost, debug=0, https_connection_factory=None,
                  calling_format=SubdomainCallingFormat(), path='/',
-                 suppress_consec_slashes=True, client_side_encryption_key=None):
+                 suppress_consec_slashes=True, client_side_encryption_key=None,
+                 client_side_encryption_registry=None):
         super(GSConnection, self).__init__(gs_access_key_id, gs_secret_access_key,
                  is_secure, port, proxy, proxy_port, proxy_user, proxy_pass,
                  host, debug, https_connection_factory, calling_format, path,
                  "google", Bucket,
                  suppress_consec_slashes=suppress_consec_slashes,
-                 client_side_encryption_key=client_side_encryption_key)
+                 client_side_encryption_key=client_side_encryption_key,
+                 client_side_encryption_registry=client_side_encryption_registry)
 
     def create_bucket(self, bucket_name, headers=None,
                       location=Location.DEFAULT, policy=None,

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -171,7 +171,8 @@ class S3Connection(AWSAuthConnection):
                  calling_format=DefaultCallingFormat, path='/',
                  provider='aws', bucket_class=Bucket, security_token=None,
                  suppress_consec_slashes=True, anon=False,
-                 validate_certs=None, profile_name=None, client_side_encryption_key=None):
+                 validate_certs=None, profile_name=None, client_side_encryption_key=None,
+                 client_side_encryption_registry=None):
         no_host_provided = False
         if host is NoHostProvided:
             no_host_provided = True
@@ -182,6 +183,9 @@ class S3Connection(AWSAuthConnection):
         self.bucket_class = bucket_class
         self.anon = anon
         self.client_side_encryption_key = client_side_encryption_key
+        self.client_side_encryption_registry = client_side_encryption_registry
+        if self.client_side_encryption_registry is None:
+            self.client_side_encryption_registry = {}
         super(S3Connection, self).__init__(host,
                 aws_access_key_id, aws_secret_access_key,
                 is_secure, port, proxy, proxy_port, proxy_user, proxy_pass,

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -171,7 +171,7 @@ class S3Connection(AWSAuthConnection):
                  calling_format=DefaultCallingFormat, path='/',
                  provider='aws', bucket_class=Bucket, security_token=None,
                  suppress_consec_slashes=True, anon=False,
-                 validate_certs=None, profile_name=None):
+                 validate_certs=None, profile_name=None, client_side_encryption_key=None):
         no_host_provided = False
         if host is NoHostProvided:
             no_host_provided = True
@@ -181,6 +181,7 @@ class S3Connection(AWSAuthConnection):
         self.calling_format = calling_format
         self.bucket_class = bucket_class
         self.anon = anon
+        self.client_side_encryption_key = client_side_encryption_key
         super(S3Connection, self).__init__(host,
                 aws_access_key_id, aws_secret_access_key,
                 is_secure, port, proxy, proxy_port, proxy_user, proxy_pass,
@@ -663,3 +664,4 @@ class S3Connection(AWSAuthConnection):
             override_num_retries=override_num_retries,
             retry_handler=retry_handler
         )
+

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -757,6 +757,7 @@ class Key(object):
             spos = None
             self.read_from_stream = False
 
+        size = size or self.size or None
         # If hash_algs is unset and the MD5 hasn't already been computed,
         # default to an MD5 hash_alg to hash the data on-the-fly.
         if hash_algs is None and not self.md5:
@@ -929,7 +930,7 @@ class Key(object):
             #if not self.base64md5:
             #    headers['Trailer'] = "Content-MD5"
         else:
-            headers['Content-Length'] = str(self.size)
+            headers['Content-Length'] = str(size)
         # This is terrible. We need a SHA256 of the body for SigV4, but to do
         # the chunked ``sender`` behavior above, the ``fp`` isn't available to
         # the auth mechanism (because closures). Detect if it's SigV4 & embelish

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -32,7 +32,7 @@ import base64
 import binascii
 import math
 import hashlib
-import urlparse
+from boto.compat import parse_qs
 from Crypto.Cipher import AES
 import boto.utils
 from boto.compat import BytesIO, six, urllib, encodebytes
@@ -990,7 +990,7 @@ class Key(object):
 
             else:
                 # Multipart upload
-                query_args_dict = urlparse.parse_qs(query_args)
+                query_args_dict = parse_qs(query_args)
                 upload_id = query_args_dict['uploadId'][0]
                 part_number = int(query_args_dict['partNumber'][0])
 

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1028,7 +1028,7 @@ class Key(object):
                 envelope_key_encrypted = base64.b64decode(envelope_key_base64_with_padding)[:-16]
                 envelope_key = AES.new(master_key, AES.MODE_ECB).decrypt(envelope_key_encrypted)
 
-                if size < 5e6 or size % 16 > 0:
+                if size < 5*2**20 or size % 16 > 0:
                     # The first time we see a file with these characteristics, we can't tell if it's the last part
                     # of the file or an error of the user (part too small or size not a multiple of the block size).
                     #

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -775,6 +775,7 @@ class Key(object):
                 # avoid setting bad data.
                 raise provider.storage_data_error(
                     'Cannot retry failed request. fp does not support seeking.')
+            sender_fp = fp
 
             # If the caller explicitly specified host header, tell putrequest
             # not to add a second host header. Similarly for accept-encoding.
@@ -821,9 +822,9 @@ class Key(object):
 
             bytes_togo = size
             if bytes_togo and bytes_togo < self.BufferSize:
-                chunk = fp.read(bytes_togo)
+                chunk = sender_fp.read(bytes_togo)
             else:
-                chunk = fp.read(self.BufferSize)
+                chunk = sender_fp.read(self.BufferSize)
 
             if not isinstance(chunk, bytes):
                 chunk = chunk.encode('utf-8')
@@ -852,9 +853,9 @@ class Key(object):
                         cb(data_len, cb_size)
                         i = 0
                 if bytes_togo and bytes_togo < self.BufferSize:
-                    chunk = fp.read(bytes_togo)
+                    chunk = sender_fp.read(bytes_togo)
                 else:
-                    chunk = fp.read(self.BufferSize)
+                    chunk = sender_fp.read(self.BufferSize)
 
                 if not isinstance(chunk, bytes):
                     chunk = chunk.encode('utf-8')

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -930,7 +930,7 @@ class Key(object):
             spos = None
             self.read_from_stream = False
 
-        size = size or self.size or None
+        size = size or self.size
         md5, base64md5 = self.md5, self.base64md5
         iv, envelope_key, master_key = None, None, self.bucket.connection.client_side_encryption_key
         self.delete_metadata('x-amz-iv')
@@ -961,7 +961,7 @@ class Key(object):
 
             # Adjust the size to take the padding into account
             # If the size is a multiple of the block size (16 bytes), a full block will be added
-            if size and not chunked_transfer:
+            if size is not None and not chunked_transfer:
                 size += 16 - size % 16
 
         # If hash_algs is unset and the MD5 hasn't already been computed,

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -561,6 +561,9 @@ class Key(object):
     def update_metadata(self, d):
         self.metadata.update(d)
 
+    def delete_metadata(self, name):
+        self.metadata.pop(name, None)
+
     # convenience methods for setting/getting ACL
     def set_acl(self, acl_str, headers=None):
         if self.bucket is not None:

--- a/boto/s3/multipart.py
+++ b/boto/s3/multipart.py
@@ -252,6 +252,8 @@ class MultiPartUpload(object):
         """
         if part_num < 1:
             raise ValueError('Part numbers must be greater than zero')
+        if self.bucket.connection.client_side_encryption_key:
+            raise ValueError('Multipart upload with client-side encryption is not yet supported.')
         query_args = 'uploadId=%s&partNumber=%d' % (self.id, part_num)
         key = self.bucket.new_key(self.key_name)
         key.set_contents_from_file(fp, headers=headers, replace=replace,
@@ -289,6 +291,8 @@ class MultiPartUpload(object):
         """
         if part_num < 1:
             raise ValueError('Part numbers must be greater than zero')
+        if self.bucket.connection.client_side_encryption_key:
+            raise ValueError('Multipart upload with client-side encryption is not yet supported.')
         query_args = 'uploadId=%s&partNumber=%d' % (self.id, part_num)
         if start is not None and end is not None:
             rng = 'bytes=%s-%s' % (start, end)

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -994,7 +994,7 @@ def compute_md5(fp, buf_size=8192, size=None):
 def compute_hash(fp, buf_size=8192, size=None, hash_algorithm=md5):
     hash_obj = hash_algorithm()
     spos = fp.tell()
-    if size and size < buf_size:
+    if size is not None and size < buf_size:
         s = fp.read(size)
     else:
         s = fp.read(buf_size)

--- a/tests/integration/s3/test_client_side_encryption.java
+++ b/tests/integration/s3/test_client_side_encryption.java
@@ -1,0 +1,49 @@
+import py4j.GatewayServer;
+import com.amazonaws.services.s3.AmazonS3EncryptionClient;
+import com.amazonaws.util.Base64;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import com.amazonaws.services.s3.model.EncryptionMaterials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import org.apache.commons.io.IOUtils;
+import java.nio.charset.StandardCharsets;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import java.io.FileInputStream;
+
+public class BotoS3Gateway {
+
+    public AmazonS3EncryptionClient getClient(String accessKey, String secretKey, String base64EncryptionKey) throws Exception {
+        SecretKey encryptionKey = new SecretKeySpec(Base64.decode(base64EncryptionKey), "AES");
+        EncryptionMaterials encryptionMaterials = new EncryptionMaterials(encryptionKey);
+
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        AmazonS3EncryptionClient s3 = new AmazonS3EncryptionClient(credentials, encryptionMaterials);
+
+        return s3;
+    }
+
+    public void putString(String accessKey, String secretKey, String base64EncryptionKey, String bucketName, String key, String content) throws Exception {
+        AmazonS3EncryptionClient s3 = getClient(accessKey, secretKey, base64EncryptionKey);
+        s3.putObject(bucketName, key, IOUtils.toInputStream(content, StandardCharsets.UTF_8.name()), new ObjectMetadata());
+    }
+
+    public void putFile(String accessKey, String secretKey, String base64EncryptionKey, String bucketName, String key, String filename) throws Exception {
+        AmazonS3EncryptionClient s3 = getClient(accessKey, secretKey, base64EncryptionKey);
+        FileInputStream fileInputStream = new FileInputStream(filename);
+        s3.putObject(bucketName, key, fileInputStream, new ObjectMetadata());
+        fileInputStream.close();
+    }
+
+    public String getString(String accessKey, String secretKey, String base64EncryptionKey, String bucketName, String key) throws Exception {
+        AmazonS3EncryptionClient s3 = getClient(accessKey, secretKey, base64EncryptionKey);
+        S3Object obj = s3.getObject(bucketName, key);
+        return IOUtils.toString(obj.getObjectContent(), StandardCharsets.UTF_8.name());
+    }
+
+    public static void main(String[] args) {
+        System.out.println("Starting gateway...");
+        GatewayServer gatewayServer = new GatewayServer(new BotoS3Gateway());
+        gatewayServer.start();
+    }
+}

--- a/tests/integration/s3/test_client_side_encryption.py
+++ b/tests/integration/s3/test_client_side_encryption.py
@@ -54,11 +54,11 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
         for encryption_key_index, encryption_key in enumerate(client_side_encryption_keys):
             encryption_key_hex = binascii.b2a_hex(encryption_key)
             encryption_key_base64 = binascii.b2a_base64(encryption_key)
-            print 'Key of size {}, hex={}, base64={}'.format(
+            print('Key of size {}, hex={}, base64={}'.format(
                 8 * len(encryption_key),
                 encryption_key_hex,
                 encryption_key_base64
-            )
+            ))
 
             encrypted_connection = S3Connection(client_side_encryption_key=encryption_key)
             encrypted_bucket = encrypted_connection.get_bucket(self.bucket_name)
@@ -75,7 +75,7 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
                 '0123456801234567' * 2**6 + '0',  # 1Kb content, needs padding
             ]
             for key_content_index, key_content in enumerate(key_contents):
-                print '\tTest using content {}'.format(key_content_index)
+                print('\tTest using content {}'.format(key_content_index))
 
                 methods = [
                     lambda key, content, filename, fp: key.set_contents_from_string(content),
@@ -85,7 +85,7 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
                     # lambda key, content, filename, fp: key.set_contents_from_stream(fp),
                 ]
                 for method_index, method in enumerate(methods):
-                    print '\t\tTest using method {}'.format(method_index)
+                    print('\t\tTest using method {}'.format(method_index))
 
                     key_size = len(key_content)
                     key_name = key_name_base.format(key_content_index=key_content_index,
@@ -190,7 +190,7 @@ class _TestWithJavaS3GatewayMixin(object):
                 url = base_url.format(base_package=base_package, package=package, version=version)
                 jar = '/tmp/{package}-{version}.jar'.format(package=package, version=version)
                 if not os.path.isfile(jar):
-                    print 'Downloading {}'.format(url)
+                    print('Downloading {}'.format(url))
                     urllib.URLopener().retrieve(url, jar)
                 jars.append(jar)
 
@@ -207,7 +207,7 @@ class _TestWithJavaS3GatewayMixin(object):
                 url = base_url.format(path=path, name=name, version=version)
                 jar = '/tmp/{name}-{version}.jar'.format(name=name, version=version)
                 if not os.path.isfile(jar):
-                    print 'Downloading {}'.format(url)
+                    print('Downloading {}'.format(url))
                     urllib.URLopener().retrieve(url, jar)
                 jars.append(jar)
 
@@ -220,7 +220,7 @@ class _TestWithJavaS3GatewayMixin(object):
         import psutil
         for process in psutil.process_iter():
             if 'BotoS3Gateway' in process.cmdline():
-                print 'Stopping gateway...'
+                print('Stopping gateway...')
                 process.kill()
                 time.sleep(1)
 
@@ -297,11 +297,11 @@ class S3ClientSideEncryptionTestJavaImplementationCompatibility(_TestWithJavaS3G
         for encryption_key_index, encryption_key in enumerate(client_side_encryption_keys):
             encryption_key_hex = binascii.b2a_hex(encryption_key)
             encryption_key_base64 = binascii.b2a_base64(encryption_key)
-            print 'Key of size {}, hex={}, base64={}'.format(
+            print('Key of size {}, hex={}, base64={}'.format(
                 8 * len(encryption_key),
                 encryption_key_hex,
                 encryption_key_base64
-            ).replace('\n', '')
+            ).replace('\n', ''))
 
             encrypted_connection = S3Connection(client_side_encryption_key=encryption_key)
             encrypted_bucket = encrypted_connection.get_bucket(self.bucket_name)
@@ -318,7 +318,7 @@ class S3ClientSideEncryptionTestJavaImplementationCompatibility(_TestWithJavaS3G
                 '0123456701234567' * 2**6 + '0',  # 1Kb content, needs padding
             ]
             for key_content_index, key_content in enumerate(key_contents):
-                print '\tTest using content {}'.format(key_content_index)
+                print('\tTest using content {}'.format(key_content_index))
 
                 methods = [
                     lambda a, b, c, d, e, content, filename: self.gateway.entry_point.putString(a, b, c, d,
@@ -327,7 +327,7 @@ class S3ClientSideEncryptionTestJavaImplementationCompatibility(_TestWithJavaS3G
                                                                                               e, filename),
                 ]
                 for method_index, method in enumerate(methods):
-                    print '\t\tTest using method {}'.format(method_index)
+                    print('\t\tTest using method {}'.format(method_index))
 
                     key_size = len(key_content)
                     key_name = key_name_base.format(key_content_index=key_content_index,

--- a/tests/integration/s3/test_client_side_encryption.py
+++ b/tests/integration/s3/test_client_side_encryption.py
@@ -12,6 +12,7 @@ import urllib2
 from pip.vendor.distlib.version import NormalizedVersion
 
 from boto.s3.connection import S3Connection
+from boto.s3.multipart import MultiPartUpload
 
 try:
     import psutil
@@ -148,6 +149,18 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
                         self.assertEqual(encrypted_key2.size, key_size)
 
         print('--- {} tests completed ---'.format(self.__class__.__name__))
+
+    def test_client_side_encryption_multipart(self):
+        print('--- running {} multipart tests ---'.format(self.__class__.__name__))
+
+        connection = S3Connection(client_side_encryption_key=os.urandom(256 / 8))
+        bucket = connection.get_bucket(self.bucket_name)
+
+        multipart_upload = MultiPartUpload(bucket)  # does not create an upload, so there's nothing to clean
+        self.assertRaises(ValueError, multipart_upload.upload_part_from_file, None, None)
+        self.assertRaises(ValueError, multipart_upload.copy_part_from_key, None, None, None)
+
+        print('--- tests {} multipart tests completed ---'.format(self.__class__.__name__))
 
 
 class _TestWithJavaS3GatewayMixin(object):

--- a/tests/integration/s3/test_client_side_encryption.py
+++ b/tests/integration/s3/test_client_side_encryption.py
@@ -9,6 +9,7 @@ import time
 import urllib
 import binascii
 import urllib2
+from StringIO import StringIO
 from pip.vendor.distlib.version import NormalizedVersion
 
 from boto.s3.connection import S3Connection
@@ -77,10 +78,18 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
             for key_content_index, key_content in enumerate(key_contents):
                 print('\tTest using content {}'.format(key_content_index))
 
+                def set_content_from_file_with_too_much_content(key, content, filename, fp):
+                    """
+                    Add extra content add the end of the file to make sure that the size parameter works properly
+                    """
+                    content = fp.read()
+                    key.set_contents_from_file(StringIO(content + 'abcde'), size=len(content))
+
                 methods = [
                     lambda key, content, filename, fp: key.set_contents_from_string(content),
                     lambda key, content, filename, fp: key.set_contents_from_filename(filename),
                     lambda key, content, filename, fp: key.set_contents_from_file(fp),
+                    set_content_from_file_with_too_much_content,
                     # BotoClientError: s3 does not support chunked transfer
                     # lambda key, content, filename, fp: key.set_contents_from_stream(fp),
                 ]

--- a/tests/integration/s3/test_client_side_encryption.py
+++ b/tests/integration/s3/test_client_side_encryption.py
@@ -9,8 +9,19 @@ import time
 import urllib
 import binascii
 import urllib2
+from pip.vendor.distlib.version import NormalizedVersion
 
 from boto.s3.connection import S3Connection
+
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
+try:
+    import py4j
+except ImportError:
+    py4j = None
 
 
 class S3ClientSideEncryptionTest(unittest.TestCase):
@@ -135,5 +146,213 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
                         encrypted_key2 = encrypted_bucket.new_key(key_name)
                         decrypted_content2 = encrypted_key2.get_contents_as_string()
                         self.assertEqual(encrypted_key2.size, key_size)
+
+        print('--- {} tests completed ---'.format(self.__class__.__name__))
+
+
+class _TestWithJavaS3GatewayMixin(object):
+    jars = None
+    gateway = None
+
+    @classmethod
+    def _get_classpath(cls):
+
+        if not cls.jars:
+            aws_java_sdk_version = '1.8.11'
+
+            manifest_url = 'https://raw.githubusercontent.com/aws/aws-sdk-java/{}/META-INF/MANIFEST.MF'.format(aws_java_sdk_version)
+            manifest_lines = urllib2.urlopen(manifest_url).read().split('\n')
+            bundle_lines = [line for line in manifest_lines if 'bundle-version' in line]
+            bundles = [(line.split(';')[0].split(' ')[-1], line.split('"')[1]) for line in bundle_lines]
+
+            jars = []
+            for package, version in bundles:
+                base_package = package.rsplit('.', 1)[0]
+                if 'jackson' in package:
+                    version = '2.0.2'
+                if 'javax.mail' in package:
+                    base_package = package
+                base_url = "http://repository.springsource.com/ivy/bundles/external/{base_package}/com.springsource.{package}/{version}/com.springsource.{package}-{version}.jar"
+                url = base_url.format(base_package=base_package, package=package, version=version)
+                jar = '/tmp/{package}-{version}.jar'.format(package=package, version=version)
+                if not os.path.isfile(jar):
+                    print 'Downloading {}'.format(url)
+                    urllib.URLopener().retrieve(url, jar)
+                jars.append(jar)
+
+            mvn_bundles = [
+                ('net/sf/py4j', 'py4j', '0.8.2'),
+                ('com/amazonaws', 'aws-java-sdk', aws_java_sdk_version),
+                ('org/apache/commons', 'commons-io', '1.3.2'),
+                ('joda-time', 'joda-time', '2.2'),
+            ]
+            if NormalizedVersion(aws_java_sdk_version) >= NormalizedVersion('1.8.10'):
+                mvn_bundles.append(('com/amazonaws', 'aws-java-sdk-core', aws_java_sdk_version))
+            for path, name, version in mvn_bundles:
+                base_url = "http://central.maven.org/maven2/{path}/{name}/{version}/{name}-{version}.jar"
+                url = base_url.format(path=path, name=name, version=version)
+                jar = '/tmp/{name}-{version}.jar'.format(name=name, version=version)
+                if not os.path.isfile(jar):
+                    print 'Downloading {}'.format(url)
+                    urllib.URLopener().retrieve(url, jar)
+                jars.append(jar)
+
+            cls.jars = jars
+
+        return ':'.join(['.'] + cls.jars)
+
+    @classmethod
+    def _stop_gateway(cls):
+        import psutil
+        for process in psutil.process_iter():
+            if 'BotoS3Gateway' in process.cmdline():
+                print 'Stopping gateway...'
+                process.kill()
+                time.sleep(1)
+
+    @classmethod
+    def _build_gateway(cls):
+        src_filename = __file__.replace('.pyc', '.java').replace('.py', '.java')
+        dst_filename = '/tmp/BotoS3Gateway.java'
+        if os.path.isfile(dst_filename):
+            os.remove(dst_filename)
+        shutil.copy(src_filename, dst_filename)
+        subprocess.check_output(
+            [
+                'javac',
+                '-cp',
+                cls._get_classpath(),
+                dst_filename
+            ],
+            cwd='/tmp',
+        )
+
+    @classmethod
+    def _start_gateway(cls):
+        subprocess.Popen(
+            [
+                'java',
+                '-cp',
+                cls._get_classpath(),
+                'BotoS3Gateway',
+            ],
+            cwd='/tmp',
+        )
+        time.sleep(3)
+        from py4j.java_gateway import JavaGateway
+        cls.gateway = JavaGateway()
+
+    def setUp(self):
+        super(_TestWithJavaS3GatewayMixin, self).setUp()
+        self._stop_gateway()
+        self._build_gateway()
+        self._start_gateway()
+
+    def tearDown(self):
+        self._stop_gateway()
+        super(_TestWithJavaS3GatewayMixin, self).tearDown()
+
+
+class S3ClientSideEncryptionTestJavaImplementationCompatibility(_TestWithJavaS3GatewayMixin, unittest.TestCase):
+    s3 = True
+
+    def setUp(self):
+        super(S3ClientSideEncryptionTestJavaImplementationCompatibility, self).setUp()
+        self.conn = S3Connection()
+        self.bucket_name = 'client-side-encryption-%d' % int(time.time())
+        self.bucket = self.conn.create_bucket(self.bucket_name)
+
+    def tearDown(self):
+        for key in self.bucket:
+            key.delete()
+        self.bucket.delete()
+        super(S3ClientSideEncryptionTestJavaImplementationCompatibility, self).setUp()
+
+    @unittest.skipIf(not psutil or not py4j, "Please install psutil and py4j to run this test")
+    def test_client_side_encryption_java_compatibility(self):
+        print('--- running {} tests ---'.format(self.__class__.__name__))
+
+        client_side_encryption_keys = [
+            ''.join([chr(0)] * (128 / 8)),  # Zero-key, AES 128
+            ''.join([chr(0)] * (192 / 8)),  # Zero-key, AES 192
+            ''.join([chr(0)] * (256 / 8)),  # Zero-key, AES 256
+            os.urandom(128 / 8),  # Random-key, AES 128
+            os.urandom(192 / 8),  # Random-key, AES 192
+            os.urandom(256 / 8),  # Random-key, AES 256
+        ]
+        for encryption_key_index, encryption_key in enumerate(client_side_encryption_keys):
+            encryption_key_hex = binascii.b2a_hex(encryption_key)
+            encryption_key_base64 = binascii.b2a_base64(encryption_key)
+            print 'Key of size {}, hex={}, base64={}'.format(
+                8 * len(encryption_key),
+                encryption_key_hex,
+                encryption_key_base64
+            ).replace('\n', '')
+
+            encrypted_connection = S3Connection(client_side_encryption_key=encryption_key)
+            encrypted_bucket = encrypted_connection.get_bucket(self.bucket_name)
+
+            unencrypted_connection = S3Connection()
+            unencrypted_bucket = unencrypted_connection.get_bucket(self.bucket_name)
+
+            key_name_base = 'foo-{key_content_index}-encrypted-using-key-{encryption_key_index}'
+            key_contents = [
+                '0123456701234567',   # Small content, multiple of the block size (16)
+                '0123456701234567' + '0',  # Small content, needs padding
+                '0123456701234567' * 2**6,        # 1Kb content, multiple of the block size (16)
+                '0123456701234567' * 2**6 + '0',  # 1Kb content, needs padding
+            ]
+            for key_content_index, key_content in enumerate(key_contents):
+                print '\tTest using content {}'.format(key_content_index)
+
+                methods = [
+                    lambda a, b, c, d, e, content, filename: self.gateway.entry_point.putString(a, b, c, d,
+                                                                                                e, content),
+                    lambda a, b, c, d, e, content, filename: self.gateway.entry_point.putFile(a, b, c, d,
+                                                                                              e, filename),
+                ]
+                for method_index, method in enumerate(methods):
+                    print '\t\tTest using method {}'.format(method_index)
+
+                    key_size = len(key_content)
+                    key_name = key_name_base.format(key_content_index=key_content_index,
+                                                    encryption_key_index=encryption_key_index)
+                    encrypted_key = encrypted_bucket.new_key(key_name)
+                    unencrypted_key = unencrypted_bucket.new_key(key_name)
+
+                    key_content_filename = '/tmp/{}'.format(key_name)
+                    with open(key_content_filename, 'w') as key_content_fp:
+                        key_content_fp.write(key_content)
+
+                    access_key = unencrypted_connection.provider.access_key
+                    secret_key = unencrypted_connection.provider.secret_key
+
+                    # To make debugging easier if something fails later, test the java encryption
+                    method(access_key, secret_key, encryption_key_base64,
+                           self.bucket_name, key_name,
+                           key_content, key_content_filename)
+                    raw_content = unencrypted_key.get_contents_as_string()
+                    self.assertNotEqual(key_content, raw_content)
+                    decrypted_content = self.gateway.entry_point.getString(access_key, secret_key,
+                                                                           encryption_key_base64,
+                                                                           self.bucket_name, key_name)
+                    self.assertEqual(key_content, decrypted_content)
+
+                    # Encrypt with python, decrypt with java
+                    encrypted_key.set_contents_from_string(key_content)
+                    decrypted_content = self.gateway.entry_point.getString(access_key, secret_key, encryption_key_base64,
+                                                                           self.bucket_name, key_name)
+                    self.assertEqual(key_content, decrypted_content)
+
+                    # Encrypt with java, decrypt with python
+                    method(access_key, secret_key, encryption_key_base64,
+                           self.bucket_name, key_name,
+                           key_content, key_content_filename)
+                    decrypted_content = encrypted_key.get_contents_as_string()
+                    self.assertEqual(key_content, decrypted_content)
+                    # When sending the size in java like in these tests, the original size
+                    # of the file won't be set. Test that it's handled properly
+                    self.assertEqual(key_content, decrypted_content)
+                    self.assertEqual(encrypted_key.size, key_size)
 
         print('--- {} tests completed ---'.format(self.__class__.__name__))

--- a/tests/integration/s3/test_client_side_encryption.py
+++ b/tests/integration/s3/test_client_side_encryption.py
@@ -1,8 +1,13 @@
 """
 Some unit tests for the S3 Client Side Encryption
 """
+from distutils.spawn import find_executable
+from io import StringIO
+import json
 import os
+import random
 import shutil
+import string
 import subprocess
 import unittest
 import time
@@ -11,6 +16,9 @@ import binascii
 import urllib2
 from StringIO import StringIO
 from pip.vendor.distlib.version import NormalizedVersion
+from unittest2 import skip
+from boto.exception import BotoClientError
+from multiprocessing import Process
 
 from boto.s3.connection import S3Connection
 from boto.s3.multipart import MultiPartUpload
@@ -25,12 +33,21 @@ try:
 except ImportError:
     py4j = None
 
+try:
+    import memcache
+except ImportError:
+    memcache = None
 
-class S3ClientSideEncryptionTest(unittest.TestCase):
+
+class _TestWithS3BucketMixin(unittest.TestCase):
     s3 = True
 
+    conn = None
+    bucket_name = None
+    bucket = None
+
     def setUp(self):
-        super(S3ClientSideEncryptionTest, self).setUp()
+        super(_TestWithS3BucketMixin, self).setUp()
         self.conn = S3Connection()
         self.bucket_name = 'client-side-encryption-%d' % int(time.time())
         self.bucket = self.conn.create_bucket(self.bucket_name)
@@ -38,8 +55,16 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
     def tearDown(self):
         for key in self.bucket:
             key.delete()
+        for multipart_upload in self.bucket.list_multipart_uploads():
+            self.bucket.cancel_multipart_upload(
+                multipart_upload.key_name,
+                multipart_upload.id,
+            )
         self.bucket.delete()
-        super(S3ClientSideEncryptionTest, self).tearDown()
+        super(_TestWithS3BucketMixin, self).tearDown()
+
+
+class S3ClientSideEncryptionTest(_TestWithS3BucketMixin, unittest.TestCase):
 
     def test_client_side_encryption(self):
         print('--- running {} tests ---'.format(self.__class__.__name__))
@@ -160,20 +185,226 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
 
         print('--- {} tests completed ---'.format(self.__class__.__name__))
 
-    def test_client_side_encryption_multipart(self):
-        print('--- running {} multipart tests ---'.format(self.__class__.__name__))
 
-        connection = S3Connection(client_side_encryption_key=os.urandom(256 / 8))
+class S3ClientSideEncryptionMultipartTest(_TestWithS3BucketMixin, unittest.TestCase):
+
+    def test_client_side_encryption_multipart(self):
+
+        threshold = 5 * 2**20
+        values = string.letters + string.digits + string.punctuation
+        content_below_threshold = ''.join(random.choice(values) for _ in xrange(threshold - threshold/2))
+        content_above_threshold = ''.join(random.choice(values) for _ in xrange(threshold + threshold/2))
+
+        all_parts = [
+            [''],  # Edge case
+            [content_below_threshold],  # Final part will be detected during upload
+            [content_above_threshold],  # Final part won't be detected during upload
+            [content_above_threshold, content_below_threshold],  # Final part will be detected during upload
+            [content_above_threshold, content_above_threshold],  # Final part won't be detected during upload
+        ]
+
+        for i, parts in enumerate(all_parts):
+            print('Testing with content {}...'.format(i))
+            content = ''.join(parts)
+
+            connection = S3Connection(
+                client_side_encryption_key=os.urandom(256 / 8)
+            )
+            bucket = connection.get_bucket(self.bucket_name)
+
+            # Test the presence of the metadata
+            key_name = 'file-%d' % int(time.time())
+            multipart_upload = bucket.initiate_multipart_upload(key_name)
+            metadata_key = '{}-{}-metadata'.format(bucket.name, multipart_upload.id)
+            self.assertIn(metadata_key, connection.client_side_encryption_registry)
+
+            # Check the content of the metadata
+            encryption_metadata = json.loads(connection.client_side_encryption_registry[metadata_key])
+            self.assertIn('x-amz-iv', encryption_metadata)
+            self.assertIn('x-amz-key', encryption_metadata)
+            self.assertIn('x-amz-matdesc', encryption_metadata)
+
+            # Check that first iv is present
+            # This is also available in the metadata but "Special cases aren't special enough to break the rules."
+            part_0_key = '{}-{}-0'.format(bucket.name, multipart_upload.id)
+            self.assertIn(part_0_key, connection.client_side_encryption_registry)
+
+            # Upload the content
+            for j, part in enumerate(parts):
+                print('\tUploading part {}...'.format(j+1))
+                fp = StringIO()
+                fp.write(part.decode('utf-8'))
+                fp.seek(0)
+                multipart_upload.upload_part_from_file(fp, j+1)
+            print('\tCompleting upload...')
+            multipart_upload.complete_upload()
+
+            print('\tTesting content...')
+            key = bucket.get_key(key_name)
+            key_content = key.get_contents_as_string()
+            self.assertEqual(key_content, content, "The uploaded content is not equal to the original content.")
+
+            registry_key_prefix = '{}-{}'.format(bucket.name, multipart_upload.id)
+            for registry_key in connection.client_side_encryption_registry:
+                self.assertNotIn(registry_key_prefix, registry_key, "The client-side encryption registry still contains "
+                                                                    "data about the upload after its completion.")
+
+    def test_client_side_encryption_multipart_copy(self):
+        connection = S3Connection(
+            client_side_encryption_key=os.urandom(256 / 8)
+        )
         bucket = connection.get_bucket(self.bucket_name)
 
-        multipart_upload = MultiPartUpload(bucket)  # does not create an upload, so there's nothing to clean
-        self.assertRaises(ValueError, multipart_upload.upload_part_from_file, None, None)
+        multipart_upload = MultiPartUpload(bucket)  # does not actually create an upload
         self.assertRaises(ValueError, multipart_upload.copy_part_from_key, None, None, None)
 
-        print('--- tests {} multipart tests completed ---'.format(self.__class__.__name__))
+    def test_client_side_encryption_multipart_errors(self):
+
+        connection = S3Connection(
+            client_side_encryption_key=os.urandom(256 / 8)
+        )
+        bucket = connection.get_bucket(self.bucket_name)
+
+        threshold = 5 * 2**20
+        values = string.letters + string.digits + string.punctuation
+        content_below_threshold = ''.join(random.choice(values) for _ in xrange(threshold - threshold/2))
+        content_above_threshold = ''.join(random.choice(values) for _ in xrange(threshold + threshold/2))
+
+        all_parts = [
+            ([1, 2], [content_above_threshold + '0', content_below_threshold]),  # First part not multiple of 16
+            ([1, 2], [content_below_threshold, content_below_threshold]),  # First part too short
+            ([2, 1], [content_above_threshold, content_above_threshold]),  # Wrong order
+        ]
+
+        def upload_wrong_parts(part_numbers, parts):
+            key_name = 'file-%d' % int(time.time())
+            multipart_upload = bucket.initiate_multipart_upload(key_name)
+
+            for j, part in zip(part_numbers, parts):
+                fp = StringIO()
+                fp.write(part.decode('utf-8'))
+                fp.seek(0)
+                multipart_upload.upload_part_from_file(fp, j+1)
+            multipart_upload.complete_upload()
+
+        for i, (part_numbers, parts) in enumerate(all_parts):
+            print('Testing with content {}...'.format(i))
+            self.assertRaises(BotoClientError, lambda: upload_wrong_parts(part_numbers, parts))
 
 
-class _TestWithJavaS3GatewayMixin(object):
+class MemcachedDictionary(object):
+
+    def __init__(self, memcache_client):
+        self.memcache_client = memcache_client
+
+    def __getitem__(self, key):
+        return self.memcache_client.get(key)
+
+    def get(self, key, default):
+        if not key in self:
+            return default
+        return self[key]
+
+    def __setitem__(self, key, value):
+        self.memcache_client.set(key, value, time=60*60*24)
+
+    def __delitem__(self, key):
+        self.memcache_client.delete(key)
+
+    def keys(self):
+        # This will prevent the deletion of the data of completed uploads, but should it be enough for the tests
+        return []
+
+    def __contains__(self, key):
+        return self.memcache_client.get(key) is not None
+
+
+class S3ClientSideEncryptionMultipartMemcachedTest(_TestWithS3BucketMixin, unittest.TestCase):
+
+    memcache_process = None
+
+    @staticmethod
+    def _get_memcache_client():
+        return memcache.Client(['127.0.0.1:51211'])
+
+    @staticmethod
+    def _kill_memcached():
+        import psutil
+        for process in psutil.process_iter():
+            if '51211' in process.cmdline():
+                print('Stopping memcached...')
+                process.kill()
+                time.sleep(1)
+
+    def setUp(self):
+        self._kill_memcached()
+        self.memcache_process = subprocess.Popen(['memcached', '-p', '51211'])
+        time.sleep(3)
+
+        super(S3ClientSideEncryptionMultipartMemcachedTest, self).setUp()
+
+    def tearDown(self):
+        self._kill_memcached()
+        self.memcache_process.kill()
+        super(S3ClientSideEncryptionMultipartMemcachedTest, self).tearDown()
+
+    @staticmethod
+    def _upload_part(cls, client_side_encryption_key, bucket_name, key_name, multipart_upload_id, part_number, part):
+        connection = S3Connection(
+            client_side_encryption_key=client_side_encryption_key,
+            client_side_encryption_registry=MemcachedDictionary(cls._get_memcache_client()),
+        )
+        bucket = connection.get_bucket(bucket_name)
+
+        multipart_upload = MultiPartUpload(bucket)
+        multipart_upload.key_name = key_name
+        multipart_upload.id = multipart_upload_id
+
+        fp = StringIO()
+        fp.write(part.decode('utf-8'))
+        fp.seek(0)
+        multipart_upload.upload_part_from_file(fp, part_number)
+
+    @unittest.skipIf(not psutil, "Please install psutil (python package) to run this test")
+    @unittest.skipIf(not memcache, "Please install python-memcached (python package) to run this test")
+    @unittest.skipIf(not find_executable('memcached'), "Please install memcached (program) to run this test")
+    def test_with_memcached_using_multiprocessing(self):
+
+        print('Creating content...')
+        threshold = 5 * 2**20
+        values = string.letters + string.digits + string.punctuation
+        content_above_threshold = ''.join(random.choice(values) for _ in xrange(threshold + threshold/2))
+        parts = [content_above_threshold, content_above_threshold]
+        content = ''.join(parts)
+
+        print('Creating upload...')
+        connection = S3Connection(
+            client_side_encryption_key=os.urandom(256 / 8),
+            client_side_encryption_registry=MemcachedDictionary(self._get_memcache_client()),
+        )
+        bucket = connection.get_bucket(self.bucket_name)
+        key_name = 'file-%d' % int(time.time())
+        multipart_upload = bucket.initiate_multipart_upload(key_name)
+
+        for j, part in enumerate(parts):
+            print('Uploading part {} in a subprocess...'.format(j+1))
+            process = Process(
+                target=S3ClientSideEncryptionMultipartMemcachedTest._upload_part,
+                args=(S3ClientSideEncryptionMultipartMemcachedTest, connection.client_side_encryption_key,
+                      self.bucket_name, key_name, multipart_upload.id, j+1, part))
+            process.start()
+            process.join()
+
+        print('Completing upload...')
+        multipart_upload.complete_upload()
+
+        print('Testing content...')
+        key = bucket.get_key(key_name)
+        key_content = key.get_contents_as_string()
+        self.assertEqual(key_content, content, "The uploaded content is not equal to the original content.")
+
+
+class _TestWithJavaS3GatewayMixin(unittest.TestCase):
     jars = None
     gateway = None
 
@@ -276,20 +507,8 @@ class _TestWithJavaS3GatewayMixin(object):
         super(_TestWithJavaS3GatewayMixin, self).tearDown()
 
 
-class S3ClientSideEncryptionTestJavaImplementationCompatibility(_TestWithJavaS3GatewayMixin, unittest.TestCase):
-    s3 = True
-
-    def setUp(self):
-        super(S3ClientSideEncryptionTestJavaImplementationCompatibility, self).setUp()
-        self.conn = S3Connection()
-        self.bucket_name = 'client-side-encryption-%d' % int(time.time())
-        self.bucket = self.conn.create_bucket(self.bucket_name)
-
-    def tearDown(self):
-        for key in self.bucket:
-            key.delete()
-        self.bucket.delete()
-        super(S3ClientSideEncryptionTestJavaImplementationCompatibility, self).setUp()
+class S3ClientSideEncryptionTestJavaImplementationCompatibility(_TestWithS3BucketMixin, _TestWithJavaS3GatewayMixin,
+                                                                unittest.TestCase):
 
     @unittest.skipIf(not psutil or not py4j, "Please install psutil and py4j to run this test")
     def test_client_side_encryption_java_compatibility(self):

--- a/tests/integration/s3/test_client_side_encryption.py
+++ b/tests/integration/s3/test_client_side_encryption.py
@@ -68,6 +68,7 @@ class S3ClientSideEncryptionTest(unittest.TestCase):
 
             key_name_base = 'foo-{key_content_index}-encrypted-using-key-{encryption_key_index}-method-{method_index}'
             key_contents = [
+                '',   # Empty content, edge case
                 '0123456701234567',   # Small content, multiple of the block size (16)
                 '0123456701234567' + '0',  # Small content, needs padding
                 '0123456701234567' * 2**6,        # 1Kb content, multiple of the block size (16)
@@ -310,6 +311,7 @@ class S3ClientSideEncryptionTestJavaImplementationCompatibility(_TestWithJavaS3G
 
             key_name_base = 'foo-{key_content_index}-encrypted-using-key-{encryption_key_index}'
             key_contents = [
+                '',   # Empty content, edge case
                 '0123456701234567',   # Small content, multiple of the block size (16)
                 '0123456701234567' + '0',  # Small content, needs padding
                 '0123456701234567' * 2**6,        # 1Kb content, multiple of the block size (16)

--- a/tests/integration/s3/test_client_side_encryption.py
+++ b/tests/integration/s3/test_client_side_encryption.py
@@ -1,0 +1,139 @@
+"""
+Some unit tests for the S3 Client Side Encryption
+"""
+import os
+import shutil
+import subprocess
+import unittest
+import time
+import urllib
+import binascii
+import urllib2
+
+from boto.s3.connection import S3Connection
+
+
+class S3ClientSideEncryptionTest(unittest.TestCase):
+    s3 = True
+
+    def setUp(self):
+        super(S3ClientSideEncryptionTest, self).setUp()
+        self.conn = S3Connection()
+        self.bucket_name = 'client-side-encryption-%d' % int(time.time())
+        self.bucket = self.conn.create_bucket(self.bucket_name)
+
+    def tearDown(self):
+        for key in self.bucket:
+            key.delete()
+        self.bucket.delete()
+        super(S3ClientSideEncryptionTest, self).tearDown()
+
+    def test_client_side_encryption(self):
+        print('--- running {} tests ---'.format(self.__class__.__name__))
+
+        client_side_encryption_keys = [
+            ''.join([chr(0)] * (128 / 8)),  # Zero-key, AES 128
+            ''.join([chr(0)] * (192 / 8)),  # Zero-key, AES 192
+            ''.join([chr(0)] * (256 / 8)),  # Zero-key, AES 256
+            os.urandom(128 / 8),  # Random-key, AES 128
+            os.urandom(192 / 8),  # Random-key, AES 192
+            os.urandom(256 / 8),  # Random-key, AES 256
+        ]
+        for encryption_key_index, encryption_key in enumerate(client_side_encryption_keys):
+            encryption_key_hex = binascii.b2a_hex(encryption_key)
+            encryption_key_base64 = binascii.b2a_base64(encryption_key)
+            print 'Key of size {}, hex={}, base64={}'.format(
+                8 * len(encryption_key),
+                encryption_key_hex,
+                encryption_key_base64
+            )
+
+            encrypted_connection = S3Connection(client_side_encryption_key=encryption_key)
+            encrypted_bucket = encrypted_connection.get_bucket(self.bucket_name)
+
+            unencrypted_connection = S3Connection()
+            unencrypted_bucket = unencrypted_connection.get_bucket(self.bucket_name)
+
+            key_name_base = 'foo-{key_content_index}-encrypted-using-key-{encryption_key_index}-method-{method_index}'
+            key_contents = [
+                '0123456701234567',   # Small content, multiple of the block size (16)
+                '0123456701234567' + '0',  # Small content, needs padding
+                '0123456701234567' * 2**6,        # 1Kb content, multiple of the block size (16)
+                '0123456801234567' * 2**6 + '0',  # 1Kb content, needs padding
+            ]
+            for key_content_index, key_content in enumerate(key_contents):
+                print '\tTest using content {}'.format(key_content_index)
+
+                methods = [
+                    lambda key, content, filename, fp: key.set_contents_from_string(content),
+                    lambda key, content, filename, fp: key.set_contents_from_filename(filename),
+                    lambda key, content, filename, fp: key.set_contents_from_file(fp),
+                    # BotoClientError: s3 does not support chunked transfer
+                    # lambda key, content, filename, fp: key.set_contents_from_stream(fp),
+                ]
+                for method_index, method in enumerate(methods):
+                    print '\t\tTest using method {}'.format(method_index)
+
+                    key_size = len(key_content)
+                    key_name = key_name_base.format(key_content_index=key_content_index,
+                                                    encryption_key_index=encryption_key_index,
+                                                    method_index=method_index)
+
+                    key_content_filename = '/tmp/{}'.format(key_name)
+                    with open(key_content_filename, 'w') as key_content_fp:
+                        key_content_fp.write(key_content)
+
+                    # Encrypted content shouldn't be readable
+                    with open(key_content_filename, 'r') as key_content_fp:
+                        encrypted_key = encrypted_bucket.new_key(key_name)
+                        unencrypted_key = unencrypted_bucket.new_key(key_name)
+                        method(encrypted_key, key_content, key_content_filename, key_content_fp)
+                        raw_content = unencrypted_key.get_contents_as_string()
+                        decrypted_content = encrypted_key.get_contents_as_string()
+                        self.assertNotEqual(key_content, raw_content)
+                        self.assertEqual(key_content, decrypted_content)
+
+                    # Unencrypted content should still be readable
+                    # (files stored in clear can still be read)
+                    with open(key_content_filename, 'r') as key_content_fp:
+                        encrypted_key = encrypted_bucket.new_key(key_name)
+                        unencrypted_key = unencrypted_bucket.new_key(key_name)
+                        method(unencrypted_key, key_content, key_content_filename, key_content_fp)
+                        raw_content = unencrypted_key.get_contents_as_string()
+                        decrypted_content = encrypted_key.get_contents_as_string()
+                        self.assertEqual(key_content, raw_content)
+                        self.assertEqual(key_content, decrypted_content)
+
+                    # Successive GET should return the same value (checks internal state/caching)
+                    with open(key_content_filename, 'r') as key_content_fp:
+                        encrypted_key = encrypted_bucket.new_key(key_name)
+                        method(encrypted_key, key_content, key_content_filename, key_content_fp)
+                        decrypted_content1 = encrypted_key.get_contents_as_string()
+                        decrypted_content2 = encrypted_key.get_contents_as_string()
+                        self.assertEqual(key_content, decrypted_content1)
+                        self.assertEqual(key_content, decrypted_content2)
+
+                    # PUT/GET x2 using the same key object
+                    # This checks if the iv and the key are updated properly
+                    encrypted_key = encrypted_bucket.new_key(key_name)
+                    with open(key_content_filename, 'r') as key_content_fp:
+                        method(encrypted_key, key_content, key_content_filename, key_content_fp)
+                        decrypted_content1 = encrypted_key.get_contents_as_string()
+                    with open(key_content_filename, 'r') as key_content_fp:
+                        method(encrypted_key, key_content, key_content_filename, key_content_fp)
+                        decrypted_content2 = encrypted_key.get_contents_as_string()
+                    self.assertEqual(key_content, decrypted_content1)
+                    self.assertEqual(key_content, decrypted_content2)
+
+                    # Check that the size is correct
+                    with open(key_content_filename, 'r') as key_content_fp:
+                        # The size should be set after an upload
+                        encrypted_key1 = encrypted_bucket.new_key(key_name)
+                        method(encrypted_key1, key_content, key_content_filename, key_content_fp)
+                        self.assertEqual(encrypted_key1.size, key_size)
+                        # The size should be set after a download
+                        encrypted_key2 = encrypted_bucket.new_key(key_name)
+                        decrypted_content2 = encrypted_key2.get_contents_as_string()
+                        self.assertEqual(encrypted_key2.size, key_size)
+
+        print('--- {} tests completed ---'.format(self.__class__.__name__))

--- a/tests/unit/s3/test_key.py
+++ b/tests/unit/s3/test_key.py
@@ -86,6 +86,7 @@ class TestS3Key(AWSMockServiceTestCase):
         # Mock out the bucket object - we really only care about calls
         # to list.
         k.bucket = mock.MagicMock()
+        k.bucket.connection.client_side_encryption_key = None
 
         # Default behavior doesn't call list
         k.set_contents_from_string('test')


### PR DESCRIPTION
## Overview

This pull request adds the support of multipart uploads with client-side encryption. It is based of the work done in #2671.

Multipart upload without client-side encryption provides [the following advantages](http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html):

> 1. **Improved throughput**—You can upload parts in parallel to improve throughput.
> 2. **Quick recovery from any network issues**—Smaller part size minimizes the impact of restarting a failed upload due to a network error.
> 3. **Pause and resume object uploads**—You can upload object parts over time. Once you initiate a multipart upload there is no expiry; you must explicitly complete or abort the multipart upload.
> 4. **Begin an upload before you know the final object size**—You can upload an object as you are creating it.

The advantages `2.`, `3.` and `4.` will still exist with client-side encryption but not `1.` because the current implementation uses [CBC](http://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher-block_chaining_.28CBC.29). This could be improved in the future by using GCM (see [counter mode](http://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Counter_.28CTR.29)).
## Usage

If you upload all the parts in the same process, you only need to:
- instantiate your connection with an encryption key (see #2671)
- upload the parts in order
## Advanced usage

By default, you won't be able to upload different parts from different processes because to encrypt a part you need the last block of the previous part, the envelope key and some information about the padding. These values are kept on the connection in the `client_side_encryption_registry`. 

You can get around the problem by implementing your own `client_side_encryption_registry`. Example from the tests:

```
class MemcachedDictionary(object):

    def __init__(self, memcache_client):
        self.memcache_client = memcache_client

    def __getitem__(self, key):
        return self.memcache_client.get(key)

    def get(self, key, default):
        if not key in self:
            return default
        return self[key]

    def __setitem__(self, key, value):
        self.memcache_client.set(key, value, time=60*60)

    def __delitem__(self, key):
        self.memcache_client.delete(key)

    def keys(self):
        # This will prevent the deletion of the data of completed uploads, but should be enough for the tests
        return []

    def __contains__(self, key):
        return self.memcache_client.get(key) is not None

memcache_client = MemcachedDictionary(memcache.Client(['127.0.0.1:11211']))
connection = S3Connection(
    client_side_encryption_key=...,
    client_side_encryption_registry=memcache_client,
)

...
```

You only need to implement the methods listed above to have a functional `client_side_encryption_registry`.
## Testing

I added some tests to make sure that the content  is encrypted properly and that the parts can be uploaded from different processes.
