### PR TITLE
Add tags parameter to datapipeline create_pipeline

### DIFF
--- a/boto/datapipeline/layer1.py
+++ b/boto/datapipeline/layer1.py
@@ -113,7 +113,7 @@ class DataPipelineConnection(AWSQueryConnection):
         return self.make_request(action='ActivatePipeline',
                                  body=json.dumps(params))
 
-    def create_pipeline(self, name, unique_id, description=None):
+    def create_pipeline(self, name, unique_id, description=None, tags=None):
         """
         Creates a new empty pipeline. When this action succeeds, you
         can then use the PutPipelineDefinition action to populate the
@@ -143,10 +143,18 @@ class DataPipelineConnection(AWSQueryConnection):
         :type description: string
         :param description: The description of the new pipeline.
 
+        :type tags: list
+        :param tags: A list of tags to associate with a pipeline at creation
+            time. Tags let you control access to pipelines. For more
+            information, see Controlling User Access to Pipelines in the AWS
+            Data Pipeline Developer Guide.
+
         """
         params = {'name': name, 'uniqueId': unique_id, }
         if description is not None:
             params['description'] = description
+        if tags is not None:
+            params['tags'] = tags
         return self.make_request(action='CreatePipeline',
                                  body=json.dumps(params))
 


### PR DESCRIPTION
Amazon DataPipeline recently (< 4 days ago) released the ability to add tags to data pipelines via the create_pipeline.

See documentation here: http://docs.aws.amazon.com/cli/latest/reference/datapipeline/create-pipeline.html
