### PR TITLE
added doc2dash support in the docs Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,6 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
+DOC2DASH      = doc2dash
 PAPER         =
 BUILDDIR      = build
 
@@ -12,7 +13,7 @@ PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
-.PHONY: help clean html dirhtml pickle json epub htmlhelp qthelp latex changes linkcheck doctest
+.PHONY: help clean html dirhtml pickle json epub htmlhelp qthelp latex changes linkcheck doctest dash
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -24,9 +25,11 @@ help:
 	@echo "  htmlhelp  to make HTML files and a HTML help project"
 	@echo "  qthelp    to make HTML files and a qthelp project"
 	@echo "  latex     to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
+	@echo "  dash      to make Dash docset files"
 	@echo "  changes   to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck to check all external links for integrity"
 	@echo "  doctest   to run all doctests embedded in the documentation (if enabled)"
+
 
 clean:
 	-rm -rf $(BUILDDIR)/*
@@ -77,6 +80,10 @@ latex:
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
 	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \
 	      "run these through (pdf)latex."
+
+dash: html
+	$(DOC2DASH) -f -n boto -d $(BUILDDIR) $(BUILDDIR)/html/
+	@echo "Build Finished; the Dash files are in $(BUILDDIR)/boto.docset."
 
 changes:
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes


### PR DESCRIPTION
Added DOC2DASH support in the Makefile allowing you to run "make dash". This will generate the html docs then make the Dash docset under the build directory. Requires dash2doc http://pypi.python.org/pypi/doc2dash
