### PR TITLE
Fix Key.change_storage_class so that it obeys dst_bucket

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -426,12 +426,13 @@ class Key(object):
         :param validate_dst_bucket: If True, will validate the dst_bucket
             by using an extra list request.
         """
+        bucket_name = dst_bucket or self.bucket.name
         if new_storage_class == 'STANDARD':
-            return self.copy(self.bucket.name, self.name,
+            return self.copy(bucket_name, self.name,
                              reduced_redundancy=False, preserve_acl=True,
                              validate_dst_bucket=validate_dst_bucket)
         elif new_storage_class == 'REDUCED_REDUNDANCY':
-            return self.copy(self.bucket.name, self.name,
+            return self.copy(bucket_name, self.name,
                              reduced_redundancy=True, preserve_acl=True,
                              validate_dst_bucket=validate_dst_bucket)
         else:

--- a/tests/unit/s3/test_key.py
+++ b/tests/unit/s3/test_key.py
@@ -103,6 +103,54 @@ class TestS3Key(AWSMockServiceTestCase):
         k.set_contents_from_string('test')
         k.bucket.list.assert_not_called()
 
+    def test_change_storage_class(self):
+        self.set_http_response(status_code=200)
+        b = Bucket(self.service_connection, 'mybucket')
+        k = b.get_key('fookey')
+
+        # Mock out Key.copy so we can record calls to it
+        k.copy = mock.MagicMock()
+        # Mock out the bucket so we don't actually need to have fake responses
+        k.bucket = mock.MagicMock()
+        k.bucket.name = 'mybucket'
+
+        self.assertEqual(k.storage_class, 'STANDARD')
+
+        # The default change_storage_class call should result in a copy to our
+        # bucket
+        k.change_storage_class('REDUCED_REDUNDANCY')
+        k.copy.assert_called_with(
+            'mybucket',
+            'fookey',
+            reduced_redundancy=True,
+            preserve_acl=True,
+            validate_dst_bucket=True,
+        )
+
+    def test_change_storage_class_new_bucket(self):
+        self.set_http_response(status_code=200)
+        b = Bucket(self.service_connection, 'mybucket')
+        k = b.get_key('fookey')
+
+        # Mock out Key.copy so we can record calls to it
+        k.copy = mock.MagicMock()
+        # Mock out the bucket so we don't actually need to have fake responses
+        k.bucket = mock.MagicMock()
+        k.bucket.name = 'mybucket'
+
+        self.assertEqual(k.storage_class, 'STANDARD')
+        # Specifying a different dst_bucket should result in a copy to the new
+        # bucket
+        k.copy.reset_mock()
+        k.change_storage_class('REDUCED_REDUNDANCY', dst_bucket='yourbucket')
+        k.copy.assert_called_with(
+            'yourbucket',
+            'fookey',
+            reduced_redundancy=True,
+            preserve_acl=True,
+            validate_dst_bucket=True,
+        )
+
 
 def counter(fn):
     def _wrapper(*args, **kwargs):


### PR DESCRIPTION
Key.change_storage_class() accepts a dst_bucket parameter which is supposed to let you copy the key to another bucket. However, it appears as though this parameter is ignored.
