### PR TITLE
Add support for ModifySubnetAttribute

### DIFF
--- a/boto/vpc/__init__.py
+++ b/boto/vpc/__init__.py
@@ -1198,6 +1198,34 @@ class VPCConnection(EC2Connection):
             params['DryRun'] = 'true'
         return self.get_status('DeleteSubnet', params)
 
+    def modify_subnet_attribute(self, subnet_id,
+                                map_public_ip_on_launch=None, dry_run=False):
+        """
+        Modifies the specified attribute of the specified subnet.
+        You can only modify one attribute at a time.
+
+        :type subnet_id: str
+        :param subnet_id: The ID of the subnet to be modified.
+
+        :type map_public_ip_on_launch: bool
+        :param map_public_ip_on_launch: Specifies whether instances launched in
+            the subnet should be automatically assigned a public IP when
+            launched.
+
+        :type dry_run: bool
+        :param dry_run: Set to True if the operation should not actually run.
+
+        """
+        params = {'SubnetId': subnet_id}
+        if map_public_ip_on_launch is not None:
+            if map_public_ip_on_launch:
+                params['MapPublicIpOnLaunch.Value'] = 'true'
+            else:
+                params['MapPublicIpOnLaunch.Value'] = 'false'
+        if dry_run:
+            params['DryRun'] = 'true'
+        return self.get_status('ModifySubnetAttribute', params)
+
     # DHCP Options
 
     def get_all_dhcp_options(self, dhcp_options_ids=None, filters=None, dry_run=False):

--- a/tests/unit/vpc/test_subnet.py
+++ b/tests/unit/vpc/test_subnet.py
@@ -128,6 +128,30 @@ class TestDeleteSubnet(AWSMockServiceTestCase):
                                   'Version'])
         self.assertEquals(api_response, True)
 
+class TestModifySubnetAttribute(AWSMockServiceTestCase):
+
+    connection_class = VPCConnection
+
+    def default_body(self):
+        return b"""
+            <ModifySubnetAttributeResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-01/">
+               <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
+               <return>true</return>
+            </ModifySubnetAttributeResponse>
+        """
+
+    def test_modify_subnet_attribute_map_public_ip_on_launch(self):
+        self.set_http_response(status_code=200)
+        api_response = self.service_connection.modify_subnet_attribute(
+            'subnet-1a2b3c4d', map_public_ip_on_launch=True)
+        self.assert_request_parameters({
+            'Action': 'ModifySubnetAttribute',
+            'SubnetId': 'subnet-1a2b3c4d',
+            'MapPublicIpOnLaunch.Value': 'true'},
+            ignore_params_values=['AWSAccessKeyId', 'SignatureMethod',
+                                  'SignatureVersion', 'Timestamp',
+                                  'Version'])
+        self.assertEquals(api_response, True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This allows users to set the MapPublicIpOnLaunch property on subnets.

I've tested this in AWS, which required writing a custom IAM policy to give access to ModifySubnetAttribute, since this doesn't seem to exist by default in the Amazon managed policies. It similarly doesn't show up in the policy generator.