### PR TITLE
Fixed spelling of boto.awslambda package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(name = "boto",
                   "boto.route53.domains", "boto.cognito",
                   "boto.cognito.identity", "boto.cognito.sync",
                   "boto.cloudsearchdomain", "boto.kms",
-                  "boto.awslamba", "boto.codedeploy", "boto.configservice",
+                  "boto.awslambda", "boto.codedeploy", "boto.configservice",
                   "boto.cloudhsm", "boto.ec2containerservice"],
       package_data = {
           "boto.cacerts": ["cacerts.txt"],


### PR DESCRIPTION
Installed boto on new system and found a simple typo in package list.