### PR TITLE
add some minor documentation for Route53 tutorial

### DIFF
--- a/docs/source/route53_tut.rst
+++ b/docs/source/route53_tut.rst
@@ -85,3 +85,19 @@ You can call the API again and ask for the current status as follows:
 When the status has changed to *INSYNC*, the change has been propagated to
 remote servers
 
+Working with Change Sets
+-----------------------
+
+You can also do bulk updates using ResourceRecordSets. For example updating the TTL
+
+>>> zone = conn.get_zone('example.com')
+>>> change_set = boto.route53.record.ResourceRecordSets(conn, zone.id)
+>>> for rrset in conn.get_all_rrsets(zone.id):
+...     u = change_set.add_change("UPSERT", rrset.name, rrset.type, ttl=3600)
+...     u.add_value(rrset.resource_records[0])
+... results = change_set.commit()
+Done
+
+In this example we update the TTL to 1hr (3600 seconds) for all records recursed from 
+example.com.
+Note: this will also change the SOA and NS records which may not be ideal for many users.


### PR DESCRIPTION
Leading users to get a light example of ResourceRecordSets which seems to be something missing based on some of the questions I had when I started working with the Route53 library.