### PR TITLE
Ensure Content-Length header is a str

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -381,7 +381,7 @@ class HTTPRequest(object):
         if 'Content-Length' not in self.headers:
             if 'Transfer-Encoding' not in self.headers or \
                     self.headers['Transfer-Encoding'] != 'chunked':
-                self.headers['Content-Length'] = len(self.body)
+                self.headers['Content-Length'] = str(len(self.body))
 
 
 class HTTPResponse(http_client.HTTPResponse):

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -524,6 +524,16 @@ class TestHTTPRequest(unittest.TestCase):
                          {'Some-Header': 'should%20be%20url%20encoded',
                           'User-Agent': UserAgent})
 
+    def test_content_length_str(self):
+        request = HTTPRequest('PUT', 'https', 'amazon.com', 443, None,
+                              None, {}, {}, 'Body')
+        mock_connection = mock.Mock()
+        request.authorize(mock_connection)
+
+        # Ensure Content-Length header is a str. This is more explicit than
+        # relying on other code cast the value later. (Python 2.7.0, for
+        # example, assumes headers are of type str.)
+        self.assertIsInstance(request.headers['Content-Length'], str)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Ensure Content-Length header is a str. This is more explicit than relying on other code cast the value later.

This skirts an issue with httplib in Python 2.7.0, which assumes headers are already of type str. Though newer versions of httplib cast headers to str values, it seems more explicit for boto to do the casting.