### PR TITLE
[Doc] EC2 Instance type candidates for c4 instances

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -804,6 +804,11 @@ class EC2Connection(AWSQueryConnection):
             * c3.2xlarge
             * c3.4xlarge
             * c3.8xlarge
+            * c4.large
+            * c4.xlarge
+            * c4.2xlarge
+            * c4.4xlarge
+            * c4.8xlarge
             * i2.xlarge
             * i2.2xlarge
             * i2.4xlarge
@@ -1504,6 +1509,11 @@ class EC2Connection(AWSQueryConnection):
             * c3.2xlarge
             * c3.4xlarge
             * c3.8xlarge
+            * c4.large
+            * c4.xlarge
+            * c4.2xlarge
+            * c4.4xlarge
+            * c4.8xlarge
             * i2.xlarge
             * i2.2xlarge
             * i2.4xlarge

--- a/boto/ec2/image.py
+++ b/boto/ec2/image.py
@@ -230,6 +230,11 @@ class Image(TaggedEC2Object):
             * c3.2xlarge
             * c3.4xlarge
             * c3.8xlarge
+            * c4.large
+            * c4.xlarge
+            * c4.2xlarge
+            * c4.4xlarge
+            * c4.8xlarge
             * i2.xlarge
             * i2.2xlarge
             * i2.4xlarge


### PR DESCRIPTION
parameter candidates addition for [c4 Instances](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/c4-instances.html)

c4 instance types is available API Version `2014-10-01` (default by boto currently version)