### PR TITLE
Fix cacerts.txt loading from within zipimport

### DIFF
--- a/boto/cacerts/__init__.py
+++ b/boto/cacerts/__init__.py
@@ -20,3 +20,31 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
+
+import os
+import tempfile
+import atexit
+
+
+class CAcerts:
+    """This allows boto to work when imported from zip file using
+    zipimport module.
+    """
+    def __init__(self):
+        cacerts_file = os.path.join(os.path.dirname(__file__), "cacerts.txt")
+        try:
+            __loader__
+        except NameError:
+            self.cacerts_file = os.path.abspath(cacerts_file)
+        else:
+            def cleanup(f):
+                f.close()
+
+            self.cacerts_temp = tempfile.NamedTemporaryFile()
+            self.cacerts_temp.write(__loader__.get_data(cacerts_file))
+            self.cacerts_temp.flush()
+
+            atexit.register(cleanup, self.cacerts_temp)
+
+            self.cacerts_file = self.cacerts_temp.name
+

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -90,7 +90,7 @@ ON_APP_ENGINE = all(key in os.environ for key in (
 PORTS_BY_SECURITY = {True: 443,
                      False: 80}
 
-DEFAULT_CA_CERTS_FILE = os.path.join(os.path.dirname(os.path.abspath(boto.cacerts.__file__)), "cacerts.txt")
+DEFAULT_CA_CERTS_FILE = boto.cacerts.CAcerts().cacerts_file
 
 
 class HostConnectionPool(object):


### PR DESCRIPTION
Boto could not access the cacerts.txt file when loaded by zipimport from zip file. This solves #2872.
Please check if this is a sane solution as I'm python newbie.