### PR TITLE
enable .egg/zipfiles, use pkg_resources

### DIFF
--- a/boto/__init__.py
+++ b/boto/__init__.py
@@ -59,8 +59,8 @@ TOO_LONG_DNS_NAME_COMP = re.compile(r'[-_a-z0-9]{64}')
 GENERATION_RE = re.compile(r'(?P<versionless_uri_str>.+)'
                            r'#(?P<generation>[0-9]+)$')
 VERSION_RE = re.compile('(?P<versionless_uri_str>.+)#(?P<version_id>.+)$')
-ENDPOINTS_PATH = os.path.join(os.path.dirname(__file__), 'endpoints.json')
-
+from pkg_resources import resource_filename
+ENDPOINTS_PATH = resource_filename(__name__, 'endpoints.json')
 
 def init_logging():
     for file in BotoConfigLocations:

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -90,7 +90,8 @@ ON_APP_ENGINE = all(key in os.environ for key in (
 PORTS_BY_SECURITY = {True: 443,
                      False: 80}
 
-DEFAULT_CA_CERTS_FILE = os.path.join(os.path.dirname(os.path.abspath(boto.cacerts.__file__)), "cacerts.txt")
+from pkg_resources import resource_filename
+DEFAULT_CA_CERTS_FILE = resource_filename(__name__, 'cacerts/cacerts.txt')
 
 
 class HostConnectionPool(object):


### PR DESCRIPTION
by using a .egg file directly (i.e,. sys.path.insert(0,"boto-2.36.0-py2.7.egg") we
lose the os.path.* making any sense; pkg_resources was designed to fix this
https://pythonhosted.org/setuptools/pkg_resources.html#resource-extraction