### PR TITLE
Add Amazon DynamoDB online indexing support on High level API

### DIFF
--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -371,10 +371,9 @@ class Table(object):
             raw_indexes = result['Table'].get('LocalSecondaryIndexes', [])
             self.indexes = self._introspect_indexes(raw_indexes)
 
-        if not self.global_indexes:
-            # Build the global index information as well.
-            raw_global_indexes = result['Table'].get('GlobalSecondaryIndexes', [])
-            self.global_indexes = self._introspect_global_indexes(raw_global_indexes)
+        # Build the global index information as well.
+        raw_global_indexes = result['Table'].get('GlobalSecondaryIndexes', [])
+        self.global_indexes = self._introspect_global_indexes(raw_global_indexes)
 
         # This is leaky.
         return result
@@ -465,6 +464,9 @@ class Table(object):
         Requires a ``global_indexes`` parameter, which should be a
         ``GlobalBaseIndexField`` subclass representing the desired index.
 
+        To update ``global_indexes`` information on the ``Table``, you'll need
+        to call ``Table.describe``.
+
         Returns ``True`` on success.
 
         Example::
@@ -517,6 +519,9 @@ class Table(object):
         Requires a ``global_index_name`` parameter, which should be a simple
         string of the name of the global secondary index.
 
+        To update ``global_indexes`` information on the ``Table``, you'll need
+        to call ``Table.describe``.
+
         Returns ``True`` on success.
 
         Example::
@@ -557,6 +562,9 @@ class Table(object):
         dictionary. If provided, it should specify the index name, which is also
         a dict containing a ``read`` & ``write`` key, both of which
         should have an integer value associated with them.
+
+        To update ``global_indexes`` information on the ``Table``, you'll need
+        to call ``Table.describe``.
 
         Returns ``True`` on success.
 

--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -443,12 +443,20 @@ class Table(object):
                     },
                 })
 
-        self.connection.update_table(
-            self.table_name,
-            provisioned_throughput=data,
-            global_secondary_index_updates=gsi_data,
-        )
-        return True
+        if throughput or global_indexes:
+            self.connection.update_table(
+                self.table_name,
+                provisioned_throughput=data,
+                global_secondary_index_updates=gsi_data,
+            )
+
+            return True
+        else:
+            msg = 'You need to provide either the throughput or the ' \
+                  'global_indexes to update method'
+            boto.log.error(msg)
+
+            return False
 
     def create_global_secondary_index(self, global_index):
         """
@@ -477,9 +485,6 @@ class Table(object):
 
         """
 
-        gsi_data = None
-        gsi_data_attr_def = None
-
         if global_index:
             gsi_data = []
             gsi_data_attr_def = []
@@ -491,12 +496,19 @@ class Table(object):
             for attr_def in global_index.parts:
                 gsi_data_attr_def.append(attr_def.definition())
 
-        self.connection.update_table(
-            self.table_name,
-            global_secondary_index_updates=gsi_data,
-            attribute_definitions=gsi_data_attr_def
-        )
-        return True
+            self.connection.update_table(
+                self.table_name,
+                global_secondary_index_updates=gsi_data,
+                attribute_definitions=gsi_data_attr_def
+            )
+
+            return True
+        else:
+            msg = 'You need to provide the global_index to ' \
+                  'create_global_secondary_index method'
+            boto.log.error(msg)
+
+            return False
 
     def delete_global_secondary_index(self, global_index_name):
         """
@@ -515,8 +527,6 @@ class Table(object):
 
         """
 
-        gsi_data = None
-
         if global_index_name:
             gsi_data = [
                 {
@@ -526,11 +536,18 @@ class Table(object):
                 }
             ]
 
-        self.connection.update_table(
-            self.table_name,
-            global_secondary_index_updates=gsi_data,
-        )
-        return True
+            self.connection.update_table(
+                self.table_name,
+                global_secondary_index_updates=gsi_data,
+            )
+
+            return True
+        else:
+            msg = 'You need to provide the global index name to ' \
+                  'delete_global_secondary_index method'
+            boto.log.error(msg)
+
+            return False
 
     def update_global_secondary_index(self, global_index):
         """
@@ -555,7 +572,6 @@ class Table(object):
             True
 
         """
-        gsi_data = None
 
         if global_index:
             gsi_data = []
@@ -571,11 +587,17 @@ class Table(object):
                     },
                 })
 
-        self.connection.update_table(
-            self.table_name,
-            global_secondary_index_updates=gsi_data,
-        )
-        return True
+            self.connection.update_table(
+                self.table_name,
+                global_secondary_index_updates=gsi_data,
+            )
+            return True
+        else:
+            msg = 'You need to provide the global index to ' \
+                  'update_global_secondary_index method'
+            boto.log.error(msg)
+
+            return False
 
     def delete(self):
         """

--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -137,9 +137,9 @@ class Table(object):
         to define the key structure of the table.
 
         **IMPORTANT** - You should consider the usage pattern of your table
-        up-front, as the schema & indexes can **NOT** be modified once the
-        table is created, requiring the creation of a new table & migrating
-        the data should you wish to revise it.
+        up-front, as the schema can **NOT** be modified once the table is
+        created, requiring the creation of a new table & migrating the data
+        should you wish to revise it.
 
         **IMPORTANT** - If the table already exists in DynamoDB, additional
         calls to this method will result in an error. If you just need
@@ -499,8 +499,7 @@ class Table(object):
                                 "WriteCapacityUnits": int(gsi_operation_value['write']),
                             },
                         },
-                     })
-
+                    })
 
         self.connection.update_table(
             self.table_name,

--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -549,9 +549,9 @@ class Table(object):
 
             return False
 
-    def update_global_secondary_index(self, global_index):
+    def update_global_secondary_index(self, global_indexes):
         """
-        Updates a global index in DynamoDB after the table has been created.
+        Updates a global index(es) in DynamoDB after the table has been created.
 
         Requires a ``global_indexes`` parameter, which should be a
         dictionary. If provided, it should specify the index name, which is also
@@ -563,7 +563,7 @@ class Table(object):
         Example::
 
             # To update a global index
-            >>> users.update_global_secondary_index(global_index={
+            >>> users.update_global_secondary_index(global_indexes={
             ...     'TheIndexNameHere': {
             ...         'read': 15,
             ...         'write': 5,
@@ -573,10 +573,10 @@ class Table(object):
 
         """
 
-        if global_index:
+        if global_indexes:
             gsi_data = []
 
-            for gsi_name, gsi_throughput in global_index.items():
+            for gsi_name, gsi_throughput in global_indexes.items():
                 gsi_data.append({
                     "Update": {
                         "IndexName": gsi_name,
@@ -593,7 +593,7 @@ class Table(object):
             )
             return True
         else:
-            msg = 'You need to provide the global index to ' \
+            msg = 'You need to provide the global indexes to ' \
                   'update_global_secondary_index method'
             boto.log.error(msg)
 

--- a/tests/integration/dynamodb2/test_highlevel.py
+++ b/tests/integration/dynamodb2/test_highlevel.py
@@ -719,7 +719,7 @@ class DynamoDBv2Test(unittest.TestCase):
 
     def test_update_table_online_indexing_support(self):
         # Create a table using gsi to test the DynamoDB online indexing support
-        # https://github.com/boto/boto/issues/2828
+        # https://github.com/boto/boto/pull/2925
         users = Table.create('online_indexing_support_users', schema=[
             HashKey('user_id')
         ], throughput={
@@ -740,8 +740,16 @@ class DynamoDBv2Test(unittest.TestCase):
         # Wait for it.
         time.sleep(60)
 
+        # Fetch fresh table desc from DynamoDB
+        users.describe()
+
+        # Assert if everything is fine so far
+        self.assertEqual(len(users.global_indexes), 1)
+        self.assertEqual(users.global_indexes[0].throughput['read'], 2)
+        self.assertEqual(users.global_indexes[0].throughput['write'], 2)
+
         # Update a GSI throughput. it should work.
-        users.update_global_secondary_index(global_index={
+        users.update_global_secondary_index(global_indexes={
             'EmailGSIIndex': {
                 'read': 2,
                 'write': 1,
@@ -750,6 +758,14 @@ class DynamoDBv2Test(unittest.TestCase):
 
         # Wait for it.
         time.sleep(60)
+
+        # Fetch fresh table desc from DynamoDB
+        users.describe()
+
+        # Assert if everything is fine so far
+        self.assertEqual(len(users.global_indexes), 1)
+        self.assertEqual(users.global_indexes[0].throughput['read'], 2)
+        self.assertEqual(users.global_indexes[0].throughput['write'], 1)
 
         # Update a GSI throughput using the old fashion way for compatibility
         # purposes. it should work.
@@ -763,11 +779,25 @@ class DynamoDBv2Test(unittest.TestCase):
         # Wait for it.
         time.sleep(60)
 
+        # Fetch fresh table desc from DynamoDB
+        users.describe()
+
+        # Assert if everything is fine so far
+        self.assertEqual(len(users.global_indexes), 1)
+        self.assertEqual(users.global_indexes[0].throughput['read'], 3)
+        self.assertEqual(users.global_indexes[0].throughput['write'], 2)
+
         # Delete a GSI. it should work.
         users.delete_global_secondary_index('EmailGSIIndex')
 
         # Wait for it.
         time.sleep(60)
+
+        # Fetch fresh table desc from DynamoDB
+        users.describe()
+
+        # Assert if everything is fine so far
+        self.assertEqual(len(users.global_indexes), 0)
 
         # Create a GSI. it should work.
         users.create_global_secondary_index(
@@ -781,3 +811,11 @@ class DynamoDBv2Test(unittest.TestCase):
         )
         # Wait for it. This operation usually takes much longer than the others
         time.sleep(60*10)
+
+        # Fetch fresh table desc from DynamoDB
+        users.describe()
+
+        # Assert if everything is fine so far
+        self.assertEqual(len(users.global_indexes), 1)
+        self.assertEqual(users.global_indexes[0].throughput['read'], 1)
+        self.assertEqual(users.global_indexes[0].throughput['write'], 1)

--- a/tests/integration/dynamodb2/test_highlevel.py
+++ b/tests/integration/dynamodb2/test_highlevel.py
@@ -741,12 +741,10 @@ class DynamoDBv2Test(unittest.TestCase):
         time.sleep(60)
 
         # Update a GSI throughput. it should work.
-        users.update(global_indexes={
-            'update': {
-                'EmailGSIIndex': {
-                    'read': 2,
-                    'write': 1,
-                }
+        users.update_global_secondary_index(global_index={
+            'EmailGSIIndex': {
+                'read': 2,
+                'write': 1,
             }
         })
 
@@ -757,8 +755,8 @@ class DynamoDBv2Test(unittest.TestCase):
         # purposes. it should work.
         users.update(global_indexes={
             'EmailGSIIndex': {
-                'read': 2,
-                'write': 1,
+                'read': 3,
+                'write': 2,
             }
         })
 
@@ -766,18 +764,20 @@ class DynamoDBv2Test(unittest.TestCase):
         time.sleep(60)
 
         # Delete a GSI. it should work.
-        users.update(global_indexes={
-            'delete': 'EmailGSIIndex'
-        })
+        users.delete_global_secondary_index('EmailGSIIndex')
 
-        users.update(global_indexes={
-            'create': GlobalAllIndex('AddressGSIIndex', parts=[
+        # Wait for it.
+        time.sleep(60)
+
+        # Create a GSI. it should work.
+        users.create_global_secondary_index(
+            global_index=GlobalAllIndex(
+                'AddressGSIIndex', parts=[
                     HashKey('address', data_type=STRING)
                 ], throughput={
                     'read': 1,
                     'write': 1,
                 })
-
-        })
+        )
         # Wait for it. This operation usually takes much longer than the others
-        time.sleep(60*5)
+        time.sleep(60*10)

--- a/tests/unit/dynamodb2/test_table.py
+++ b/tests/unit/dynamodb2/test_table.py
@@ -1536,8 +1536,7 @@ class TableTestCase(unittest.TestCase):
             provisioned_throughput={
                 'WriteCapacityUnits': 2,
                 'ReadCapacityUnits': 7
-            },
-            attribute_definitions=None
+            }
         )
 
         with mock.patch.object(

--- a/tests/unit/dynamodb2/test_table.py
+++ b/tests/unit/dynamodb2/test_table.py
@@ -1536,7 +1536,8 @@ class TableTestCase(unittest.TestCase):
             provisioned_throughput={
                 'WriteCapacityUnits': 2,
                 'ReadCapacityUnits': 7
-            }
+            },
+            attribute_definitions=None
         )
 
         with mock.patch.object(


### PR DESCRIPTION
Hi,

Yesterday (Jan-29), Amazon has added support to add or delete global indexes at any time, which is by far the feature I was most looking forward using for over a year. 

I've changed dynamodb2.table.update method taking into account the backward campatibility as well. Documentation amendments and a unit test case has been provided too accordingly to the contributing guidelines.

Looking forward to see this in the new version of boto. 
