### PR TITLE
Fix region bug

### DIFF
--- a/boto/endpoints.json
+++ b/boto/endpoints.json
@@ -112,8 +112,7 @@
         "us-west-2": "datapipeline.us-west-2.amazonaws.com",
         "eu-west-1": "datapipeline.eu-west-1.amazonaws.com",
         "ap-southeast-2": "datapipeline.ap-southeast-2.amazonaws.com",
-        "ap-northeast-1": "datapipeline.ap-northeast-1.amazonaws.com",
-        "eu-central-1": "datapipeline.eu-central-1.amazonaws.com"
+        "ap-northeast-1": "datapipeline.ap-northeast-1.amazonaws.com"
     },
     "directconnect": {
         "ap-northeast-1": "directconnect.ap-northeast-1.amazonaws.com",


### PR DESCRIPTION
AWS Data Pipeline is not actually available in `eu-central-1` according to the [regions and endpoints](http://docs.aws.amazon.com/general/latest/gr/rande.html#datapipeline_region) documentation. This just removes the line that was mistakenly added.

cc @jamesls @kyleknap 