### PR TITLE
Change exception class from 'JSONResponseError' to 'BotoServerError'. Fixes #2776

### DIFF
--- a/boto/redshift/layer1.py
+++ b/boto/redshift/layer1.py
@@ -24,7 +24,7 @@ import boto
 from boto.compat import json
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import BotoServerError
 from boto.redshift import exceptions
 
 
@@ -60,7 +60,7 @@ class RedshiftConnection(AWSQueryConnection):
     APIVersion = "2012-12-01"
     DefaultRegionName = "us-east-1"
     DefaultRegionEndpoint = "redshift.us-east-1.amazonaws.com"
-    ResponseError = JSONResponseError
+    ResponseError = BotoServerError
 
     _faults = {
         "SnapshotCopyAlreadyDisabled": exceptions.SnapshotCopyAlreadyDisabled,


### PR DESCRIPTION
Fix bug by using a different exception class. The `BotoServerError` class can parse the JSON error response from Redshift and publish the right values for `error_code` and `error_message`. Fixes #2776