### PR TITLE
Fixed bug that unable call query_2 after call describe method on dynamodb2 module

### DIFF
--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -301,10 +301,10 @@ class Table(object):
         """
         Describes the current structure of the table in DynamoDB.
 
-        This information will be used to update the ``schema``, ``indexes``
-        and ``throughput`` information on the ``Table``. Some calls, such as
-        those involving creating keys or querying, will require this
-        information to be populated.
+        This information will be used to update the ``schema``, ``indexes``,
+        ``global_indexes`` and ``throughput`` information on the ``Table``. Some
+        calls, such as those involving creating keys or querying, will require
+        this information to be populated.
 
         It also returns the full raw data structure from DynamoDB, in the
         event you'd like to parse out additional information (such as the

--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -306,7 +306,7 @@ class Table(object):
         those involving creating keys or querying, will require this
         information to be populated.
 
-        It also returns the full raw datastructure from DynamoDB, in the
+        It also returns the full raw data structure from DynamoDB, in the
         event you'd like to parse out additional information (such as the
         ``ItemCount`` or usage information).
 
@@ -338,6 +338,11 @@ class Table(object):
             # Build the index information as well.
             raw_indexes = result['Table'].get('LocalSecondaryIndexes', [])
             self.indexes = self._introspect_indexes(raw_indexes)
+
+        if not self.global_indexes:
+            # Build the index information as well.
+            raw_global_indexes = result['Table'].get('GlobalSecondaryIndexes', [])
+            self.global_indexes = self._introspect_indexes(raw_global_indexes)
 
         # This is leaky.
         return result

--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -340,7 +340,7 @@ class Table(object):
             self.indexes = self._introspect_indexes(raw_indexes)
 
         if not self.global_indexes:
-            # Build the index information as well.
+            # Build the global index information as well.
             raw_global_indexes = result['Table'].get('GlobalSecondaryIndexes', [])
             self.global_indexes = self._introspect_indexes(raw_global_indexes)
 

--- a/tests/integration/dynamodb2/test_highlevel.py
+++ b/tests/integration/dynamodb2/test_highlevel.py
@@ -656,7 +656,7 @@ class DynamoDBv2Test(unittest.TestCase):
             'read': 5,
             'write': 5
         }, global_indexes=[
-            GlobalAllIndex('EmailGSIIndex', part=[
+            GlobalAllIndex('EmailGSIIndex', parts=[
                 HashKey('email')
             ], throughput={
                 'read': 1,

--- a/tests/integration/dynamodb2/test_highlevel.py
+++ b/tests/integration/dynamodb2/test_highlevel.py
@@ -29,7 +29,8 @@ import time
 from tests.unit import unittest
 from boto.dynamodb2 import exceptions
 from boto.dynamodb2.fields import (HashKey, RangeKey, KeysOnlyIndex,
-                                   GlobalKeysOnlyIndex, GlobalIncludeIndex)
+                                   GlobalKeysOnlyIndex, GlobalIncludeIndex,
+                                   GlobalAllIndex)
 from boto.dynamodb2.items import Item
 from boto.dynamodb2.table import Table
 from boto.dynamodb2.types import NUMBER
@@ -645,3 +646,73 @@ class DynamoDBv2Test(unittest.TestCase):
                 '2013-12-24T15:22:22',
             ]
         )
+
+    def test_query_after_describe_with_gsi(self):
+        # Create a table to using gsi to reproduce the error mentioned on issue
+        # https://github.com/boto/boto/issues/2828
+        users = Table.create('more_gsi_query_users', schema=[
+            HashKey('user_id')
+        ], throughput={
+            'read': 5,
+            'write': 5
+        }, global_indexes=[
+            GlobalAllIndex('EmailGSIIndex', part=[
+                HashKey('email')
+            ], throughput={
+                'read': 1,
+                'write': 1
+            })
+        ])
+
+        # Add this function to be called after tearDown()
+        self.addCleanup(users.delete)
+
+        # Wait for it.
+        time.sleep(60)
+
+        # populate a couple of items in it
+        users.put_item(data={
+            'user_id': '7',
+            'username': 'johndoe',
+            'first_name': 'John',
+            'last_name': 'Doe',
+            'email': 'johndoe@johndoe.com',
+        })
+        users.put_item(data={
+            'user_id': '24',
+            'username': 'alice',
+            'first_name': 'Alice',
+            'last_name': 'Expert',
+            'email': 'alice@alice.com',
+        })
+        users.put_item(data={
+            'user_id': '35',
+            'username': 'jane',
+            'first_name': 'Jane',
+            'last_name': 'Doe',
+            'email': 'jane@jane.com',
+        })
+
+        # Try the GSI. it should work.
+        rs = users.query_2(
+            email__eq='johndoe@johndoe.com',
+            index='EmailGSIIndex'
+        )
+
+        for rs_item in rs:
+            self.assertEqual(rs_item['username'], ['johndoe'])
+
+        # The issue arises when we're introspecting the table and try to
+        # query_2 after call describe method
+        users_hit_api = Table('more_gsi_query_users')
+        users_hit_api.describe()
+
+        # Try the GSI. This is what os going wrong on #2828 issue. It should
+        # work fine now.
+        rs = users_hit_api.query_2(
+            email__eq='johndoe@johndoe.com',
+            index='EmailGSIIndex'
+        )
+
+        for rs_item in rs:
+            self.assertEqual(rs_item['username'], ['johndoe'])


### PR DESCRIPTION
This fixes the #2828 and #2708 issues.

As shown on that issue, there was a strange behaviour when calling describe method and then query_2. 

I've found out that when you create a fresh new Table instance it has not schema, indexes or even global_indexes. So when you call query_2 method is check whether you have those parameters and if you haven't it tries to perform the call as usual. 

In the other hand when you call describe method it was setting all those instance variables but self.global_indexes which was causing it to raising an exception on the following statement at the begging of query_2 method as shown below;

```Python
 if self.schema:
            if len(self.schema) == 1:
                if len(filter_kwargs) <= 1:
                    if not self.global_indexes or not len(self.global_indexes):
                        # If the schema only has one field, there's <= 1 filter
                        # param & no Global Secondary Indexes, this is user
                        # error. Bail early.
                        raise exceptions.QueryError(
                            "You must specify more than one key to filter on."
                        )
```

As Global Secondary Indexes were being sent by the DynamoDB API, all I had to do was to update the instance variable self.global_indexes with that information.  Now it's working as expected :)

I hope you find my pull request useful. If you do, please accept my pull request.

Best Regards