### PR TITLE
[bug]: Cloudsearch facet search bug

### DIFF
--- a/boto/cloudsearchdomain/layer1.py
+++ b/boto/cloudsearchdomain/layer1.py
@@ -68,7 +68,7 @@ class CloudSearchDomainConnection(AWSAuthConnection):
             )
         super(CloudSearchDomainConnection, self).__init__(**kwargs)
         self.region = region
-    
+
     def _required_auth_capability(self):
         return ['hmac-v4']
 
@@ -402,7 +402,8 @@ class CloudSearchDomainConnection(AWSAuthConnection):
         if expr is not None:
             query_params['expr'] = expr
         if facet is not None:
-            query_params['facet'] = facet
+            for (facet_field, facet_options) in facet.iteritems():
+                query_params[facet_field] = facet_options
         if filter_query is not None:
             query_params['fq'] = filter_query
         if highlight is not None:


### PR DESCRIPTION
Facet search param should be something like facet.FIELD=some_json_string, not
facet={facet.FIELD: some_json_string}

boto.exception.JSONResponseError: JSONResponseError: 400 Bad Request
{u'message': u"Invalid field name 'facet.category_id' in facet parameter", u'__type': u'#SearchException', u'error': {u'rid': u'+MeAy7kpogoK6ZBr', u'message': u"[*Deprecated*: Use the outer message field] Invalid field name 'facet.category_id' in facet parameter"}}