### PR TITLE
Correct docs around overriding SGs on ELBs

### DIFF
--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -695,9 +695,9 @@ class ELBConnection(AWSQueryConnection):
 
     def apply_security_groups_to_lb(self, name, security_groups):
         """
-        Applies security groups to the load balancer.
-        Applying security groups that are already registered with the
-        Load Balancer has no effect.
+        Associates one or more security groups with the load balancer.
+        The provided security groups will override any currently applied
+        security groups.
 
         :type name: string
         :param name: The name of the Load Balancer

--- a/boto/ec2/elb/loadbalancer.py
+++ b/boto/ec2/elb/loadbalancer.py
@@ -404,9 +404,9 @@ class LoadBalancer(object):
 
     def apply_security_groups(self, security_groups):
         """
-        Applies security groups to the load balancer.
-        Applying security groups that are already registered with the
-        Load Balancer has no effect.
+        Associates one or more security groups with the load balancer.
+        The provided security groups will override any currently applied
+        security groups.
 
         :type security_groups: string or List of strings
         :param security_groups: The name of the security group(s) to add.


### PR DESCRIPTION
This commit corrects a critical documentation error where the
`LoadBalancer.apply_security_groups` and
`ELBConnection.apply_security_groups_to_lb` methods incorrectly
state that they add security groups to a load balancer. These
methods are not additive, rather they override any currently
applied security groups with the security groups passed to them.

This is potentially catastrophic from a user's perspective as
a destructive method is being presented as non-destructive.

The AWS documentation for the ApplySecurityGroupsToLoadBalancer
action may be found here:
http://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_ApplySecurityGroupsToLoadBalancer.html