### PR TITLE
Kinesis update

### DIFF
--- a/boto/kinesis/layer1.py
+++ b/boto/kinesis/layer1.py
@@ -28,6 +28,7 @@ from boto.regioninfo import RegionInfo
 from boto.exception import JSONResponseError
 from boto.kinesis import exceptions
 from boto.compat import json
+from boto.compat import six
 
 
 class KinesisConnection(AWSQueryConnection):
@@ -652,7 +653,7 @@ class KinesisConnection(AWSQueryConnection):
         if sequence_number_for_ordering is not None:
             params['SequenceNumberForOrdering'] = sequence_number_for_ordering
         if b64_encode:
-            if not isinstance(params['Data'], bytes):
+            if not isinstance(params['Data'], six.binary_type):
                 params['Data'] = params['Data'].encode('utf-8')
             params['Data'] = base64.b64encode(params['Data']).decode('utf-8')
         return self.make_request(action='PutRecord',
@@ -738,9 +739,11 @@ class KinesisConnection(AWSQueryConnection):
         params = {'Records': records, 'StreamName': stream_name, }
         if b64_encode:
             for i in range(len(params['Records'])):
+                data = params['Records'][i]['Data']
+                if not isinstance(data, six.binary_type):
+                    params['Records'][i]['Data'] = data.encode('utf-8')
                 params['Records'][i]['Data'] = base64.b64encode(
-                    params['Records'][i]['Data'].encode('utf-8')).\
-                        decode('utf-8')
+                    data).decode('utf-8')
         return self.make_request(action='PutRecords',
                                  body=json.dumps(params))
 

--- a/boto/kinesis/layer1.py
+++ b/boto/kinesis/layer1.py
@@ -591,8 +591,9 @@ class KinesisConnection(AWSQueryConnection):
         if sequence_number_for_ordering is not None:
             params['SequenceNumberForOrdering'] = sequence_number_for_ordering
         if b64_encode:
-            params['Data'] = base64.b64encode(
-                params['Data'].encode('utf-8')).decode('utf-8')
+            if not isinstance(params['Data'], bytes):
+                params['Data'] = params['Data'].encode('utf-8')
+            params['Data'] = base64.b64encode(params['Data']).decode('utf-8')
         return self.make_request(action='PutRecord',
                                  body=json.dumps(params))
 

--- a/boto/kinesis/layer1.py
+++ b/boto/kinesis/layer1.py
@@ -741,7 +741,7 @@ class KinesisConnection(AWSQueryConnection):
             for i in range(len(params['Records'])):
                 data = params['Records'][i]['Data']
                 if not isinstance(data, six.binary_type):
-                    params['Records'][i]['Data'] = data.encode('utf-8')
+                    data = data.encode('utf-8')
                 params['Records'][i]['Data'] = base64.b64encode(
                     data).decode('utf-8')
         return self.make_request(action='PutRecords',

--- a/boto/kinesis/layer1.py
+++ b/boto/kinesis/layer1.py
@@ -738,9 +738,9 @@ class KinesisConnection(AWSQueryConnection):
         params = {'Records': records, 'StreamName': stream_name, }
         if b64_encode:
             for i in range(len(params['Records'])):
-                record = params['Records'][i]
-                params['Records'][i] = base64.b64encode(
-                    record.encode('utf-8')).decode('utf-8')
+                params['Records'][i]['Data'] = base64.b64encode(
+                    params['Records'][i]['Data'].encode('utf-8')).\
+                        decode('utf-8')
         return self.make_request(action='PutRecords',
                                  body=json.dumps(params))
 

--- a/tests/unit/kinesis/test_kinesis.py
+++ b/tests/unit/kinesis/test_kinesis.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2013 Amazon.com, Inc. or its affiliates.  All Rights Reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+
+from boto.compat import json
+from boto.kinesis.layer1 import KinesisConnection
+from tests.unit import AWSMockServiceTestCase
+
+
+class TestKinesis(AWSMockServiceTestCase):
+    connection_class = KinesisConnection
+
+    def default_body(self):
+        return b'{}'
+
+    def test_put_record_binary(self):
+        self.set_http_response(status_code=200)
+        self.service_connection.put_record('stream-name',
+            b'\x00\x01\x02\x03\x04\x05', 'partition-key')
+
+        body = json.loads(self.actual_request.body)
+        self.assertEqual(body['Data'], 'AAECAwQF')
+
+        target = self.actual_request.headers['X-Amz-Target']
+        self.assertTrue('PutRecord' in target)
+
+    def test_put_record_string(self):
+        self.set_http_response(status_code=200)
+        self.service_connection.put_record('stream-name',
+            'data', 'partition-key')
+
+        body = json.loads(self.actual_request.body)
+        self.assertEqual(body['Data'], 'ZGF0YQ==')
+
+        target = self.actual_request.headers['X-Amz-Target']
+        self.assertTrue('PutRecord' in target)

--- a/tests/unit/kinesis/test_kinesis.py
+++ b/tests/unit/kinesis/test_kinesis.py
@@ -52,3 +52,23 @@ class TestKinesis(AWSMockServiceTestCase):
 
         target = self.actual_request.headers['X-Amz-Target']
         self.assertTrue('PutRecord' in target)
+
+    def test_put_records(self):
+        self.set_http_response(status_code=200)
+        record_binary = {
+            'Data': b'\x00\x01\x02\x03\x04\x05',
+            'PartitionKey': 'partition-key'
+        }
+        record_str = {
+            'Data': 'data',
+            'PartitionKey': 'partition-key'
+        }
+        self.service_connection.put_records(stream_name='stream-name',
+            records=[record_binary, record_str])
+
+        body = json.loads(self.actual_request.body)
+        self.assertEqual(body['Records'][0]['Data'], 'AAECAwQF')
+        self.assertEqual(body['Records'][1]['Data'], 'ZGF0YQ==')
+
+        target = self.actual_request.headers['X-Amz-Target']
+        self.assertTrue('PutRecord' in target)


### PR DESCRIPTION
This updates Kinesis to the latest API. This includes being able to tag streams and use ``put_records``. I also pulled in the commits from another PR from @danielgtaylor that is still open: https://github.com/boto/boto/pull/2555. That was needed so that binary data for both ``put_record`` and ``put_records`` were treated properly.

cc @danielgtaylor @jamesls 