### PR TITLE
fix keypair.save() to work with Python3 (unicode/byte strings)

### DIFF
--- a/boto/ec2/keypair.py
+++ b/boto/ec2/keypair.py
@@ -82,7 +82,7 @@ class KeyPair(EC2Object):
             if os.path.exists(file_path):
                 raise BotoClientError('%s already exists, it will not be overwritten' % file_path)
             with open(file_path, 'wb') as fp:
-                fp.write(self.material.encode('ascii'))
+                fp.write(self.material)
             os.chmod(file_path, 0o600)
             return True
         else:

--- a/boto/ec2/keypair.py
+++ b/boto/ec2/keypair.py
@@ -81,7 +81,7 @@ class KeyPair(EC2Object):
             file_path = os.path.join(directory_path, '%s.pem' % self.name)
             if os.path.exists(file_path):
                 raise BotoClientError('%s already exists, it will not be overwritten' % file_path)
-            with open(file_path, 'wb') as fp:
+            with open(file_path, 'w') as fp:
                 fp.write(self.material)
             os.chmod(file_path, 0o600)
             return True

--- a/boto/ec2/keypair.py
+++ b/boto/ec2/keypair.py
@@ -81,9 +81,8 @@ class KeyPair(EC2Object):
             file_path = os.path.join(directory_path, '%s.pem' % self.name)
             if os.path.exists(file_path):
                 raise BotoClientError('%s already exists, it will not be overwritten' % file_path)
-            fp = open(file_path, 'wb')
-            fp.write(self.material)
-            fp.close()
+            with open(file_path, 'wb') as fp:
+                fp.write(self.material.encode('ascii'))
             os.chmod(file_path, 0o600)
             return True
         else:


### PR DESCRIPTION
Quickfix to make KeyPair.save() work with Python 3 (self.material is a str in Python 2 and Python 3, so the file needs to be opened in text mode).

Should work with Python 2.6 (uses "with" statement) and up.
