### PR TITLE
Fix bug that prevented initializing a dynamo item from existing item

### DIFF
--- a/boto/dynamodb2/items.py
+++ b/boto/dynamodb2/items.py
@@ -35,7 +35,8 @@ class Item(object):
         being table-level. It's also for persisting schema around many objects.
 
         Optionally accepts a ``data`` parameter, which should be a dictionary
-        of the fields & values of the item.
+        of the fields & values of the item. Alternatively, an ``Item`` instance
+        may be provided from which to extract the data.
 
         Optionally accepts a ``loaded`` parameter, which should be a boolean.
         ``True`` if it was preexisting data loaded from DynamoDB, ``False`` if
@@ -71,6 +72,8 @@ class Item(object):
         self._data = data
         self._dynamizer = Dynamizer()
 
+        if isinstance(self._data, Item):
+            self._data = self._data._data
         if self._data is None:
             self._data = {}
 

--- a/tests/unit/dynamodb2/test_table.py
+++ b/tests/unit/dynamodb2/test_table.py
@@ -823,6 +823,12 @@ class ItemTestCase(unittest.TestCase):
         self.assertFalse(self.create_item({}))
 
 
+class ItemFromItemTestCase(ItemTestCase):
+    def setUp(self):
+        super(ItemFromItemTestCase, self).setUp()
+        self.johndoe = self.create_item(self.johndoe)
+
+
 def fake_results(name, greeting='hello', exclusive_start_key=None, limit=None):
     if exclusive_start_key is None:
         exclusive_start_key = -1


### PR DESCRIPTION
Switching from Boto 2.27 to 2.34 breaks the ability to create an Item by passing another directly into the ‘data’ field.

In 2.27 you can do (where item is dynamodb2.items.Item, and history_table is a separate table):
history_item = Item(history_table, data=item)
history_item.save()

But with 2.33 you get an exception during save() -> mark_clean() -> copy.deepcopy(). An exception here would make it seem like the save was unsuccessful, but it actually does save to the database.

To maintain backwards compatability and clear confusion on DB state by the exceptions that get raised, here is a fix. 

cc @danielgtaylor @jamesls 
