### PR TITLE
Allow for binary to be passed to sqs message

### DIFF
--- a/boto/sqs/message.py
+++ b/boto/sqs/message.py
@@ -68,6 +68,7 @@ import base64
 import boto
 
 from boto.compat import StringIO
+from boto.compat import six
 from boto.sqs.attributes import Attributes
 from boto.sqs.messageattributes import MessageAttributes
 from boto.exception import SQSDecodeError
@@ -163,7 +164,9 @@ class Message(RawMessage):
     """
 
     def encode(self, value):
-        return base64.b64encode(value.encode('utf-8')).decode('utf-8')
+        if not isinstance(value, six.binary_type):
+            value = value.encode('utf-8')
+        return base64.b64encode(value).decode('utf-8')
 
     def decode(self, value):
         try:

--- a/tests/unit/sqs/test_message.py
+++ b/tests/unit/sqs/test_message.py
@@ -23,6 +23,7 @@ from tests.unit import unittest
 
 from boto.sqs.message import MHMessage
 from boto.sqs.message import RawMessage
+from boto.sqs.message import Message
 from boto.sqs.bigmessage import BigMessage
 from boto.exception import SQSDecodeError
 
@@ -68,6 +69,20 @@ class TestEncodeMessage(unittest.TestCase):
         message = context.exception.message
         self.assertEquals(message.id, sample_value)
         self.assertEquals(message.receipt_handle, sample_value)
+
+    @attr(sqs=True)
+    def test_encode_bytes_message(self):
+        message = Message()
+        body = b'\x00\x01\x02\x03\x04\x05'
+        message.set_body(body)
+        self.assertEqual(message.get_body_encoded(), 'AAECAwQF')
+
+    @attr(sqs=True)
+    def test_encode_string_message(self):
+        message = Message()
+        body = 'hello world'
+        message.set_body(body)
+        self.assertEqual(message.get_body_encoded(), 'aGVsbG8gd29ybGQ=')
 
 
 class TestBigMessage(unittest.TestCase):


### PR DESCRIPTION
Fixes https://github.com/boto/boto/issues/2865

Originally was not taking into account binary data when base64 encoding the message body.

cc @danielgtaylor @jamesls 