### PR TITLE
Added 'end' attribute to ReservedInstance

### DIFF
--- a/boto/ec2/reservedinstance.py
+++ b/boto/ec2/reservedinstance.py
@@ -134,6 +134,7 @@ class ReservedInstance(ReservedInstancesOffering):
         self.instance_count = instance_count
         self.state = state
         self.start = None
+        self.end = None
 
     def __repr__(self):
         return 'ReservedInstance:%s' % self.id
@@ -147,6 +148,8 @@ class ReservedInstance(ReservedInstancesOffering):
             self.state = value
         elif name == 'start':
             self.start = value
+        elif name == 'end':
+            self.end = value
         else:
             super(ReservedInstance, self).endElement(name, value, connection)
 

--- a/tests/unit/ec2/test_reservedinstance.py
+++ b/tests/unit/ec2/test_reservedinstance.py
@@ -1,0 +1,44 @@
+from tests.unit import AWSMockServiceTestCase
+from boto.ec2.connection import EC2Connection
+from boto.ec2.reservedinstance import ReservedInstance
+
+
+class TestReservedInstancesSet(AWSMockServiceTestCase):
+    connection_class = EC2Connection
+
+    def default_body(self):
+        return b"""
+<reservedInstancesSet>
+    <item>
+        <reservedInstancesId>ididididid</reservedInstancesId>
+        <instanceType>t1.micro</instanceType>
+        <start>2014-05-03T14:10:10.944Z</start>
+        <end>2014-05-03T14:10:11.000Z</end>
+        <duration>64800000</duration>
+        <fixedPrice>62.5</fixedPrice>
+        <usagePrice>0.0</usagePrice>
+        <instanceCount>5</instanceCount>
+        <productDescription>Linux/UNIX</productDescription>
+        <state>retired</state>
+        <instanceTenancy>default</instanceTenancy>
+        <currencyCode>USD</currencyCode>
+        <offeringType>Heavy Utilization</offeringType>
+        <recurringCharges>
+            <item>
+                <frequency>Hourly</frequency>
+                <amount>0.005</amount>
+            </item>
+        </recurringCharges>
+    </item>
+</reservedInstancesSet>"""
+
+    def test_get_all_reserved_instaces(self):
+        self.set_http_response(status_code=200)
+        response = self.service_connection.get_all_reserved_instances()
+
+        self.assertEqual(len(response), 1)
+        self.assertTrue(isinstance(response[0], ReservedInstance))
+        self.assertEquals(response[0].id, 'ididididid')
+        self.assertEquals(response[0].instance_count, 5)
+        self.assertEquals(response[0].start, '2014-05-03T14:10:10.944Z')
+        self.assertEquals(response[0].end, '2014-05-03T14:10:11.000Z')


### PR DESCRIPTION
Hi. I've happened upon #2757 and decided to fix it. 

I was a bit unsure what the right approach to testing this was. There was no existing test for the `EC2Connection.get_all_reserved_instances` call. In the end I've mimicked [one of the latest added tests](https://github.com/boto/boto/blob/develop/tests/unit/emr/test_connection.py) - is this test how the tests should be written currently?
