### PR TITLE
CORS add_rule(), copy/paste error preventing allowed_header check.

### DIFF
--- a/boto/s3/cors.py
+++ b/boto/s3/cors.py
@@ -195,11 +195,11 @@ class CORSConfiguration(list):
             allowed_method = [allowed_method]
         if not isinstance(allowed_origin, (list, tuple)):
             allowed_origin = [allowed_origin]
-        if not isinstance(allowed_origin, (list, tuple)):
-            if allowed_origin is None:
-                allowed_origin = []
+        if not isinstance(allowed_header, (list, tuple)):
+            if allowed_header is None:
+                allowed_header = []
             else:
-                allowed_origin = [allowed_origin]
+                allowed_header = [allowed_header]
         if not isinstance(expose_header, (list, tuple)):
             if expose_header is None:
                 expose_header = []

--- a/tests/unit/s3/test_cors_configuration.py
+++ b/tests/unit/s3/test_cors_configuration.py
@@ -44,6 +44,20 @@ CORS_BODY_3 = (
     '</CORSRule>'
     '</CORSConfiguration>')
 
+CORS_BODY_4 = (
+    '<CORSConfiguration>'
+    '<CORSRule>'
+    '<AllowedMethod>PUT</AllowedMethod>'
+    '<AllowedOrigin>http://www.example.com</AllowedOrigin>'
+    '<AllowedHeader>foo</AllowedHeader>'
+    '<AllowedHeader>bar</AllowedHeader>'
+    '</CORSRule>'
+    '<CORSRule>'
+    '<AllowedMethod>PUT</AllowedMethod>'
+    '<AllowedOrigin>http://www.example.com</AllowedOrigin>'
+    '<AllowedHeader>foo</AllowedHeader>'
+    '</CORSRule>'
+    '</CORSConfiguration>')
 
 class TestCORSConfiguration(unittest.TestCase):
 
@@ -71,6 +85,14 @@ class TestCORSConfiguration(unittest.TestCase):
         cfg = CORSConfiguration()
         cfg.add_rule('GET', '*')
         self.assertEqual(cfg.to_xml(), CORS_BODY_3)
+
+    def test_allowed_header(self):
+        cfg = CORSConfiguration()
+        cfg.add_rule('PUT', 'http://www.example.com',
+                     allowed_header=['foo', 'bar'])
+        cfg.add_rule('PUT', 'http://www.example.com',
+                     allowed_header='foo')
+        self.assertEqual(cfg.to_xml(), CORS_BODY_4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
S3 CORS clearly isn't being used very much. Simple copy paste error in cors.py "add_rule()" when passing a single "allowed header" as a string. allowed_origin variable was incorrectly being used twice when the second type check should have been allowed_header (similar to expose_header check). All other tags are handled correctly.