### PR TITLE
Add query string to body for anon STS POST

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -771,16 +771,15 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
                                     urllib.parse.urlencode(req.params))
 
 
-class QueryAuthHandler(AuthHandler):
+class STSAnonHandler(AuthHandler):
     """
     Provides pure query construction (no actual signing).
 
-    Mostly useful for STS' ``assume_role_with_web_identity``.
-
-    Does **NOT** escape query string values!
+    Used for making anonymous STS request for operations like
+    ``assume_role_with_web_identity``.
     """
 
-    capability = ['pure-query']
+    capability = ['sts-anon']
 
     def _escape_value(self, value):
         # This is changed from a previous version because this string is

--- a/boto/sts/connection.py
+++ b/boto/sts/connection.py
@@ -108,7 +108,7 @@ class STSConnection(AWSQueryConnection):
 
     def _required_auth_capability(self):
         if self.anon:
-            return ['pure-query']
+            return ['sts-anon']
         else:
             return ['hmac-v4']
 

--- a/tests/unit/auth/test_stsanon.py
+++ b/tests/unit/auth/test_stsanon.py
@@ -23,11 +23,11 @@ import copy
 from mock import Mock
 from tests.unit import unittest
 
-from boto.auth import QueryAuthHandler
+from boto.auth import STSAnonHandler
 from boto.connection import HTTPRequest
 
 
-class TestQueryAuthHandler(unittest.TestCase):
+class TestSTSAnonHandler(unittest.TestCase):
     def setUp(self):
         self.provider = Mock()
         self.provider.access_key = 'access_key'
@@ -51,8 +51,8 @@ class TestQueryAuthHandler(unittest.TestCase):
         )
 
     def test_escape_value(self):
-        auth = QueryAuthHandler('sts.amazonaws.com',
-                                 Mock(), self.provider)
+        auth = STSAnonHandler('sts.amazonaws.com',
+                              Mock(), self.provider)
         # This is changed from a previous version because this string is
         # being passed to the query string and query strings must
         # be url encoded.
@@ -60,16 +60,16 @@ class TestQueryAuthHandler(unittest.TestCase):
         self.assertEqual(value, 'Atza%7CIQEBLjAsAhRkcxQ')
 
     def test_build_query_string(self):
-        auth = QueryAuthHandler('sts.amazonaws.com',
-                                 Mock(), self.provider)
+        auth = STSAnonHandler('sts.amazonaws.com',
+                              Mock(), self.provider)
         query_string = auth._build_query_string(self.request.params)
         self.assertEqual(query_string, 'Action=AssumeRoleWithWebIdentity' + \
             '&ProviderId=2012-06-01&RoleSessionName=web-identity-federation' + \
             '&Version=2011-06-15&WebIdentityToken=Atza%7CIQEBLjAsAhRkcxQ')
 
     def test_add_auth(self):
-        auth = QueryAuthHandler('sts.amazonaws.com',
-                                 Mock(), self.provider)
+        auth = STSAnonHandler('sts.amazonaws.com',
+                              Mock(), self.provider)
         req = copy.copy(self.request)
         auth.add_auth(req)
         self.assertEqual(req.body,


### PR DESCRIPTION
So this PR will solely affect anonymous requests using STS. Before, the request would put the query string into the URL path. However, all requests for STS are modeled as a post and that data should be in the body. This PR removes the query string from the URL path and adds it to the body. I tested it out using some of the different ways to assume a role and it looks like it is working fine.

cc @danielgtaylor @jamesls 
