### PR TITLE
I believe bucket versioning is no longer in beta.  Updating docstring

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -1262,8 +1262,6 @@ class Bucket(object):
         """
         Configure versioning for this bucket.
 
-        ..note:: This feature is currently in beta.
-
         :type versioning: bool
         :param versioning: A boolean indicating whether version is
             enabled (True) or disabled (False).


### PR DESCRIPTION
S3 bucket versioning has come out of beta: http://aws.amazon.com/about-aws/whats-new/2010/02/08/versioning-feature-for-amazon-s3-now-available/.  The comment hung me up a little bit thinking it was the boto code it was referring to.  If the comment was referring to the status of the AWS feature, it is no longer true.

Thanks!

SB