### PR TITLE
Throw host warning for cloudsearch domain

### DIFF
--- a/boto/cloudsearchdomain/layer1.py
+++ b/boto/cloudsearchdomain/layer1.py
@@ -60,7 +60,12 @@ class CloudSearchDomainConnection(AWSAuthConnection):
         else:
             del kwargs['region']
         if kwargs.get('host', None) is None:
-            kwargs['host'] = region.endpoint
+            raise ValueError(
+                'The argument, host, must be provided when creating a '
+                'CloudSearchDomainConnection because its methods require the '
+                'specific domain\'s endpoint in order to successfully make '
+                'requests to that CloudSearch Domain.'
+            )
         super(CloudSearchDomainConnection, self).__init__(**kwargs)
         self.region = region
     

--- a/tests/unit/cloudsearchdomain/test_cloudsearchdomain.py
+++ b/tests/unit/cloudsearchdomain/test_cloudsearchdomain.py
@@ -29,6 +29,12 @@ class CloudSearchDomainConnectionTest(AWSMockServiceTestCase):
         "SearchPartitionCount": 0
       }"""
 
+    def create_service_connection(self, **kwargs):
+        if kwargs.get('host', None) is None:
+            kwargs['host'] = 'search-demo.us-east-1.cloudsearch.amazonaws.com'
+        return super(CloudSearchDomainConnectionTest, self).\
+            create_service_connection(**kwargs)
+
     def test_get_search_service(self):
         layer1 = CloudSearchConnection(aws_access_key_id='aws_access_key_id',
                                        aws_secret_access_key='aws_secret_access_key',
@@ -111,3 +117,11 @@ class CloudSearchDomainConnectionTest(AWSMockServiceTestCase):
         headers = self.actual_request.headers
 
         self.assertIsNotNone(headers.get('Authorization'))
+
+    def test_no_host_provided(self):
+        # A host must be provided or a error is thrown.
+        with self.assertRaises(ValueError):
+            CloudSearchDomainConnection(
+                aws_access_key_id='aws_access_key_id',
+                aws_secret_access_key='aws_secret_access_key'
+            )


### PR DESCRIPTION
If a host is not specified for the cloudsearch domain connection, its request methods will fail. This will help ensure users supply the host url before using any of its methods.

cc @jamesls @danielgtaylor 
