### PR TITLE
Fix #2946 parse entire response from GetTransactionsForSubscription

### DIFF
--- a/boto/fps/connection.py
+++ b/boto/fps/connection.py
@@ -358,11 +358,12 @@ class FPSConnection(AWSQueryConnection):
 
     @requires(['SubscriptionId'])
     @api_action()
-    def get_transactions_for_subscription(self, action, response, **kw):
+    def get_transactions_for_subscription(self, action, _, **kw):
         """
         Returns the transactions for a given subscriptionID.
         """
-        return self.get_object(action, kw, response)
+        return self.get_list(action, kw,
+                [('SubscriptionTransaction', boto.fps.response.Transaction)])
 
     @requires(['SubscriptionId'])
     @api_action()


### PR DESCRIPTION
This parses and returns a list of all the transactions in the api response.  It ignores the `response` object passed in by the wrapper which `api_action` creates, but it seemed like the easiest, most consistent way to adjust the behavior.