### PR TITLE
Add support for the 'cursor' parameter in cloudsearch

### DIFF
--- a/boto/cloudsearch2/search.py
+++ b/boto/cloudsearch2/search.py
@@ -83,6 +83,9 @@ class Query(object):
                  facet=None, highlight=None, partial=None, options=None,
                  cursor=None):
 
+        if cursor is not None:
+            start = None  # start can't coexist with cursor
+
         self.q = q
         self.parser = parser
         self.fq = fq
@@ -109,7 +112,10 @@ class Query(object):
         :rtype: dict
         :return: search parameters
         """
-        params = {'start': self.start, 'size': self.real_size}
+        params = {'size': self.real_size}
+
+        if self.start is not None:
+            params['start'] = self.start
 
         if self.q:
             params['q'] = self.q

--- a/boto/cloudsearch2/search.py
+++ b/boto/cloudsearch2/search.py
@@ -43,6 +43,7 @@ class SearchResults(object):
         self.docs = attrs['hits']['hit']
         self.start = attrs['hits']['start']
         self.query = attrs['query']
+        self.cursor = attrs['hits'].get('cursor')
         self.search_service = attrs['search_service']
 
         self.facets = {}
@@ -79,7 +80,8 @@ class Query(object):
 
     def __init__(self, q=None, parser=None, fq=None, expr=None,
                  return_fields=None, size=10, start=0, sort=None,
-                 facet=None, highlight=None, partial=None, options=None):
+                 facet=None, highlight=None, partial=None, options=None,
+                 cursor=None):
 
         self.q = q
         self.parser = parser
@@ -93,6 +95,7 @@ class Query(object):
         self.partial = partial
         self.options = options
         self.page = 0
+        self.cursor = cursor
         self.update_size(size)
 
     def update_size(self, new_size):
@@ -142,6 +145,9 @@ class Query(object):
 
         if self.sort:
             params['sort'] = ','.join(self.sort)
+
+        if self.cursor:
+            params['cursor'] = self.cursor
 
         return params
 
@@ -233,14 +239,14 @@ class SearchConnection(object):
 
     def build_query(self, q=None, parser=None, fq=None, rank=None, return_fields=None,
                     size=10, start=0, facet=None, highlight=None, sort=None,
-                    partial=None, options=None):
+                    partial=None, options=None, cursor=None):
         return Query(q=q, parser=parser, fq=fq, expr=rank, return_fields=return_fields,
                      size=size, start=start, facet=facet, highlight=highlight,
-                     sort=sort, partial=partial, options=options)
+                     sort=sort, partial=partial, options=options, cursor=cursor)
 
     def search(self, q=None, parser=None, fq=None, rank=None, return_fields=None,
                size=10, start=0, facet=None, highlight=None, sort=None, partial=None,
-               options=None):
+               options=None, cursor=None):
         """
         Send a query to CloudSearch
 
@@ -293,6 +299,9 @@ class SearchConnection(object):
             Specified as a string in JSON format.
             ``{fields: ['title^5', 'description']}``
 
+        :type cursor: str
+        :param cursor: The cursor id for iterating on query results.
+
         :rtype: :class:`boto.cloudsearch2.search.SearchResults`
         :return: Returns the results of this search
 
@@ -332,7 +341,8 @@ class SearchConnection(object):
                                  return_fields=return_fields,
                                  size=size, start=start, facet=facet,
                                  highlight=highlight, sort=sort,
-                                 partial=partial, options=options)
+                                 partial=partial, options=options,
+                                 cursor=cursor)
         return self(query)
 
     def _search_with_auth(self, params):

--- a/boto/cloudsearch2/search.py
+++ b/boto/cloudsearch2/search.py
@@ -66,12 +66,18 @@ class SearchResults(object):
         :rtype: :class:`boto.cloudsearch2.search.SearchResults`
         :return: the following page of search results
         """
-        if self.query.page <= self.num_pages_needed:
-            self.query.start += self.query.real_size
-            self.query.page += 1
-            return self.search_service(self.query)
+        if self.cursor is None:
+            if self.query.page <= self.num_pages_needed:
+                self.query.start += self.query.real_size
+                self.query.page += 1
+                return self.search_service(self.query)
+            else:
+                raise StopIteration
         else:
-            raise StopIteration
+            if not self.docs:
+                raise StopIteration
+            self.query.cursor = self.cursor
+            return self.search_service(self.query)
 
 
 class Query(object):


### PR DESCRIPTION
Adds support for the cursor parameter on cloudsearch, which is missing, and also makes the next_page() method of the result use the cursor when it's available, allowing us to iterate through the whole result set, unrestrained by amazon's 10000 limit.
