### PR TITLE
Ignore the `rounding` parameter to use the default value

### DIFF
--- a/boto/dynamodb/types.py
+++ b/boto/dynamodb/types.py
@@ -33,7 +33,7 @@ from boto.compat import filter, map, six, long_type
 
 
 DYNAMODB_CONTEXT = Context(
-    Emin=-128, Emax=126, rounding=None, prec=38,
+    Emin=-128, Emax=126, prec=38,
     traps=[Clamped, Overflow, Inexact, Rounded, Underflow])
 
 


### PR DESCRIPTION
By removing this explicit `rounding=None`,
we can avoid `TypeError: invalid rounding mode` when using
[cdecimal](https://pypi.python.org/pypi/cdecimal/).

Though `cdecimal` can be used as a drop-in replacement for `decimal`,
there are still some differences. The one I discovered when using it
with `boto` is how they handle the default parameters of `Context`.

When using the built-in `decimal`, things work as expected:

```
    In [1]: from decimal import Context

    In [2]: Context(rounding=None)
    Out[2]: Context(prec=28, rounding=ROUND_HALF_EVEN, Emin=-999999999,
    Emax=999999999, capitals=1, flags=[], traps=[DivisionByZero, Overflow,
    InvalidOperation])
```

But with `cdecimal`:

```
    In [1]: import sys

    In [2]: import cdecimal

    In [3]: sys.modules['decimal'] = cdecimal

    In [4]: from decimal import Context

    In [5]: Context(rounding=None)
    ---------------------------------------------------------------------------
    TypeError                                 Traceback (most recent call
    last)
    <ipython-input-5-45fe5c326aaa> in <module>()
    ----> 1 Context(rounding=None)

    TypeError: invalid rounding mode.

    In [6]: Context()
    Out[6]: Context(prec=28, rounding=ROUND_HALF_EVEN, Emin=-999999999,
    Emax=999999999, capitals=1, clamp=0, flags=[], traps=[InvalidOperation,
    DivisionByZero, Overflow])
```