### PR TITLE
added keyring support for profile.

### DIFF
--- a/boto/utils.py
+++ b/boto/utils.py
@@ -862,6 +862,15 @@ def get_utf8_value(value):
 
     return value
 
+def get_keyring_password(service, name):
+    try:
+        import keyring
+    except ImportError:
+        boto.log.error("The keyring module could not be imported. "
+                       "For keyring support, install the keyring "
+                       "module.")
+        raise
+    return keyring.get_password(service, name)
 
 def mklist(value):
     if not isinstance(value, list):

--- a/tests/unit/provider/test_provider.py
+++ b/tests/unit/provider/test_provider.py
@@ -212,6 +212,63 @@ class TestProvider(unittest.TestCase):
             if not imported:
                 del sys.modules['keyring']
 
+
+    def test_keyring_is_used_for_profile_in_config(self):
+        self.config = {
+            'profile dev': {
+                'aws_access_key_id': 'dev_access_key',
+                'keyring': 'dev'
+            }
+        }
+
+        import sys
+        try:
+            import keyring
+            imported = True
+        except ImportError:
+            sys.modules['keyring'] = keyring = type(mock)('keyring', '')
+            imported = False
+
+        try:
+            with mock.patch('keyring.get_password', create=True):
+                keyring.get_password.side_effect = (
+                    lambda kr, login: kr+login+'pw')
+                p = provider.Provider('aws', profile_name='dev')
+                self.assertEqual(p.access_key, 'dev_access_key')
+                self.assertEqual(p.secret_key, 'devdev_access_keypw')
+                self.assertIsNone(p.security_token)
+        finally:
+            if not imported:
+                del sys.modules['keyring']
+
+    def test_keyring_is_used_for_profile_in_shared(self):
+        self.shared_config = {
+            'dev': {
+                'aws_access_key_id': 'dev_access_key',
+                'keyring': 'dev'
+            }
+        }
+
+        import sys
+        try:
+            import keyring
+            imported = True
+        except ImportError:
+            sys.modules['keyring'] = keyring = type(mock)('keyring', '')
+            imported = False
+
+        try:
+            with mock.patch('keyring.get_password', create=True):
+                keyring.get_password.side_effect = (
+                    lambda kr, login: kr+login+'pw')
+                p = provider.Provider('aws', profile_name='dev')
+                self.assertEqual(p.access_key, 'dev_access_key')
+                self.assertEqual(p.secret_key, 'devdev_access_keypw')
+                self.assertIsNone(p.security_token)
+        finally:
+            if not imported:
+                del sys.modules['keyring']
+
     def test_passed_in_values_beat_env_vars(self):
         self.environ['AWS_ACCESS_KEY_ID'] = 'env_access_key'
         self.environ['AWS_SECRET_ACCESS_KEY'] = 'env_secret_key'


### PR DESCRIPTION
Right now it is only support keyring on [Credentials] section in ~/.boto, so I am thinking it will be better if boto for [profile ] to support keyring as well.