### PR TITLE
EC2 connection filters can use tuple values

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -126,12 +126,11 @@ class EC2Connection(AWSQueryConnection):
             filters = dict(filters)
 
         i = 1
-        for name in filters:
+        for name, value in six.iteritems(filters):
             aws_name = name
             if not aws_name.startswith('tag:'):
                 aws_name = name.replace('_', '-')
             params['Filter.%d.Name' % i] = aws_name
-            value = filters[name]
             if not isinstance(value, list):
                 value = [value]
             j = 1

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -131,7 +131,7 @@ class EC2Connection(AWSQueryConnection):
             if not aws_name.startswith('tag:'):
                 aws_name = name.replace('_', '-')
             params['Filter.%d.Name' % i] = aws_name
-            if not isinstance(value, list):
+            if not isinstance(value, (list, tuple)):
                 value = [value]
             j = 1
             for v in value:


### PR DESCRIPTION
The first thing is simple, just grab the key and value from the dict at the same time.

Second change allows values to be given as tuples and not just lists. Solves this case:
```
>>> connection.get_only_instances(filters={"tag:Name": ["example", "test"]})
[Instance:i-b67dc459, Instance:i-5b9d20b4]
>>> connection.get_only_instances(filters={"tag:Name": ("example", "test")})
[]
```