### PR TITLE
Fix for forcing user to change password at next login

### DIFF
--- a/boto/iam/connection.py
+++ b/boto/iam/connection.py
@@ -964,7 +964,7 @@ class IAMConnection(AWSQueryConnection):
         params = {'UserName': user_name}
         return self.get_response('DeleteLoginProfile', params)
 
-    def update_login_profile(self, user_name, password):
+    def update_login_profile(self, user_name, password=None, password_reset_required=False): 
         """
         Resets the password associated with the user's login profile.
 
@@ -974,9 +974,15 @@ class IAMConnection(AWSQueryConnection):
         :type password: string
         :param password: The new password for the user
 
+        :type password_reset_required: boolean
+        :param password_reset_required: Should the user be required to change the password next login.
+
         """
-        params = {'UserName': user_name,
-                  'Password': password}
+        params = {'UserName': user_name}
+        if password:
+            params['Password'] = password
+        if password_reset_required == True:
+            params['PasswordResetRequired'] = 'true'        
         return self.get_response('UpdateLoginProfile', params)
 
     def create_account_alias(self, alias):


### PR DESCRIPTION
Fix for forcing user to change password at next login.

AWS has a setting the mark a user for forcing password change at the next login. More details here: http://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateLoginProfile.html

This adds the feature to boto. 

Fix for #2732 
