### PR TITLE
Fix: find_records does not support identifier as documented

### DIFF
--- a/boto/route53/zone.py
+++ b/boto/route53/zone.py
@@ -246,8 +246,7 @@ class Zone(object):
         region = None
         if identifier is not None:
             try:
-                int(identifier[1])
-                weight = identifier[1]
+                weight = int(identifier[1])
             except:
                 region = identifier[1]
 


### PR DESCRIPTION
The dostring for `find_records` says that you can specify an identifier:
```
        :type identifier: Tuple
        :param identifier: A tuple specifying WRR or LBR attributes.  Valid
           forms are:

           * (str, int): WRR record [e.g. ('foo',10)]
           * (str, str): LBR record [e.g. ('foo','us-east-1')
```
https://github.com/boto/boto/blob/develop/boto/route53/zone.py#L226

The doc says `('foo',10)` with 10 as an int (to differentiate weight (int) and region (string).

But it only work if you specify the weight as a string and not an int. It should cast the weight as an int for the filter to work, right now it's broken.

See:

```
# Using unfiltered find_records with all=True to show that I have valid entries
In [28]: prclt.find_records('lolo-1-grader.prclt.net.', 'CNAME', identifier=None, all=True)
Out[28]: 
[<Record:lolo-1-grader.prclt.net.:CNAME:i-726b31b1.grader.prclt.net. (WRR id=i-726b31b1, w=10)>,
 <Record:lolo-1-grader.prclt.net.:CNAME:i-8ba6b042.grader.prclt.net. (WRR id=i-8ba6b042, w=10)>,
 <Record:lolo-1-grader.prclt.net.:CNAME:i-8ba6b043.grader.prclt.net. (WRR id=i-8ba6b043, w=10)>]

# Trying to find a given record as stated in the doc, using a int(10) as a weight: no result
In [29]: prclt.find_records('lolo-1-grader.prclt.net.', 'CNAME', identifier=('i-8ba6b042', 10), all=True)

# Trying to find a given record, not as stated in the doc, using a str(10) as a weight: I got a result
In [30]: prclt.find_records('lolo-1-grader.prclt.net.', 'CNAME', identifier=('i-8ba6b042', '10'), all=True)
Out[30]: <Record:lolo-1-grader.prclt.net.:CNAME:i-8ba6b042.grader.prclt.net. (WRR id=i-8ba6b042, w=10)>
```

This is problematic as all the other functions depends on this filter, I found this bug while doing a `delete_cname()` and I wasn't able to delete any cname with an identifier.