### PR TITLE
Correct parameters for SSHClient

### DIFF
--- a/boto/manage/cmdshell.py
+++ b/boto/manage/cmdshell.py
@@ -404,4 +404,4 @@ def sshclient_from_instance(instance, ssh_key_file,
                     private key.
     """
     s = FakeServer(instance, ssh_key_file)
-    return SSHClient(s, host_key_file, user_name, ssh_pwd)
+    return SSHClient(s, host_key_file, uname=user_name, ssh_pwd=ssh_pwd)


### PR DESCRIPTION
Pass the correct keyword parameters to SSHClient from sshclient_from_instance - this fixes issue #2599