### PR TITLE
Refactor S3 metadata handling. Fix issue #2798.

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -205,8 +205,7 @@ class Bucket(object):
             provider = self.connection.provider
             k.metadata = boto.utils.get_aws_metadata(response.msg, provider)
             for field in Key.base_fields:
-                k.__dict__[field.lower().replace('-', '_')] = \
-                    response.getheader(field)
+                k.set_metadata(field, response.getheader(field))
             # the following machinations are a workaround to the fact that
             # apache/fastcgi omits the content-length header on HEAD
             # requests when the content-length is zero.
@@ -862,6 +861,7 @@ class Bucket(object):
         if provider.storage_class_header and storage_class:
             headers[provider.storage_class_header] = storage_class
         if metadata is not None:
+            metadata = Key._normalize_metadata(metadata)
             headers[provider.metadata_directive_header] = 'REPLACE'
             headers = boto.utils.merge_meta(headers, metadata, provider)
         elif not query_args:  # Can't use this header with multi-part copy.
@@ -1745,6 +1745,8 @@ class Bucket(object):
             headers[provider.server_side_encryption_header] = 'AES256'
         if metadata is None:
             metadata = {}
+        else:
+            metadata = Key._normalize_metadata(metadata)
 
         headers = boto.utils.merge_meta(headers, metadata,
                 self.connection.provider)

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -167,11 +167,20 @@ def merge_meta(headers, metadata, provider=None):
         provider = boto.provider.get_default()
     metadata_prefix = provider.metadata_prefix
     final_headers = headers.copy()
-    for k in metadata.keys():
-        if k.lower() in boto.s3.key.Key.base_user_settable_fields:
-            final_headers[k] = metadata[k]
+    for k, v in metadata.iteritems():
+        # Content-type and content-md5 must have specific
+        # capitalization for the signatures to match.
+        if k.lower() == 'content-type':
+            final_headers['Content-Type'] = v
+        elif k.lower() == 'content-md5':
+            final_headers['Content-MD5'] = v
+        elif k.lower() in boto.s3.key.Key.base_user_settable_fields:
+            final_headers[k] = v
+        elif k.lower() in boto.s3.key.Key.base_fields:
+            # Ignore fields we can not set.
+            pass
         else:
-            final_headers[metadata_prefix + k] = metadata[k]
+            final_headers[metadata_prefix + k] = v
 
     return final_headers
 


### PR DESCRIPTION
System metadata of a key could be stored in two places, e.g.
key.cache_control and key.metadata['cache-control']. This led to
inconsistencies and trouble, see https://github.com/boto/boto/issues/2798

Fix that. Store all metadata, system and custom, in key.metadata. For
backwards compatibility and convenience, system metadata can still be
accessed via key.cache_control, key.content_type etc.

This breaks backwards compatibility in couple of cases, e.g.
key.get_metadata('date') used to return custom metadata 'x-amz-meta-date'.
Now it returns system metadata 'Date'. I don't think this is a problem, and the
new behaviour seems more sensible to me, but someone more qualified than me
should judge that.