### PR TITLE
Fix S3 sigv4 signature when non-ascii present in query string or tilde characters present in key name

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -571,7 +571,7 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         # Because some quoting may have already been applied, let's back it out.
         unquoted = urllib.parse.unquote(path.path)
         # Requote, this time addressing all characters.
-        encoded = urllib.parse.quote(unquoted)
+        encoded = urllib.parse.quote(unquoted, safe='/~')
         return encoded
 
     def canonical_query_string(self, http_request):

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -686,7 +686,7 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
             modified_req.params = copy_params
 
         raw_qs = parsed_path.query
-        existing_qs = urllib.parse.parse_qs(
+        existing_qs = boto.utils.parse_qs_safe(
             raw_qs,
             keep_blank_values=True
         )

--- a/tests/integration/s3/test_key.py
+++ b/tests/integration/s3/test_key.py
@@ -488,6 +488,19 @@ class S3KeySigV4Test(unittest.TestCase):
         self.assertEqual(from_s3_key.get_contents_as_string().decode('utf-8'),
                          body)
 
+    def test_head_put_get_with_non_ascii_key(self):
+        k = Key(self.bucket)
+        k.key = u'''pt-Olá_ch-你好_ko-안녕_ru-Здравствуйте%20,.<>~`!@#$%^&()_-+='"'''
+        body = 'This is a test of S3'
+
+        k.set_contents_from_string(body)
+        from_s3_key = self.bucket.get_key(k.key, validate=True)
+        self.assertEqual(from_s3_key.get_contents_as_string().decode('utf-8'),
+                         body)
+
+        keys = self.bucket.get_all_keys(prefix=k.key, max_keys=1)
+        self.assertEqual(1, len(keys))
+
 
 class S3KeyVersionCopyTest(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -342,13 +342,13 @@ class TestS3HmacAuthV4Handler(unittest.TestCase):
     def test_canonical_uri(self):
         request = HTTPRequest(
             'GET', 'https', 's3-us-west-2.amazonaws.com', 443,
-            'x/./././x .html', None, {},
+            'x/./././~x .html', None, {},
             {}, ''
         )
         canonical_uri = self.auth.canonical_uri(request)
         # S3 doesn't canonicalize the way other SigV4 services do.
         # This just urlencoded, no normalization of the path.
-        self.assertEqual(canonical_uri, 'x/./././x%20.html')
+        self.assertEqual(canonical_uri, 'x/./././~x%20.html')
 
     def test_determine_service_name(self):
         # What we wish we got.

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -447,6 +447,27 @@ class TestS3HmacAuthV4Handler(unittest.TestCase):
             'delete': ''
         })
 
+    def test_unicode_query_string(self):
+        request = HTTPRequest(
+            method='HEAD',
+            protocol='https',
+            host='awesome-bucket.s3-us-west-2.amazonaws.com',
+            port=443,
+            path=u'/?max-keys=1&prefix=El%20Ni%C3%B1o',
+            auth_path=u'/awesome-bucket/?max-keys=1&prefix=El%20Ni%C3%B1o',
+            params={},
+            headers={},
+            body=''
+        )
+
+        mod_req = self.auth.mangle_path_and_params(request)
+        self.assertEqual(mod_req.path, u'/?max-keys=1&prefix=El%20Ni%C3%B1o')
+        self.assertEqual(mod_req.auth_path, u'/awesome-bucket/')
+        self.assertEqual(mod_req.params, {
+            u'max-keys': u'1',
+            u'prefix': u'El Ni\xf1o',
+        })
+
     def test_canonical_request(self):
         expected = """GET
 /


### PR DESCRIPTION
This fixes incorrect sigv4 signature for S3 requests (#2846, #2849):

1. When non-ascii characters are present in request's query string in Python 2. For calculation of the signature, the query string is parsed and placed into the mangled request's parameters. This is done by parsing the query string using `urllib.parse.parse_qs`. The query string given is in Unicode which in Python 2 `parse_qs` doesn't do decoding of URL-encoded %HH bytes. When the query string has URL-encoded non-ascii characters, the wrong Unicode string is returned.
   * e.g. a value of u'%C3%B1' would be outputted from `parse_qs` as u'\xc3\xb1', but originally the value url encoded was b'\xc3\xb1' (utf-8 encoded bytes) or u'\xf1' in Unicode.

2. When tilde characters `~` are present in the key name since the Canonical URI URL-encodes `~` which is incorrect by http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html