### PR TITLE
Correct type hint of `num_cb` in s3.set_contents_from_filename

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1323,7 +1323,7 @@ class Key(object):
             the second representing the size of the to be transmitted
             object.
 
-        :type cb: int
+        :type num_cb: int
         :param num_cb: (optional) If a callback is specified with the
             cb parameter this parameter determines the granularity of
             the callback by defining the maximum number of times the


### PR DESCRIPTION
Minor docstring correction. `:type cb` was specified twice, the second one should be `:type num_cb`.