### PR TITLE
Fix for ec2.connection.get_all_reserved_instances() with a tagSet (includes tests) #3034

### DIFF
--- a/tests/unit/ec2/test_reservedinstance.py
+++ b/tests/unit/ec2/test_reservedinstance.py
@@ -20,6 +20,16 @@ class TestReservedInstancesSet(AWSMockServiceTestCase):
         <instanceCount>5</instanceCount>
         <productDescription>Linux/UNIX</productDescription>
         <state>retired</state>
+        <tagSet>
+            <item>
+                <key>already_present_key</key>
+                <value>already_present_value</value>
+            </item>
+            <item>
+                <key>Name</key>
+                <value/>
+            </item>
+        </tagSet>
         <instanceTenancy>default</instanceTenancy>
         <currencyCode>USD</currencyCode>
         <offeringType>Heavy Utilization</offeringType>
@@ -35,10 +45,20 @@ class TestReservedInstancesSet(AWSMockServiceTestCase):
     def test_get_all_reserved_instaces(self):
         self.set_http_response(status_code=200)
         response = self.service_connection.get_all_reserved_instances()
-
         self.assertEqual(len(response), 1)
         self.assertTrue(isinstance(response[0], ReservedInstance))
+
         self.assertEquals(response[0].id, 'ididididid')
         self.assertEquals(response[0].instance_count, 5)
         self.assertEquals(response[0].start, '2014-05-03T14:10:10.944Z')
         self.assertEquals(response[0].end, '2014-05-03T14:10:11.000Z')
+        self.assertEquals(response[0].offering_type, 'Heavy Utilization')
+
+        # Add tag to the reservation
+        response[0].add_tags({"key1": "value1", "key2": "value2"})
+
+        self.assertEqual(response[0].tags, {
+            "already_present_key": "already_present_value",
+            "Name": "",
+            "key1": "value1",
+            "key2": "value2"})


### PR DESCRIPTION
Fix for ec2.connection.get_all_reserved_instances() when reserved instances have tags.
Add tests get_all_reserved_instances() in test_reservedinstance.py