### PR TITLE
Check for results left after computing self._keys_left

### DIFF
--- a/boto/dynamodb2/results.py
+++ b/boto/dynamodb2/results.py
@@ -180,6 +180,9 @@ class BatchGetResultSet(ResultSet):
         kwargs['keys'] = self._keys_left[:self._max_batch_get]
         self._keys_left = self._keys_left[self._max_batch_get:]
 
+        if len(self._keys_left) <= 0:
+            self._results_left = False
+
         results = self.the_callable(*args, **kwargs)
 
         if not len(results.get('results', [])):
@@ -193,8 +196,8 @@ class BatchGetResultSet(ResultSet):
             # missing keys ever making it here.
             self._keys_left.insert(offset, key_data)
 
-        if len(self._keys_left) <= 0:
-            self._results_left = False
+        if len(self._keys_left) > 0:
+            self._results_left = True
 
         # Decrease the limit, if it's present.
         if self.call_kwargs.get('limit'):

--- a/tests/unit/dynamodb2/test_table.py
+++ b/tests/unit/dynamodb2/test_table.py
@@ -1130,6 +1130,13 @@ class BatchGetResultSetTestCase(unittest.TestCase):
         # Make sure we won't check for results in the future.
         self.assertFalse(self.results._results_left)
 
+    def test_fetch_more_empty(self):
+        self.results.to_call(lambda keys: {'results': [], 'last_key': None}) 
+
+        self.results.fetch_more()
+        self.assertEqual(self.results._results, [])
+        self.assertRaises(StopIteration, self.results.next)
+
     def test_iteration(self):
         # First page.
         self.assertEqual(next(self.results), 'hello alice')


### PR DESCRIPTION
Addresses https://github.com/boto/boto/issues/2870

If the final call to fetch batch results returns no data,
BatchGetResultSet enters an infinite loop. Need to check that
self._keys_left is empty before returning.