### PR TITLE
Fix the SQS certificate error for region cn-north-1

### DIFF
--- a/boto/endpoints.json
+++ b/boto/endpoints.json
@@ -324,7 +324,7 @@
         "ap-northeast-1": "ap-northeast-1.queue.amazonaws.com",
         "ap-southeast-1": "ap-southeast-1.queue.amazonaws.com",
         "ap-southeast-2": "ap-southeast-2.queue.amazonaws.com",
-        "cn-north-1": "sqs.cn-north-1.amazonaws.com.cn",
+        "cn-north-1": "cn-north-1.queue.amazonaws.com.cn",
         "eu-west-1": "eu-west-1.queue.amazonaws.com",
         "sa-east-1": "sa-east-1.queue.amazonaws.com",
         "us-east-1": "queue.amazonaws.com",


### PR DESCRIPTION
Fix this error:
InvalidCertificateException: Host sqs.cn-north-1.amazonaws.com.cn returned an invalid certificate
