### PR TITLE
Improve handling of HTTP 204 responses.

### DIFF
--- a/boto/glacier/response.py
+++ b/boto/glacier/response.py
@@ -36,9 +36,10 @@ class GlacierResponse(dict):
         if response_headers:
             for header_name, item_name in response_headers:
                 self[item_name] = http_response.getheader(header_name)
-        if http_response.getheader('Content-Type') == 'application/json':
-            body = json.loads(http_response.read().decode('utf-8'))
-            self.update(body)
+        if http_response.status != 204: 
+            if http_response.getheader('Content-Type') == 'application/json':
+                body = json.loads(http_response.read().decode('utf-8'))
+                self.update(body)
         size = http_response.getheader('Content-Length', None)
         if size is not None:
             self.size = size

--- a/tests/unit/glacier/test_response.py
+++ b/tests/unit/glacier/test_response.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2013 Amazon.com, Inc. or its affiliates.  All Rights Reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+from tests.unit import AWSMockServiceTestCase
+from boto.glacier.layer1 import Layer1
+from boto.glacier.response import GlacierResponse
+
+class TestResponse(AWSMockServiceTestCase):
+    connection_class = Layer1
+
+    def test_204_body_isnt_passed_to_json(self):
+        response = self.create_response(status_code=204,header=[('Content-Type','application/json')])
+        result = GlacierResponse(response,response.getheaders())
+        self.assertEquals(result.status, response.status)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
HTTP 204 responses have no body, but can have any headers they like,
including, counter-intuitively, ones specifying the content type.

This makes sure Boto won't pass a 0 length body to the json parser in
response to a 204 status from Glacier.

Unit test added to catch any regression.
