### PR TITLE
Updated #put_record docstring

### DIFF
--- a/boto/kinesis/layer1.py
+++ b/boto/kinesis/layer1.py
@@ -548,8 +548,8 @@ class KinesisConnection(AWSQueryConnection):
         :type data: blob
         :param data: The data blob to put into the record, which is
             Base64-encoded when the blob is serialized.
-            The maximum size of the data blob (the payload after
-            Base64-decoding) is 50 kilobytes (KB)
+            The maximum size of a data blob (the data payload
+            before Base64-encoding) is 50 kilobytes (KB)
             Set `b64_encode` to disable automatic Base64 encoding.
 
         :type partition_key: string


### PR DESCRIPTION
AWS has changed the kinesis docs to say that the payload should be no more than 50KB **before** base64 encoding.
- http://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html#API_PutRecord_RequestSyntax
- http://docs.aws.amazon.com/kinesis/latest/dev/key-concepts.html#partition-key
