### PR TITLE
Fixed wording in dynamodb tutorial

### DIFF
--- a/docs/source/dynamodb2_tut.rst
+++ b/docs/source/dynamodb2_tut.rst
@@ -413,8 +413,9 @@ concept, this is akin to what DynamoDB does.
 
 .. warning::
 
-    Scans are consistent & run over the entire table, so relatively speaking,
-    they're more expensive than plain queries or queries against an LSI.
+    Scans are eventually consistent & run over the entire table, so
+    relatively speaking, they're more expensive than plain queries or queries
+    against an LSI.
 
 An example scan of all records in the table looks like::
 


### PR DESCRIPTION
Fixed the wording of a dynamodb tutorial. Scans are eventually consistent as noted in the dynamodb docs:
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#ScanQueryConsistency

cc @danielgtaylor @jamesls 