### PR TITLE
Removed empty result set test to simplify fix for #2870

### DIFF
--- a/boto/dynamodb2/results.py
+++ b/boto/dynamodb2/results.py
@@ -180,13 +180,7 @@ class BatchGetResultSet(ResultSet):
         kwargs['keys'] = self._keys_left[:self._max_batch_get]
         self._keys_left = self._keys_left[self._max_batch_get:]
 
-        if len(self._keys_left) <= 0:
-            self._results_left = False
-
         results = self.the_callable(*args, **kwargs)
-
-        if not len(results.get('results', [])):
-            return
 
         self._results.extend(results['results'])
 
@@ -196,8 +190,8 @@ class BatchGetResultSet(ResultSet):
             # missing keys ever making it here.
             self._keys_left.insert(offset, key_data)
 
-        if len(self._keys_left) > 0:
-            self._results_left = True
+        if len(self._keys_left) <= 0:
+            self._results_left = False
 
         # Decrease the limit, if it's present.
         if self.call_kwargs.get('limit'):


### PR DESCRIPTION
Removed empty result set test altogether, this short circuited the test for a completely empty result set and resulted in the infinite loop described in issue #2870

Removing the empty result set test allows the _keys_left test to correctly set _results_left in case of a completely empty result set.

The issue #2870 was already fixed by pull request #2871, this pull request just attempts to simplify the fix.