### PR TITLE
Detect old-style S3 URL for auto-sigv4.

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -51,6 +51,16 @@ except ImportError:
     sha256 = None
 
 
+# Region detection strings to determine if SigV4 should be used
+# by default.
+SIGV4_DETECT = [
+    '.cn-',
+    # In eu-central we support both host styles for S3
+    '.eu-central',
+    '-eu-central',
+]
+
+
 class HmacKeys(object):
     """Key based Auth handler helper."""
 
@@ -1003,9 +1013,9 @@ def detect_potential_sigv4(func):
             # ``boto/iam/connection.py``, as several things there are also
             # endpoint-related.
             if getattr(self.region, 'endpoint', ''):
-                if '.cn-' in self.region.endpoint or \
-                        '.eu-central' in self.region.endpoint:
-                    return ['hmac-v4']
+                for test in SIGV4_DETECT:
+                    if test in self.region.endpoint:
+                        return ['hmac-v4']
 
         return func(self)
     return _wrapper
@@ -1023,8 +1033,9 @@ def detect_potential_s3sigv4(func):
             # If you're making changes here, you should also check
             # ``boto/iam/connection.py``, as several things there are also
             # endpoint-related.
-            if '.cn-' in self.host or '.eu-central' in self.host:
-                return ['hmac-v4-s3']
+            for test in SIGV4_DETECT:
+                if test in self.host:
+                    return ['hmac-v4-s3']
 
         return func(self)
     return _wrapper

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -531,8 +531,10 @@ class TestS3SigV4OptIn(MockServiceWithConfigTestCase):
 
     def test_sigv4_non_optional(self):
         # Requires SigV4.
-        fake = FakeS3Connection(host='s3.cn-north-1.amazonaws.com.cn')
-        self.assertEqual(fake._required_auth_capability(), ['hmac-v4-s3'])
+        for region in ['.cn-north', '.eu-central', '-eu-central']:
+            fake = FakeS3Connection(host='s3' + region + '-1.amazonaws.com')
+            self.assertEqual(
+                fake._required_auth_capability(), ['hmac-v4-s3'])
 
     def test_sigv4_opt_in_config(self):
         # Opt-in via the config.


### PR DESCRIPTION
This fixes detection of signature version 4 for the eu-central-1 region
when creating connections using the old-style URL, which is listed on
the [supported regions and endpoints](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region):

```
s3-eu-central-1.amazonaws.com
```

cc @kyleknap, @jamesls 
