### PR TITLE
[RDS2] Resolve the error "TypeError: the JSON object must be str, not 'bytes'"

### DIFF
--- a/boto/rds2/layer1.py
+++ b/boto/rds2/layer1.py
@@ -3760,6 +3760,8 @@ class RDSConnection(AWSQueryConnection):
                                      path='/', params=params)
         body = response.read()
         boto.log.debug(body)
+        if type(body) == bytes:
+            body = body.decode(encoding='UTF-8')
         if response.status == 200:
             return json.loads(body)
         else:

--- a/boto/rds2/layer1.py
+++ b/boto/rds2/layer1.py
@@ -3761,7 +3761,7 @@ class RDSConnection(AWSQueryConnection):
         body = response.read()
         boto.log.debug(body)
         if type(body) == bytes:
-            body = body.decode(encoding='UTF-8')
+            body = body.decode('utf-8')
         if response.status == 200:
             return json.loads(body)
         else:


### PR DESCRIPTION
The type `bytes` cannot be converted automatically to `str` by `json.loads` on Python 3.
This patch fixes this issue. 

(Please) Feel free to comment on my first contribute. :smile:
