### PR TITLE
Fix Cloudsearch facets sort order.

### DIFF
--- a/tests/unit/cloudsearch/test_search.py
+++ b/tests/unit/cloudsearch/test_search.py
@@ -349,7 +349,7 @@ class CloudSearchSearchFacetTest(CloudSearchSearchBaseTest):
         },
         'facets': {
             'tags': {},
-            'animals': {'constraints': [{'count': '2', 'value': 'fish'}, {'count': '1', 'value': 'lions'}]},
+            'animals': {'constraints': [{'count': '2', 'value': 'lions'}, {'count': '1', 'value': 'fish'}]},
         }
     }
 
@@ -361,7 +361,11 @@ class CloudSearchSearchFacetTest(CloudSearchSearchBaseTest):
         results = search.search(q='Test', facet=['tags'])
 
         self.assertTrue('tags' not in results.facets)
-        self.assertEqual(results.facets['animals'], {u'lions': u'1', u'fish': u'2'})
+        ordered_keys = results.facets['animals'].keys()
+        ordered_values = results.facets['animals'].values()
+        self.assertEqual(ordered_keys, [u'lions', u'fish'])
+        self.assertEqual(ordered_values, [u'2', u'1'])
+        self.assertEqual(results.facets['animals'], {u'lions': u'2', u'fish': u'1'})
 
 
 class CloudSearchNonJsonTest(CloudSearchSearchBaseTest):

--- a/tests/unit/cloudsearch2/test_search.py
+++ b/tests/unit/cloudsearch2/test_search.py
@@ -295,7 +295,7 @@ class CloudSearchSearchFacetTest(CloudSearchSearchBaseTest):
         },
         'facets': {
             'tags': {},
-            'animals': {'buckets': [{'count': '2', 'value': 'fish'}, {'count': '1', 'value': 'lions'}]},
+            'animals': {'buckets': [{'count': '2', 'value': 'lions'}, {'count': '1', 'value': 'fish'}]},
         }
     }
 
@@ -307,7 +307,11 @@ class CloudSearchSearchFacetTest(CloudSearchSearchBaseTest):
         results = search.search(q='Test', facet={'tags': {}})
 
         self.assertTrue('tags' not in results.facets)
-        self.assertEqual(results.facets['animals'], {u'lions': u'1', u'fish': u'2'})
+        ordered_keys = results.facets['animals'].keys()
+        ordered_values = results.facets['animals'].values()
+        self.assertEqual(ordered_keys, [u'lions', u'fish'])
+        self.assertEqual(ordered_values, [u'2', u'1'])
+        self.assertEqual(results.facets['animals'], {u'lions': u'2', u'fish': u'1'})
 
 
 class CloudSearchNonJsonTest(CloudSearchSearchBaseTest):


### PR DESCRIPTION
Facet of Cloudsearch returns the results in a state where the sort.
However, because the code of the bot is utilized dict, and thus to ignore the results of the sorting.

Therefore, I have modified the code to take advantage of OrderedDict.
And fixed tiny bug :)

Related: #2605