### PR TITLE
Fixes JSON error parsing error when receiving bytes in Python 3.

### DIFF
--- a/boto/rds2/layer1.py
+++ b/boto/rds2/layer1.py
@@ -3760,6 +3760,8 @@ class RDSConnection(AWSQueryConnection):
                                      path='/', params=params)
         body = response.read()
         boto.log.debug(body)
+        if isinstance(body, bytes):
+            body = body.decode('utf-8')
         if response.status == 200:
             return json.loads(body)
         else:

--- a/tests/unit/rds2/test_connection.py
+++ b/tests/unit/rds2/test_connection.py
@@ -203,6 +203,15 @@ class TestRDS2Connection(AWSMockServiceTestCase):
             'mydbsubnetgroup'
         )
 
+    def test_make_request_byte_decoding(self):
+        bytes_body = b'{"Error":{"Code":"DBInstanceAlreadyExists","Message":"DB Instance already exists","Type":"Sender"},"RequestId":"12345678-1234-1234-1234-000000000000"}'
+        self.create_response(status_code=200, body=bytes_body)
+        
+        try:
+            self.service_connection.create_db_instance("db-master-1", 10, 'db.m1.small', 'postgres', 'root', 'hunter2')
+        except TypeError:
+            self.fail("TypeError raised, probably due to failure to decode HTTP response body.")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Should fix a couple errors:
https://github.com/boto/boto/issues/2681
https://github.com/boto/boto/issues/2677

That said, I had a bit of trouble with testing, so I'm not 100% on this... If you're going to try to test it, I suggest removing the try/except wrapping because I was getting a different TypeError in the testing framework than I was from the actual bug.
