### PR TITLE
Fix KMS in Python 3

### DIFF
--- a/boto/kms/layer1.py
+++ b/boto/kms/layer1.py
@@ -279,7 +279,7 @@ class KMSConnection(AWSQueryConnection):
                 "Value of argument ``ciphertext_blob`` "
                 "must be of type %s." % six.binary_type)
         ciphertext_blob = base64.b64encode(ciphertext_blob)
-        params = {'CiphertextBlob': ciphertext_blob, }
+        params = {'CiphertextBlob': ciphertext_blob.decode('utf-8'), }
         if encryption_context is not None:
             params['EncryptionContext'] = encryption_context
         if grant_tokens is not None:
@@ -403,7 +403,7 @@ class KMSConnection(AWSQueryConnection):
                 "Value of argument ``plaintext`` "
                 "must be of type %s." % six.binary_type)
         plaintext = base64.b64encode(plaintext)
-        params = {'KeyId': key_id, 'Plaintext': plaintext, }
+        params = {'KeyId': key_id, 'Plaintext': plaintext.decode('utf-8'), }
         if encryption_context is not None:
             params['EncryptionContext'] = encryption_context
         if grant_tokens is not None:

--- a/tests/test.py
+++ b/tests/test.py
@@ -52,6 +52,7 @@ PY3_WHITELIST = (
     'tests/unit/glacier',
     'tests/unit/iam',
     'tests/unit/ec2',
+    'tests/unit/kms',
     'tests/unit/logs',
     'tests/unit/manage',
     'tests/unit/mws',

--- a/tests/unit/kms/test_kms.py
+++ b/tests/unit/kms/test_kms.py
@@ -39,7 +39,7 @@ class TestKinesis(AWSMockServiceTestCase):
         self.set_http_response(status_code=200)
         data = b'\x00\x01\x02\x03\x04\x05'
         self.service_connection.encrypt(key_id='foo', plaintext=data)
-        body = json.loads(self.actual_request.body)
+        body = json.loads(self.actual_request.body.decode('utf-8'))
         self.assertEqual(body['Plaintext'], 'AAECAwQF')
 
     def test_non_binary_input_for_blobs_fails(self):


### PR DESCRIPTION
Fixes #3050 
I ran the kms unit tests under 2.6, 2.7, 3.3, and 3.4.