### PR TITLE
EC2Connection should not ignore the host parameter

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -96,7 +96,7 @@ class EC2Connection(AWSQueryConnection):
                                             aws_secret_access_key,
                                             is_secure, port, proxy, proxy_port,
                                             proxy_user, proxy_pass,
-                                            self.region.endpoint, debug,
+                                            host or self.region.endpoint, debug,
                                             https_connection_factory, path,
                                             security_token,
                                             validate_certs=validate_certs,


### PR DESCRIPTION
I noticed that the `host` parameter is being completely ignored in favor of what is coming from `config`.