### PR TITLE
Handle different platforms (Windows) with splitting BOTO_PATH

### DIFF
--- a/boto/pyami/config.py
+++ b/boto/pyami/config.py
@@ -45,7 +45,7 @@ if 'BOTO_CONFIG' in os.environ:
 # as the current configuration locations, split with colons
 elif 'BOTO_PATH' in os.environ:
     BotoConfigLocations = []
-    for path in os.environ['BOTO_PATH'].split(":"):
+    for path in os.environ['BOTO_PATH'].split(os.path.pathsep):
         BotoConfigLocations.append(expanduser(path))
 
 


### PR DESCRIPTION
On Windows, paths are split with a ';' instead of a ':'. As a result, if you try to process BOTO_PATH on Windows, it will get something like ['C', '\path\to\file', 'D', '\more\files'] instead of ['C:\path\to\file', 'D:\more\files']. If windows is not provided with the drive name in the path, it will use the drive hosting your current working directory. So, if everything lives in C, including your terminal, it all coincidentally works. But if the file is in a different drive than your shell, it won't find it.

Using os.path.pathsep addresses this issue.