### PR TITLE
Adds SupportedProducts field to EMR JobFlow objects.

### DIFF
--- a/boto/emr/emrobject.py
+++ b/boto/emr/emrobject.py
@@ -64,6 +64,10 @@ class StepId(Arg):
     pass
 
 
+class SupportedProduct(Arg):
+    pass
+
+
 class JobFlowStepList(EmrObject):
     def __ini__(self, connection=None):
         self.connection = connection
@@ -190,6 +194,9 @@ class JobFlow(EmrObject):
         elif name == 'BootstrapActions':
             self.bootstrapactions = ResultSet([('member', BootstrapAction)])
             return self.bootstrapactions
+        elif name == 'SupportedProducts':
+            self.supported_products = ResultSet([('member', SupportedProduct)])
+            return self.supported_products
         else:
             return None
 

--- a/tests/unit/emr/test_emr_responses.py
+++ b/tests/unit/emr/test_emr_responses.py
@@ -42,6 +42,21 @@ JOB_FLOW_EXAMPLE = b"""
           <StartDateTime>2009-01-28T21:49:16Z</StartDateTime>
           <State>STARTING</State>
         </ExecutionStatusDetail>
+        <BootstrapActions>
+          <member>
+            <BootstrapActionConfig>
+              <ScriptBootstrapAction>
+                <Args/>
+                <Path>s3://elasticmapreduce/libs/hue/install-hue</Path>
+              </ScriptBootstrapAction>
+              <Name>Install Hue</Name>
+            </BootstrapActionConfig>
+          </member>
+        </BootstrapActions>
+        <VisibleToAllUsers>true</VisibleToAllUsers>
+        <SupportedProducts>
+          <member>Hue</member>
+        </SupportedProducts>
         <Name>MyJobFlowName</Name>
         <LogUri>mybucket/subdir/</LogUri>
         <Steps>


### PR DESCRIPTION
This fixes an issue where responses containing the SupportedProducts field
prevented other existing fields from being filled in. Also updates an
existing test to fail without this fix.

cc @jamesls, @kyleknap 
