### PR TITLE
DynamoDBConnection handles host=None

### DIFF
--- a/boto/dynamodb2/layer1.py
+++ b/boto/dynamodb2/layer1.py
@@ -169,7 +169,7 @@ class DynamoDBConnection(AWSQueryConnection):
                     break
 
         # Only set host if it isn't manually overwritten
-        if 'host' not in kwargs:
+        if kwargs.get('host') is None:
             kwargs['host'] = region.endpoint
 
         super(DynamoDBConnection, self).__init__(**kwargs)


### PR DESCRIPTION
The default value of the host argument to DynamoDBConnection's constructor is documented as None because it subclasses AWSQueryConnection. However, explicitly passing host=None did not behave the same as not passing a value because the constructor checked for 'host' as key in kwargs.