### PR TITLE
Added ability to update hosted zone comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ MANIFEST
 venv
 venv-2.5
 env-2.5
+env

--- a/boto/route53/zone.py
+++ b/boto/route53/zone.py
@@ -417,3 +417,16 @@ class Zone(object):
         if ns is not None:
             ns = ns.resource_records
         return ns
+
+    def update_comment(self, comment=""):
+        """
+        Request that this zone's comment be updated. 
+
+        :type comment: str
+        :param comment: The new comment for the hosted zone. If you don't 
+            specify a value for Comment, Amazon Route 53 deletes the existing 
+            value of the Comment element, if any.
+
+        """
+        return self.route53connection.update_hosted_zone_comment(self.id,comment)
+

--- a/tests/unit/route53/test_update_zone_comment.py
+++ b/tests/unit/route53/test_update_zone_comment.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# Copyright (c) 2014 Amazon.com, Inc. or its affiliates.  All Rights Reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+from tests.unit import AWSMockServiceTestCase
+from boto.route53.connection import Route53Connection
+from boto.route53.zone import Zone
+from nose.plugins.attrib import attr
+
+@attr(route53=True)
+class TestUpdateZoneCommentRoute53(AWSMockServiceTestCase):
+    connection_class = Route53Connection
+
+    def setUp(self):
+        super(TestUpdateZoneCommentRoute53, self).setUp()
+
+    def default_body(self):
+        return b"""
+<UpdateHostedZoneCommentResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+    <HostedZone>
+        <Id>/hostedzone/Z11111</Id>
+        <Name>example.com.</Name>
+        <CallerReference>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</CallerReference>
+        <Config>
+            <Comment>My fancy new comment</Comment>
+            <PrivateZone>false</PrivateZone>
+        </Config>
+        <ResourceRecordSetCount>2</ResourceRecordSetCount>
+    </HostedZone>
+</UpdateHostedZoneCommentResponse>
+        """
+
+    def test_update_hosted_zone_comment(self):
+        self.set_http_response(status_code=200)
+        response = self.service_connection.update_hosted_zone_comment("Z11111","My fancy new comment")
+
+        self.assertEqual(response['Id'], "Z11111")
+        self.assertEqual(response['Name'], "example.com.")
+        self.assertEqual(response['Config']['Comment'], "My fancy new comment")


### PR DESCRIPTION
Allows updating a hosted zone's comment in Route53. If no comment it given, it will delete the Comment element, if any.

Implements functionality of:
http://docs.aws.amazon.com/Route53/latest/APIReference/api-update-hosted-zone-comment.html
while following the AWS Route 53 API as closely as possible.

Passes unit test at:
tests/unit/route53/test_update_zone_comment.py