### PR TITLE
FIXING SES get_identity_dkim_attributes fails when input length > 1

### DIFF
--- a/boto/ses/connection.py
+++ b/boto/ses/connection.py
@@ -104,8 +104,8 @@ class SESConnection(AWSAuthConnection):
         body = response.read().decode('utf-8')
         if response.status == 200:
             list_markers = ('VerifiedEmailAddresses', 'Identities',
-                            'DkimTokens', 'VerificationAttributes',
-                            'SendDataPoints')
+                            'DkimTokens', 'DkimAttributes',
+                            'VerificationAttributes', 'SendDataPoints')
             item_markers = ('member', 'item', 'entry')
 
             e = boto.jsonresponse.Element(list_marker=list_markers,

--- a/tests/unit/ses/test_identity.py
+++ b/tests/unit/ses/test_identity.py
@@ -39,7 +39,7 @@ xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
   <GetIdentityDkimAttributesResult>
     <DkimAttributes>
       <entry>
-        <key>amazon.com</key>
+        <key>test@amazon.com</key>
       <value>
         <DkimEnabled>true</DkimEnabled>
         <DkimVerificationStatus>Success</DkimVerificationStatus>
@@ -50,6 +50,13 @@ xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
         </DkimTokens>
       </value>
     </entry>
+    <entry>
+      <key>secondtest@amazon.com</key>
+        <value>
+          <DkimEnabled>false</DkimEnabled>
+          <DkimVerificationStatus>NotStarted</DkimVerificationStatus>
+        </value>
+      </entry>
     </DkimAttributes>
   </GetIdentityDkimAttributesResult>
   <ResponseMetadata>
@@ -61,13 +68,17 @@ xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
         self.set_http_response(status_code=200)
 
         response = self.service_connection\
-                       .get_identity_dkim_attributes(['test@amazon.com'])
+                       .get_identity_dkim_attributes(['test@amazon.com', 'secondtest@amazon.com'])
 
         response = response['GetIdentityDkimAttributesResponse']
         result = response['GetIdentityDkimAttributesResult']
-        attributes = result['DkimAttributes']['entry']['value']
+
+        first_entry = result['DkimAttributes'][0]
+        entry_key = first_entry['key']
+        attributes = first_entry['value']
         tokens = attributes['DkimTokens']
 
+        self.assertEqual(entry_key, 'test@amazon.com')
         self.assertEqual(ListElement, type(tokens))
         self.assertEqual(3, len(tokens))
         self.assertEqual('vvjuipp74whm76gqoni7qmwwn4w4qusjiainivf6f',
@@ -76,6 +87,16 @@ xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
                          tokens[1])
         self.assertEqual('wrqplteh7oodxnad7hsl4mixg2uavzneazxv5sxi2',
                          tokens[2])
+
+        second_entry = result['DkimAttributes'][1]
+        entry_key = second_entry['key']
+        attributes = second_entry['value']
+        dkim_enabled = attributes['DkimEnabled']
+        dkim_verification_status = attributes['DkimVerificationStatus']
+
+        self.assertEqual(entry_key, 'secondtest@amazon.com')
+        self.assertEqual(dkim_enabled, 'false')
+        self.assertEqual(dkim_verification_status, 'NotStarted')
 
 
 class TestSESSetIdentityNotificationTopic(AWSMockServiceTestCase):


### PR DESCRIPTION
boto.ses.connection::get_identity_dkim_attributes would call
_make_request() but would incorrectly parse the XML response from AWS.
If an input list with length greater than 1 was provided, this method
would only return a response for a single list element.

Adding DkimAttributes to list_markers and updating unit tests.

Documentation does not need to be updated.
