### PR TITLE
Fix in-place dictionary key deletion.

### DIFF
--- a/boto/rds/__init__.py
+++ b/boto/rds/__init__.py
@@ -451,8 +451,10 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
 
         # Remove any params set to None
+        _params = {}
         for k, v in params.items():
-          if v is None: del(params[k])
+           if v is not None: _params[k] = v
+        params = _params
 
         return self.get_object('CreateDBInstance', params, DBInstance)
 


### PR DESCRIPTION
Fixes KeyError raised in boto.rds.create_dbinstance() by loop that deletes dictionary keys that the loop itself references.