### PR TITLE
Fix Route35 get_hosted_zone to return multiple VPC's correctly

### DIFF
--- a/boto/route53/connection.py
+++ b/boto/route53/connection.py
@@ -152,8 +152,8 @@ class Route53Connection(AWSAuthConnection):
             raise exception.DNSServerError(response.status,
                                            response.reason,
                                            body)
-        e = boto.jsonresponse.Element(list_marker='NameServers',
-                                      item_marker=('NameServer',))
+        e = boto.jsonresponse.Element(list_marker=('NameServers','VPCs'),
+                                      item_marker=('NameServer','VPC',))
         h = boto.jsonresponse.XmlHandler(e, None)
         h.parse(body)
         return e

--- a/tests/integration/route53/test_zone.py
+++ b/tests/integration/route53/test_zone.py
@@ -186,6 +186,12 @@ class TestRoute53PrivateZone(unittest.TestCase):
                                                     vpc_id=self.test_vpc.id,
                                                     vpc_region='us-east-1')
 
+    def test_get_hosted_zone_for_private_zone(self):
+        self.get_hosted_zone = self.route53.get_hosted_zone_by_name(self.base_domain)
+        self.assertEquals(len(self.get_hosted_zone['GetHostedZoneResponse']['VPCs']), 1)
+        self.assertEquals(self.get_hosted_zone['GetHostedZoneResponse']['VPCs'][0]['VPCRegion'], 'us-east-1')
+        self.assertEquals(self.get_hosted_zone['GetHostedZoneResponse']['VPCs'][0]['VPCId'], self.test_vpc.id)
+    
     @classmethod
     def tearDownClass(self):
         if self.zone is not None:

--- a/tests/unit/route53/test_connection.py
+++ b/tests/unit/route53/test_connection.py
@@ -313,6 +313,16 @@ class TestGetHostedZoneRoute53(AWSMockServiceTestCase):
             <NameServer>ns-1000.awsdns-00.co.uk</NameServer>
         </NameServers>
     </DelegationSet>
+    <VPCs>
+      <VPC>
+         <VPCRegion>eu-west-1</VPCRegion>
+         <VPCId>vpc-12345</VPCId>
+      </VPC>
+      <VPC>
+         <VPCRegion>us-west-1</VPCRegion>
+         <VPCId>vpc-78900</VPCId>
+      </VPC>
+   </VPCs> 
 </GetHostedZoneResponse>
 """
 
@@ -330,7 +340,18 @@ class TestGetHostedZoneRoute53(AWSMockServiceTestCase):
                                  ['DelegationSet']['NameServers'],
                          ['ns-1000.awsdns-40.org', 'ns-200.awsdns-30.com',
                           'ns-900.awsdns-50.net', 'ns-1000.awsdns-00.co.uk'])
-
+        self.assertEqual(response['GetHostedZoneResponse']
+                                 ['VPCs'][0]['VPCRegion'],
+                         'eu-west-1')
+        self.assertEqual(response['GetHostedZoneResponse']
+                                 ['VPCs'][0]['VPCId'],
+                         'vpc-12345')
+        self.assertEqual(response['GetHostedZoneResponse']
+                                 ['VPCs'][1]['VPCRegion'],
+                         'us-west-1')
+        self.assertEqual(response['GetHostedZoneResponse']
+                                 ['VPCs'][1]['VPCId'],
+                         'vpc-78900')
 
 @attr(route53=True)
 class TestGetAllRRSetsRoute53(AWSMockServiceTestCase):


### PR DESCRIPTION
The Route53 get_hosted_zone call only returns details of a single VPC even if multiple VPC's are associated to the zone.

Example result of the existing get_hosted_zone based on the raw AWS response below:
```
{u'GetHostedZoneResponse': {u'VPCs': {u'VPC': {u'VPCId': u'vpc-1c284579', u'VPCRegion': u'us-east-1'}}, u'HostedZone': {u'ResourceRecordSetCount': u'2', u'CallerReference': u'8b010150-fbbd-4b70-9029-7b4e95d72f14', u'Config': {u'PrivateZone': u'true'}, u'Id': u'/hostedzone/Z3KVR6U0WL4AY', u'Name': u'boto-private-zone-test-1421179530.com.'}}}
```
As you can see only a single VPC is returned (Note the lack of array within VPCs).

If there are multiple VPC's this is what I would expect:
```
{u'GetHostedZoneResponse': {u'VPCs': [{u'VPCId': u'vpc-b3debcd6', u'VPCRegion': u'eu-west-1'}, {u'VPCId': u'vpc-fe29449b', u'VPCRegion': u'us-west-1'}], u'HostedZone': {u'ResourceRecordSetCount': u'2', u'CallerReference': u'cf2fd10a-31e9-4098-807b-f4947132ad43', u'Config': {u'PrivateZone': u'true'}, u'Id': u'/hostedzone/Z2U2TW0PJPZ1P9', u'Name': u'boto-private-zone-test-1421179054.com.'}}}
```

The bug appears to be as a result of XML -> json conversion where lists need to be defined.

Unit test and fix are attached as a PR, its my first time with Python so feedback would be appreciated.

Raw AWS response:
```
<GetHostedZoneResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
   <HostedZone>
      <Id>/hostedzone/Z2U2TW0PJPZ1P9</Id>
      <Name>boto-private-zone-test-1421179054.com.</Name>
      <CallerReference>cf2fd10a-31e9-4098-807b-f4947132ad43</CallerReference>
      <Config>
         <PrivateZone>true</PrivateZone>
      </Config>
      <ResourceRecordSetCount>2</ResourceRecordSetCount>
   </HostedZone>
   <VPCs>
      <VPC>
         <VPCRegion>eu-west-1</VPCRegion>
         <VPCId>vpc-b3debcd6</VPCId>
      </VPC>
      <VPC>
         <VPCRegion>us-west-1</VPCRegion>
         <VPCId>vpc-fe29449b</VPCId>
      </VPC>
   </VPCs>
</GetHostedZoneResponse>
```