### PR TITLE
ISSUE 2849: '~' character in object name causes V4 SignatureDoesNotMatch

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -385,7 +385,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
     def canonical_uri(self, http_request):
         path = http_request.auth_path
         # Normalize the path
-        # in windows normpath('/') will be '\\' so we chane it back to '/'
+        # in windows normpath('/') will be '\\' so we change it back to '/'
         normalized = posixpath.normpath(path).replace('\\', '/')
         # Then urlencode whatever's left.
         encoded = urllib.parse.quote(normalized)
@@ -570,8 +570,8 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         path = urllib.parse.urlparse(http_request.path)
         # Because some quoting may have already been applied, let's back it out.
         unquoted = urllib.parse.unquote(path.path)
-        # Requote, this time addressing all characters.
-        encoded = urllib.parse.quote(unquoted)
+        # Requote all characters except: A-Z,a-z,0-9,-,.,_,~,/
+        encoded = urllib.parse.quote(unquoted, '/~')
         return encoded
 
     def canonical_query_string(self, http_request):

--- a/tests/unit/s3/test_connection.py
+++ b/tests/unit/s3/test_connection.py
@@ -115,6 +115,12 @@ class TestSigV4Presigned(MockServiceWithConfigTestCase):
 
         self.assertIn('a937f5fbc125d98ac8f04c49e0204ea1526a7b8ca058000a54c192457be05b7d', url)
 
+        # Test various characters in the object name are handled correctly
+        url = conn.generate_url_sigv4(86400, 'GET', bucket='examplebucket',
+            key='abcdefghijklmnopqrstuvwxyz/ABCDEFGHIJKLMNOPQRSTUVWXYZ/0123456789_.-~!@#$%^&*', iso_date='20140625T000000Z')
+
+        self.assertIn('a00028aba0c606240cbf3a687fb2a3b1b3f89155d167e9fe5fea3f10d9522d11', url)
+
     def test_sigv4_presign_optional_params(self):
         self.config = {
             's3': {


### PR DESCRIPTION
When calculating the canonical request for signing with V4 signatures,
the following characters should not be url encoded in the Canonical URI:
 A-Z, a-z, 0-9, -, ., _, ~, /

All characters were handled correctly except ~.