### PR TITLE
fix: snap.create_volume documentation lists general purpose ssd

### DIFF
--- a/boto/ec2/snapshot.py
+++ b/boto/ec2/snapshot.py
@@ -141,7 +141,7 @@ class Snapshot(TaggedEC2Object):
 
         :type volume_type: string
         :param volume_type: The type of the volume. (optional).  Valid
-            values are: standard | io1.
+            values are: standard | io1 | gp2.
 
         :type iops: int
         :param iops: The provisioned IOPs you want to associate with


### PR DESCRIPTION
Just a small documentation fix :+1: 
