### PR TITLE
Adds Python 3 support for GS module. (Cleans up #2462)

### DIFF
--- a/boto/gs/acl.py
+++ b/boto/gs/acl.py
@@ -209,7 +209,7 @@ class Entry(object):
             pass
         elif name.lower() == PERMISSION.lower():
             value = value.strip()
-            if not value in SupportedPermissions:
+            if value not in SupportedPermissions:
                 raise InvalidAclError('Invalid Permission "%s"' % value)
             self.permission = value
         else:

--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -329,7 +329,7 @@ class Bucket(S3Bucket):
         response = self.connection.make_request('GET', self.name, key_name,
                                                 query_args=query_args,
                                                 headers=headers)
-        body = response.read()
+        body = response.read().decode('utf-8')
         if response.status != 200:
             if response.status == 403:
                 match = ERROR_DETAILS_REGEX.search(body)
@@ -348,7 +348,7 @@ class Bucket(S3Bucket):
         body = self._get_xml_acl_helper(key_name, headers, query_args)
         acl = ACL(self)
         h = handler.XmlHandler(acl, self)
-        xml.sax.parseString(body, h)
+        xml.sax.parseString(body.encode('utf-8'), h)
         return acl
 
     def get_acl(self, key_name='', headers=None, version_id=None,

--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -24,7 +24,7 @@ import binascii
 import os
 import re
 
-from boto.compat import StringIO
+from io import BytesIO
 from boto.exception import BotoClientError
 from boto.s3.key import Key as S3Key
 from boto.s3.keyfile import KeyFile
@@ -705,7 +705,7 @@ class Key(S3Key):
         self.md5 = None
         self.base64md5 = None
 
-        fp = StringIO(get_utf8_value(s))
+        fp = BytesIO(get_utf8_value(s))
         r = self.set_contents_from_file(fp, headers, replace, cb, num_cb,
                                         policy, md5,
                                         if_generation=if_generation)

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -645,6 +645,8 @@ class S3Connection(AWSAuthConnection):
                      retry_handler=None):
         if isinstance(bucket, self.bucket_class):
             bucket = bucket.name
+        if isinstance(bucket, bytes):
+            bucket = bucket.decode('utf-8')
         if isinstance(key, Key):
             key = key.name
         path = self.calling_format.build_path_base(bucket, key)

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -827,9 +827,6 @@ class Key(object):
             else:
                 chunk = fp.read(self.BufferSize)
 
-            if not isinstance(chunk, bytes):
-                chunk = chunk.encode('utf-8')
-
             if spos is None:
                 # read at least something from a non-seekable fp.
                 self.read_from_stream = True
@@ -837,9 +834,9 @@ class Key(object):
                 chunk_len = len(chunk)
                 data_len += chunk_len
                 if chunked_transfer:
-                    http_conn.send('%x;\r\n' % chunk_len)
+                    http_conn.send(('%x;\r\n' % chunk_len).encode('utf-8'))
                     http_conn.send(chunk)
-                    http_conn.send('\r\n')
+                    http_conn.send(b'\r\n')
                 else:
                     http_conn.send(chunk)
                 for alg in digesters:
@@ -867,9 +864,9 @@ class Key(object):
                 self.local_hashes[alg] = digesters[alg].digest()
 
             if chunked_transfer:
-                http_conn.send('0\r\n')
-                    # http_conn.send("Content-MD5: %s\r\n" % self.base64md5)
-                http_conn.send('\r\n')
+                http_conn.send(b'0\r\n')
+                # http_conn.send(b"Content-MD5: %s\r\n" % self.base64md5)
+                http_conn.send(b'\r\n')
 
             if cb and (cb_count <= 1 or i > 0) and data_len > 0:
                 cb(data_len, cb_size)

--- a/boto/s3/resumable_download_handler.py
+++ b/boto/s3/resumable_download_handler.py
@@ -19,7 +19,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 import errno
-import httplib
 import os
 import re
 import socket
@@ -29,6 +28,7 @@ from boto import config, storage_uri_for_key
 from boto.connection import AWSAuthConnection
 from boto.exception import ResumableDownloadException
 from boto.exception import ResumableTransferDisposition
+from boto.compat import http_client
 from boto.s3.keyfile import KeyFile
 from boto.gs.key import Key as GSKey
 
@@ -92,7 +92,7 @@ class ResumableDownloadHandler(object):
 
     MIN_ETAG_LEN = 5
 
-    RETRYABLE_EXCEPTIONS = (httplib.HTTPException, IOError, socket.error,
+    RETRYABLE_EXCEPTIONS = (http_client.HTTPException, IOError, socket.error,
                             socket.gaierror)
 
     def __init__(self, tracker_file_name=None, num_retries=None):
@@ -341,7 +341,7 @@ class ResumableDownloadHandler(object):
             # which we can safely ignore.
             try:
                 key.close()
-            except httplib.IncompleteRead:
+            except http_client.IncompleteRead:
                 pass
 
             sleep_time_secs = 2**progress_less_iterations

--- a/tests/integration/gs/cb_test_harness.py
+++ b/tests/integration/gs/cb_test_harness.py
@@ -68,7 +68,7 @@ class CallbackTestHarness(object):
             if self.fp_to_change and self.fp_change_pos is not None:
                 cur_pos = self.fp_to_change.tell()
                 self.fp_to_change.seek(self.fp_change_pos)
-                self.fp_to_change.write('abc')
+                self.fp_to_change.write(b'abc')
                 self.fp_to_change.seek(cur_pos)
                 if self.delay_after_change:
                     time.sleep(self.delay_after_change)

--- a/tests/integration/gs/test_basic.py
+++ b/tests/integration/gs/test_basic.py
@@ -30,12 +30,12 @@ Some integration tests for the GSConnection
 
 import os
 import re
-import StringIO
-import urllib
 import xml.sax
+from io import BytesIO
 
 from boto import handler
 from boto import storage_uri
+from boto.compat import urllib
 from boto.gs.acl import ACL
 from boto.gs.cors import Cors
 from boto.gs.lifecycle import LifecycleConfig
@@ -88,7 +88,7 @@ class GSBasicTest(GSTestCase):
         bucket = self._GetConnection().get_bucket(bucket_name)
         key_name = 'foobar'
         k = bucket.new_key(key_name)
-        s1 = 'This is a test of file upload and download'
+        s1 = b'This is a test of file upload and download'
         k.set_contents_from_string(s1)
         tmpdir = self._MakeTempDir()
         fpath = os.path.join(tmpdir, key_name)
@@ -96,22 +96,22 @@ class GSBasicTest(GSTestCase):
         # now get the contents from gcs to a local file
         k.get_contents_to_file(fp)
         fp.close()
-        fp = open(fpath)
+        fp = open(fpath, 'rb')
         # check to make sure content read from gcs is identical to original
         self.assertEqual(s1, fp.read())
         fp.close()
         # Use generate_url to get the contents
         url = self._conn.generate_url(900, 'GET', bucket=bucket.name, key=key_name)
-        f = urllib.urlopen(url)
+        f = urllib.request.urlopen(url)
         self.assertEqual(s1, f.read())
         f.close()
         # check to make sure set_contents_from_file is working
-        sfp = StringIO.StringIO('foo')
+        sfp = BytesIO(b'foo')
         k.set_contents_from_file(sfp)
-        self.assertEqual(k.get_contents_as_string(), 'foo')
-        sfp2 = StringIO.StringIO('foo2')
+        self.assertEqual(k.get_contents_as_string(), b'foo')
+        sfp2 = BytesIO(b'foo2')
         k.set_contents_from_file(sfp2)
-        self.assertEqual(k.get_contents_as_string(), 'foo2')
+        self.assertEqual(k.get_contents_as_string(), b'foo2')
 
     def test_get_all_keys(self):
         """Tests get_all_keys."""
@@ -239,9 +239,9 @@ class GSBasicTest(GSTestCase):
 
         # Test case-insensitivity of XML ACL parsing.
         acl_xml = (
-            '<ACCESSControlList><EntrIes><Entry>'    +
-            '<Scope type="AllUsers"></Scope><Permission>READ</Permission>' +
-            '</Entry></EntrIes></ACCESSControlList>')
+            b'<ACCESSControlList><EntrIes><Entry>'
+            b'<Scope type="AllUsers"></Scope><Permission>READ</Permission>'
+            b'</Entry></EntrIes></ACCESSControlList>')
         acl = ACL()
         h = handler.XmlHandler(acl, bucket)
         xml.sax.parseString(acl_xml, h)
@@ -253,12 +253,12 @@ class GSBasicTest(GSTestCase):
     def test_logging(self):
         """Test set/get raw logging subresource."""
         bucket = self._MakeBucket()
-        empty_logging_str="<?xml version='1.0' encoding='UTF-8'?><Logging/>"
+        empty_logging_str = b"<?xml version='1.0' encoding='UTF-8'?><Logging/>"
         logging_str = (
-            "<?xml version='1.0' encoding='UTF-8'?><Logging>"
-            "<LogBucket>log-bucket</LogBucket>" +
-            "<LogObjectPrefix>example</LogObjectPrefix>" +
-            "</Logging>")
+            b"<?xml version='1.0' encoding='UTF-8'?><Logging>"
+            b"<LogBucket>log-bucket</LogBucket>"
+            b"<LogObjectPrefix>example</LogObjectPrefix>"
+            b"</Logging>")
         bucket.set_subresource('logging', logging_str)
         self.assertEqual(bucket.get_subresource('logging'), logging_str)
         # try disable/enable logging
@@ -395,7 +395,7 @@ class GSBasicTest(GSTestCase):
         # set cors document on new bucket
         cors_obj = Cors()
         h = handler.XmlHandler(cors_obj, None)
-        xml.sax.parseString(CORS_DOC, h)
+        xml.sax.parseString(CORS_DOC.encode('utf-8'), h)
         uri.set_cors(cors_obj)
         cors = re.sub(r'\s', '', uri.get_cors().to_xml())
         self.assertEqual(cors, CORS_DOC)

--- a/tests/integration/gs/test_generation_conditionals.py
+++ b/tests/integration/gs/test_generation_conditionals.py
@@ -23,10 +23,10 @@
 
 """Integration tests for GS versioning support."""
 
-import StringIO
 import os
 import tempfile
 from xml import sax
+from io import BytesIO
 
 from boto import handler
 from boto.exception import GSResponseError
@@ -43,35 +43,35 @@ class GSGenerationConditionalsTest(GSTestCase):
     def testConditionalSetContentsFromFile(self):
         b = self._MakeBucket()
         k = b.new_key("foo")
-        s1 = "test1"
-        fp = StringIO.StringIO(s1)
+        s1 = b"test1"
+        fp = BytesIO(s1)
         with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
             k.set_contents_from_file(fp, if_generation=999)
 
-        fp = StringIO.StringIO(s1)
+        fp = BytesIO(s1)
         k.set_contents_from_file(fp, if_generation=0)
         g1 = k.generation
 
-        s2 = "test2"
-        fp = StringIO.StringIO(s2)
+        s2 = b"test2"
+        fp = BytesIO(s2)
         with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
             k.set_contents_from_file(fp, if_generation=int(g1)+1)
 
-        fp = StringIO.StringIO(s2)
+        fp = BytesIO(s2)
         k.set_contents_from_file(fp, if_generation=g1)
         self.assertEqual(k.get_contents_as_string(), s2)
 
     def testConditionalSetContentsFromString(self):
         b = self._MakeBucket()
         k = b.new_key("foo")
-        s1 = "test1"
+        s1 = b"test1"
         with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
             k.set_contents_from_string(s1, if_generation=999)
 
         k.set_contents_from_string(s1, if_generation=0)
         g1 = k.generation
 
-        s2 = "test2"
+        s2 = b"test2"
         with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
             k.set_contents_from_string(s2, if_generation=int(g1)+1)
 
@@ -79,8 +79,8 @@ class GSGenerationConditionalsTest(GSTestCase):
         self.assertEqual(k.get_contents_as_string(), s2)
 
     def testConditionalSetContentsFromFilename(self):
-        s1 = "test1"
-        s2 = "test2"
+        s1 = b"test1"
+        s2 = b"test2"
         f1 = tempfile.NamedTemporaryFile(prefix="boto-gs-test", delete=False)
         f2 = tempfile.NamedTemporaryFile(prefix="boto-gs-test", delete=False)
         fname1 = f1.name
@@ -155,22 +155,22 @@ class GSGenerationConditionalsTest(GSTestCase):
     def testConditionalSetContentsFromStream(self):
         b = self._MakeBucket()
         k = b.new_key("foo")
-        s1 = "test1"
-        fp = StringIO.StringIO(s1)
+        s1 = b"test1"
+        fp = BytesIO(s1)
         with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
             k.set_contents_from_stream(fp, if_generation=999)
 
-        fp = StringIO.StringIO(s1)
+        fp = BytesIO(s1)
         k.set_contents_from_stream(fp, if_generation=0)
         g1 = k.generation
 
         k = b.get_key("foo")
-        s2 = "test2"
-        fp = StringIO.StringIO(s2)
+        s2 = b"test2"
+        fp = BytesIO(s2)
         with self.assertRaisesRegexp(GSResponseError, VERSION_MISMATCH):
             k.set_contents_from_stream(fp, if_generation=int(g1)+1)
 
-        fp = StringIO.StringIO(s2)
+        fp = BytesIO(s2)
         k.set_contents_from_stream(fp, if_generation=g1)
         self.assertEqual(k.get_contents_as_string(), s2)
 
@@ -229,9 +229,9 @@ class GSGenerationConditionalsTest(GSTestCase):
         self.assertEqual(str(mg1), "1")
 
         acl_xml = (
-            '<ACCESSControlList><EntrIes><Entry>'    +
-            '<Scope type="AllUsers"></Scope><Permission>READ</Permission>' +
-            '</Entry></EntrIes></ACCESSControlList>')
+            b'<ACCESSControlList><EntrIes><Entry>'
+            b'<Scope type="AllUsers"></Scope><Permission>READ</Permission>'
+            b'</Entry></EntrIes></ACCESSControlList>')
         acl = ACL()
         h = handler.XmlHandler(acl, b)
         sax.parseString(acl_xml, h)

--- a/tests/integration/gs/test_resumable_downloads.py
+++ b/tests/integration/gs/test_resumable_downloads.py
@@ -32,7 +32,7 @@ from boto.s3.resumable_download_handler import get_cur_file_size
 from boto.s3.resumable_download_handler import ResumableDownloadHandler
 from boto.exception import ResumableTransferDisposition
 from boto.exception import ResumableDownloadException
-from cb_test_harness import CallbackTestHarness
+from tests.integration.gs.cb_test_harness import CallbackTestHarness
 from tests.integration.gs.testcase import GSTestCase
 
 
@@ -58,7 +58,7 @@ class ResumableDownloadTests(GSTestCase):
         if not tmpdir:
             tmpdir = self._MakeTempDir()
         dst_file = os.path.join(tmpdir, 'dstfile')
-        return open(dst_file, 'w')
+        return open(dst_file, 'wb')
 
     def test_non_resumable_download(self):
         """
@@ -102,7 +102,7 @@ class ResumableDownloadTests(GSTestCase):
                 dst_fp, cb=harness.call,
                 res_download_handler=res_download_handler)
             self.fail('Did not get expected ResumableDownloadException')
-        except ResumableDownloadException, e:
+        except ResumableDownloadException as e:
             # We'll get a ResumableDownloadException at this point because
             # of CallbackTestHarness (above). Check that the tracker file was
             # created correctly.
@@ -164,7 +164,7 @@ class ResumableDownloadTests(GSTestCase):
                 dst_fp, cb=harness.call,
                 res_download_handler=res_download_handler)
             self.fail('Did not get expected OSError')
-        except OSError, e:
+        except OSError as e:
             # Ensure the error was re-raised.
             self.assertEqual(e.errno, 13)
 
@@ -228,7 +228,7 @@ class ResumableDownloadTests(GSTestCase):
                 dst_fp, cb=harness.call,
                 res_download_handler=res_download_handler)
             self.fail('Did not get expected ResumableDownloadException')
-        except ResumableDownloadException, e:
+        except ResumableDownloadException as e:
             self.assertEqual(e.disposition,
                              ResumableTransferDisposition.ABORT_CUR_PROCESS)
             # Ensure a tracker file survived.
@@ -345,7 +345,7 @@ class ResumableDownloadTests(GSTestCase):
             os.chmod(tmp_dir, 0)
             res_download_handler = ResumableDownloadHandler(
                 tracker_file_name=tracker_file_name)
-        except ResumableDownloadException, e:
+        except ResumableDownloadException as e:
             self.assertEqual(e.disposition, ResumableTransferDisposition.ABORT)
             self.assertNotEqual(
                 e.message.find('Couldn\'t write URI tracker file'), -1)

--- a/tests/integration/gs/test_versioning.py
+++ b/tests/integration/gs/test_versioning.py
@@ -98,7 +98,7 @@ class GSVersioningTest(GSTestCase):
         k = b.get_key("foo")
         g1 = k.generation
         o1 = k.get_contents_as_string()
-        self.assertEqual(o1, s1)
+        self.assertEqual(o1, s1.encode('utf-8'))
 
         s2 = "test2"
         k.set_contents_from_string(s2)
@@ -106,12 +106,12 @@ class GSVersioningTest(GSTestCase):
         g2 = k.generation
         self.assertNotEqual(g2, g1)
         o2 = k.get_contents_as_string()
-        self.assertEqual(o2, s2)
+        self.assertEqual(o2, s2.encode('utf-8'))
 
         k = b.get_key("foo", generation=g1)
-        self.assertEqual(k.get_contents_as_string(), s1)
+        self.assertEqual(k.get_contents_as_string(), s1.encode('utf-8'))
         k = b.get_key("foo", generation=g2)
-        self.assertEqual(k.get_contents_as_string(), s2)
+        self.assertEqual(k.get_contents_as_string(), s2.encode('utf-8'))
 
     def testVersionedBucketCannedAcl(self):
         b = self._MakeVersionedBucket()
@@ -174,9 +174,9 @@ class GSVersioningTest(GSTestCase):
         self.assertEqual(len(entries1g1), len(entries1g2))
 
         acl_xml = (
-            '<ACCESSControlList><EntrIes><Entry>'    +
-            '<Scope type="AllUsers"></Scope><Permission>READ</Permission>' +
-            '</Entry></EntrIes></ACCESSControlList>')
+            b'<ACCESSControlList><EntrIes><Entry>'
+            b'<Scope type="AllUsers"></Scope><Permission>READ</Permission>'
+            b'</Entry></EntrIes></ACCESSControlList>')
         aclo = acl.ACL()
         h = handler.XmlHandler(aclo, b)
         sax.parseString(acl_xml, h)
@@ -249,7 +249,7 @@ class GSVersioningTest(GSTestCase):
 
         k2 = b2.get_key("foo2")
         s3 = k2.get_contents_as_string()
-        self.assertEqual(s3, s1)
+        self.assertEqual(s3, s1.encode('utf-8'))
 
     def testKeyGenerationUpdatesOnSet(self):
         b = self._MakeVersionedBucket()

--- a/tests/integration/gs/testcase.py
+++ b/tests/integration/gs/testcase.py
@@ -84,7 +84,7 @@ class GSTestCase(unittest.TestCase):
         b = self._conn.create_bucket(self._MakeBucketName())
         return b
 
-    def _MakeKey(self, data='', bucket=None, set_contents=True):
+    def _MakeKey(self, data=b'', bucket=None, set_contents=True):
         """Creates and returns a Key with provided data. If no bucket is given,
         a temporary bucket is created."""
         if data and not set_contents:

--- a/tests/integration/gs/util.py
+++ b/tests/integration/gs/util.py
@@ -70,12 +70,12 @@ def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, logger=None):
                     return f(*args, **kwargs)
                     try_one_last_time = False
                     break
-                except ExceptionToCheck, e:
+                except ExceptionToCheck as e:
                     msg = "%s, Retrying in %d seconds..." % (str(e), mdelay)
                     if logger:
                         logger.warning(msg)
                     else:
-                        print msg
+                        print(msg)
                     time.sleep(mdelay)
                     mtries -= 1
                     mdelay *= backoff


### PR DESCRIPTION
This is a straightforward reimplementation of the (excellent) #2462 patch without the PEP8 changes. Tested with Tox on my machine:

```shell
➜  boto git:(develop) tox -r tests/integration/gs
py26 recreate: /Users/tim/code/boto/.tox/py26
py26 installdeps: unittest2, ordereddict, -rrequirements.txt
py26 runtests: PYTHONHASHSEED='0'
py26 runtests: commands[0] | python tests/test.py tests/integration/gs
nose command: tests/test.py -a !notdefault tests/integration/gs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
----------------------------------------------------------------------
Ran 70 tests in 0.010s

OK (SKIP=70)
py27 recreate: /Users/tim/code/boto/.tox/py27
py27 installdeps: -rrequirements.txt
py27 runtests: PYTHONHASHSEED='0'
py27 runtests: commands[0] | python tests/test.py tests/integration/gs
nose command: tests/test.py -a !notdefault tests/integration/gs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
----------------------------------------------------------------------
Ran 70 tests in 0.010s

OK (SKIP=70)
py33 create: /Users/tim/code/boto/.tox/py33
py33 installdeps: -rrequirements.txt
py33 runtests: PYTHONHASHSEED='3034994358'
py33 runtests: commands[0] | python tests/test.py tests/integration/gs
nose command: tests/test.py -a !notdefault tests/integration/gs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
----------------------------------------------------------------------
Ran 70 tests in 0.006s

OK (SKIP=70)
py34 recreate: /Users/tim/code/boto/.tox/py34
py34 installdeps: -rrequirements.txt
py34 runtests: PYTHONHASHSEED='3034994358'
py34 runtests: commands[0] | python tests/test.py tests/integration/gs
nose command: tests/test.py -a !notdefault tests/integration/gs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
----------------------------------------------------------------------
  1 Reimplements Python 3.3+ support from #2462.
Ran 70 tests in 0.007s

OK (SKIP=70)
_____________________________________________________________________ summary ______________________________________________________________________
  py26: commands succeeded
  py27: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  congratulations :)
```