### PR TITLE
force float division while calculating chunk_count

### DIFF
--- a/docs/source/s3_tut.rst
+++ b/docs/source/s3_tut.rst
@@ -190,7 +190,7 @@ to be taken. The example below makes use of the FileChunkIO module, so
 
     # Use a chunk size of 50 MiB (feel free to change this)
     >>> chunk_size = 52428800
-    >>> chunk_count = int(math.ceil(source_size / chunk_size))
+    >>> chunk_count = int(math.ceil(source_size / float(chunk_size)))
 
     # Send the file parts, using FileChunkIO to create a file-like object
     # that points to a certain byte range within the original file. We

--- a/docs/source/s3_tut.rst
+++ b/docs/source/s3_tut.rst
@@ -195,7 +195,7 @@ to be taken. The example below makes use of the FileChunkIO module, so
     # Send the file parts, using FileChunkIO to create a file-like object
     # that points to a certain byte range within the original file. We
     # set bytes to never exceed the original file size.
-    >>> for i in range(chunk_count + 1):
+    >>> for i in range(chunk_count):
     >>>     offset = chunk_size * i
     >>>     bytes = min(chunk_size, source_size - offset)
     >>>     with FileChunkIO(source_path, 'r', offset=offset,


### PR DESCRIPTION
the math.ceil is rendered useless since integer division is performed (source_size, chunk_size are integers).