### PR TITLE
Maintain self.region when creating SWFBase objects

### DIFF
--- a/boto/swf/layer2.py
+++ b/boto/swf/layer2.py
@@ -78,6 +78,7 @@ class Domain(SWFBase):
             act_args.update({
                 'aws_access_key_id': self.aws_access_key_id,
                 'aws_secret_access_key': self.aws_secret_access_key,
+                'region': self.region,
                 'domain': self.name,
             })
             act_objects.append(ActivityType(**act_args))
@@ -95,6 +96,7 @@ class Domain(SWFBase):
             wf_args.update({
                 'aws_access_key_id': self.aws_access_key_id,
                 'aws_secret_access_key': self.aws_secret_access_key,
+                'region': self.region,
                 'domain': self.name,
             })
             
@@ -127,6 +129,7 @@ class Domain(SWFBase):
             exe_args.update({
                 'aws_access_key_id': self.aws_access_key_id,
                 'aws_secret_access_key': self.aws_secret_access_key,
+                'region': self.region,
                 'domain': self.name,
             })
             
@@ -272,7 +275,8 @@ class WorkflowType(SWFBase):
         return WorkflowExecution(name=self.name, version=self.version,
                runId=run_id, domain=self.domain, workflowId=workflow_id,
                aws_access_key_id=self.aws_access_key_id,
-               aws_secret_access_key=self.aws_secret_access_key)
+               aws_secret_access_key=self.aws_secret_access_key,
+               region=self.region)
 
 class WorkflowExecution(SWFBase):
 


### PR DESCRIPTION
Revision a79b8b7e0e0335d7c07cbdb804db53b793fe19c7 added support for
specifying the region when creating the Layer1 object.

This commit extends that capability a tiny bit: When a child object
of SWFBase instantiates another child object of SWFBase, it now passes
self.region through to the new instance.

Without this change, for example, this call:
    boto.swf.layer2.Domain(name='foo', region=region).workflows()
Returns a list of WorkflowType objects where region is not set, which
means the default region is used when calling e.g. WorkflowType.start(),
which is not what I would expect.