### PR TITLE
fix for regions in SWF layer2 - including unit tests

### DIFF
--- a/boto/swf/layer2.py
+++ b/boto/swf/layer2.py
@@ -79,6 +79,7 @@ class Domain(SWFBase):
                 'aws_access_key_id': self.aws_access_key_id,
                 'aws_secret_access_key': self.aws_secret_access_key,
                 'domain': self.name,
+                'region': self.region,
             })
             act_objects.append(ActivityType(**act_args))
         return act_objects
@@ -96,6 +97,7 @@ class Domain(SWFBase):
                 'aws_access_key_id': self.aws_access_key_id,
                 'aws_secret_access_key': self.aws_secret_access_key,
                 'domain': self.name,
+                'region': self.region,
             })
             
             wf_objects.append(WorkflowType(**wf_args))
@@ -128,6 +130,7 @@ class Domain(SWFBase):
                 'aws_access_key_id': self.aws_access_key_id,
                 'aws_secret_access_key': self.aws_secret_access_key,
                 'domain': self.name,
+                'region': self.region,
             })
             
             exe_objects.append(WorkflowExecution(**exe_args))

--- a/tests/unit/swf/test_layer2_domain.py
+++ b/tests/unit/swf/test_layer2_domain.py
@@ -11,6 +11,7 @@ class TestDomain(unittest.TestCase):
         self.domain = Domain(name='test-domain', description='My test domain')
         self.domain.aws_access_key_id = 'inheritable access key'
         self.domain.aws_secret_access_key = 'inheritable secret key'
+	self.domain.region = 'test-region'
 
     def test_domain_instantiation(self):
         self.assertEquals('test-domain', self.domain.name)
@@ -47,6 +48,7 @@ class TestDomain(unittest.TestCase):
         for activity_type in activity_types:
             self.assertIsInstance(activity_type, ActivityType)
             self.assertTrue(activity_type.name in expected_names)
+            self.assertEquals(self.domain.region, activity_type.region)
 
     def test_domain_list_workflows(self):
         self.domain._swf.list_workflow_types.return_value = {
@@ -68,6 +70,7 @@ class TestDomain(unittest.TestCase):
             self.assertEquals(self.domain.aws_access_key_id, workflow_type.aws_access_key_id)
             self.assertEquals(self.domain.aws_secret_access_key, workflow_type.aws_secret_access_key)
             self.assertEquals(self.domain.name, workflow_type.domain)
+            self.assertEquals(self.domain.region, workflow_type.region)
 
     def test_domain_list_executions(self):
         self.domain._swf.list_open_workflow_executions.return_value = {
@@ -107,6 +110,7 @@ class TestDomain(unittest.TestCase):
             self.assertEquals(self.domain.aws_access_key_id, wf_execution.aws_access_key_id)
             self.assertEquals(self.domain.aws_secret_access_key, wf_execution.aws_secret_access_key)
             self.assertEquals(self.domain.name, wf_execution.domain)
+            self.assertEquals(self.domain.region, wf_execution.region)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/swf/test_layer2_domain.py
+++ b/tests/unit/swf/test_layer2_domain.py
@@ -11,7 +11,7 @@ class TestDomain(unittest.TestCase):
         self.domain = Domain(name='test-domain', description='My test domain')
         self.domain.aws_access_key_id = 'inheritable access key'
         self.domain.aws_secret_access_key = 'inheritable secret key'
-	self.domain.region = 'test-region'
+        self.domain.region = 'test-region'
 
     def test_domain_instantiation(self):
         self.assertEquals('test-domain', self.domain.name)


### PR DESCRIPTION
Similarly to a few existing pull requests:

#2606
#2980

I've had to work around this bug in boto where the region is not propagated to other layer2 objects on calls to:

* workflows()
* activities()
* executions()
