### PR TITLE
Allowing user to override endpoint hostname / is_secure / port in the configuration file

### DIFF
--- a/boto/dynamodb2/layer1.py
+++ b/boto/dynamodb2/layer1.py
@@ -176,10 +176,22 @@ class DynamoDBConnection(AWSQueryConnection):
         if 'host' not in kwargs:
             kwargs['host'] = region.endpoint
 
+        if boto.config.has_option('DynamoDB', 'endpoint'):
+            kwargs['host'] = boto.config.get('DynamoDB', 'endpoint')
+
+        if boto.config.has_option('DynamoDB', 'port'):
+            kwargs['port'] = boto.config.getint('DynamoDB', 'port')
+
+        if boto.config.has_option('DynamoDB', 'is_secure'):
+            kwargs['is_secure'] = boto.config.getbool(
+                'DynamoDB', 'is_secure', True)
+
         super(DynamoDBConnection, self).__init__(**kwargs)
         self.region = region
         self._validate_checksums = boto.config.getbool(
             'DynamoDB', 'validate_checksums', validate_checksums)
+
+
         self.throughput_exceeded_events = 0
 
     def _required_auth_capability(self):

--- a/tests/integration/dynamodb2/test_boto_cfg.py
+++ b/tests/integration/dynamodb2/test_boto_cfg.py
@@ -1,0 +1,19 @@
+import unittest
+import os
+
+
+CURRENT_DIR = os.path.dirname(
+    os.path.realpath(__file__))
+
+
+class BotoConfigOverrideTestcase(unittest.TestCase):
+
+    def setUp(self):
+        os.environ['BOTO_PATH'] = os.path.join(CURRENT_DIR, 'ut_boto.cfg')
+
+    def test_dynamodb2(self):
+        import boto.dynamodb2
+        conn = boto.dynamodb2.connect_to_region('ap-southeast-2')
+        self.assertEqual(conn.is_secure, False)
+        self.assertEqual(conn.host, 'localhost')
+        self.assertEqual(conn.port, 8000)

--- a/tests/integration/dynamodb2/ut_boto.cfg
+++ b/tests/integration/dynamodb2/ut_boto.cfg
@@ -1,0 +1,8 @@
+[Credentials]
+aws_access_key_id = ut
+aws_secret_access_key = ut
+
+[DynamoDB]
+is_secure = False
+endpoint = localhost
+port = 8000


### PR DESCRIPTION
The following code changes, is an enhancement to DynamoDB section of boto config.
It provides three options:
is_secure, endpoint, port which are one to one mapped to key word arguments (is_secure, host, port)  in class DynamoDBConnection.

The user would be allowed to override DynamoDB endpoint / port / is_secure parameters, rather than modifying the code, but by supplying customized DynamoDB section in boto config.

Which can be very useful in some scenario, for example, using DynamoDB Local for unit testing.

Here is the example.
If you start your DynamoDB local on your port 8000, and have following BOTO_CONFIG:

```
[DynamoDB]
is_secure = False
endpoint = localhost
port = 8000
```

You would be able to connect to your dynamodb local using following code:

```
import boto.dynamodb2
conn = boto.dynamodb2.connect_to_region(YOUR_REGION)
# It would connect to YOUR_REGION if DynamoDB section in boto_config is not provided.
# otherwise it would connect to the endpoints/port 
# that are provided by DynamoDB section in boto_config.
```

PS: This code changes are only valid for boto.dynamodb2 only, but it wouldn't be difficult to implement the counter part for boto.dynamodb. Would love to do that if you think this is useful.
