### PR TITLE
Fix keyfile bug with read() updating `location` incorrectly, and re-reading key contents after the end is reached

### DIFF
--- a/boto/s3/keyfile.py
+++ b/boto/s3/keyfile.py
@@ -85,8 +85,13 @@ class KeyFile():
     self.location = pos
 
   def read(self, size):
+    if self.location >= self.key.size:
+      # FIXME: maybe this is wrong if encoding is binary? Not sure how to
+      # decide whether we want to return b'' or '' for Python 3
+      return ''
     result = self.key.read(size)
-    # we might not have read all of `size`, so increment by the actual amount read
+    # We might not have read all of `size`, so increment by the actual amount
+    # read. This is consistent with normal file FDs.
     self.location += len(result)
     return result
 


### PR DESCRIPTION
I'm not sure how to test this change yet, but this patch works in practice for my use cases. When this bug is fixed, one can stream gzip from S3 keys like so,

gzip_fd = gzip.GzipFile(fileobj=boto.s3.keyfile.KeyFile(key))

which is really handy (where `key` is a boto.s3.key.Key).
