### PR TITLE
force AuthServiceName to "dynamodb"

### DIFF
--- a/boto/dynamodb2/layer1.py
+++ b/boto/dynamodb2/layer1.py
@@ -146,6 +146,7 @@ class DynamoDBConnection(AWSQueryConnection):
     DefaultRegionEndpoint = "dynamodb.us-east-1.amazonaws.com"
     ServiceName = "DynamoDB"
     TargetPrefix = "DynamoDB_20120810"
+    AuthServiceName = "dynamodb"
     ResponseError = JSONResponseError
 
     _faults = {


### PR DESCRIPTION
this is to allow connecting to "preview" service (otherwise the service name extracted from the URL)
