### PR TITLE
Fix unit tests from hanging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ requests>=1.2.3,<=2.0.1
 rsa==3.1.4
 simplejson==3.5.2
 argparse==1.2.1
-httpretty>=0.7.0
+httpretty>=0.7.0,<=0.8.6
 paramiko>=1.10.0
 PyYAML>=3.10
 coverage==3.7.1


### PR DESCRIPTION
Bug was introduced in 0.8.7 of httpretty
that causes testes to hang.  Requiring <=0.8.6
for now.