### PR TITLE
correct argument type in doc string

### DIFF
--- a/boto/route53/record.py
+++ b/boto/route53/record.py
@@ -123,7 +123,7 @@ class ResourceRecordSets(ResultSet):
             a value that determines which region this should be associated with
             for the latency-based routing
 
-        :type alias_evaluate_target_health: Boolean
+        :type alias_evaluate_target_health: bool
         :param alias_evaluate_target_health: *Required for alias resource record
             sets* Indicates whether this Resource Record Set should respect the
             health status of any health checks associated with the ALIAS target


### PR DESCRIPTION
Calling the argument alias_evaluate_target_health a Boolean rather than a bool causes some static analysis to report an error incorrectly.
