### PR TITLE
ELB also needs v4 signature on new regions, just like EC2.

### DIFF
--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -33,6 +33,7 @@ from boto.ec2.elb.healthcheck import HealthCheck
 from boto.regioninfo import RegionInfo, get_regions, load_regions
 import boto
 from boto.compat import six
+from boto.auth import detect_potential_sigv4
 
 RegionData = load_regions().get('elasticloadbalancing', {})
 
@@ -97,6 +98,7 @@ class ELBConnection(AWSQueryConnection):
                                             validate_certs=validate_certs,
                                             profile_name=profile_name)
 
+    @detect_potential_sigv4
     def _required_auth_capability(self):
         return ['ec2']
 


### PR DESCRIPTION
With the addition of the eu-central-1 region to boto 2.34, connecting to ELB on eu-central-1 fails because it requires the v4 signature, and the code is trying to authenticate with the v2 signature.  I've just added in the same decorator as used in the EC2 connection, which uses the v4 signature for regions that require it.  I'd ask that you merge this ASAP, as the functionality is broken at the moment -- in my case, this means I have to downgrade back to boto 2.32 or my application breaks.
