### PR TITLE
Fix str encode for request with proxy (Py3)

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -793,18 +793,18 @@ class AWSAuthConnection(object):
         else:
             sock = socket.create_connection((self.proxy, int(self.proxy_port)))
         boto.log.debug("Proxy connection: CONNECT %s HTTP/1.0\r\n", host)
-        sock.sendall("CONNECT %s HTTP/1.0\r\n" % host)
-        sock.sendall("User-Agent: %s\r\n" % UserAgent)
+        sock.sendall(("CONNECT %s HTTP/1.0\r\n" % host).encode())
+        sock.sendall(("User-Agent: %s\r\n" % UserAgent).encode())
         if self.proxy_user and self.proxy_pass:
             for k, v in self.get_proxy_auth_header().items():
-                sock.sendall("%s: %s\r\n" % (k, v))
+                sock.sendall(("%s: %s\r\n" % (k, v)).encode())
             # See discussion about this config option at
             # https://groups.google.com/forum/?fromgroups#!topic/boto-dev/teenFvOq2Cc
             if config.getbool('Boto', 'send_crlf_after_proxy_auth_headers', False):
-                sock.sendall("\r\n")
+                sock.sendall(("\r\n").encode())
         else:
-            sock.sendall("\r\n")
-        resp = http_client.HTTPResponse(sock, strict=True, debuglevel=self.debug)
+            sock.sendall(("\r\n").encode())
+        resp = http_client.HTTPResponse(sock, debuglevel=self.debug)
         resp.begin()
 
         if resp.status != 200:


### PR DESCRIPTION
to fix this error:

``` python
Traceback (most recent call last):
  File "<pyshell#6>", line 1, in <module>
    conn.send_email('foo@bar.com', 'Foo!', 'Bar', ['bar@foo.com])
  File "C:\Python34\lib\site-packages\boto\ses\connection.py", line 276, in send_email
    return self._make_request('SendEmail', params)
  File "C:\Python34\lib\site-packages\boto\ses\connection.py", line 102, in _make_request
    data=urllib.parse.urlencode(params)
  File "C:\Python34\lib\site-packages\boto\connection.py", line 1068, in make_request
    retry_handler=retry_handler)
  File "C:\Python34\lib\site-packages\boto\connection.py", line 913, in _mexe
    self.is_secure)
  File "C:\Python34\lib\site-packages\boto\connection.py", line 705, in get_http_connection
    return self.new_http_connection(host, port, is_secure)
  File "C:\Python34\lib\site-packages\boto\connection.py", line 747, in new_http_connection
    connection = self.proxy_ssl(host, is_secure and 443 or 80)
  File "C:\Python34\lib\site-packages\boto\connection.py", line 796, in proxy_ssl
    sock.sendall("CONNECT %s HTTP/1.0\r\n" % host)
TypeError: 'str' does not support the buffer interface
```
