### PR TITLE
HTTPRequest.headers is a (str,str) dictionary.

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -381,7 +381,7 @@ class HTTPRequest(object):
         if 'Content-Length' not in self.headers:
             if 'Transfer-Encoding' not in self.headers or \
                     self.headers['Transfer-Encoding'] != 'chunked':
-                self.headers['Content-Length'] = len(self.body)
+                self.headers['Content-Length'] = str(len(self.body))
 
 
 class HTTPResponse(http_client.HTTPResponse):


### PR DESCRIPTION
Throughout the whole code, it is assumed of the value to be a string.
Nevertheless, in HTTPRequest.authorize() an int was assigned, leading
to nasty exceptions occuring in strange moments.
