### PR TITLE
Issue #2235. Catch EC2ResponseError in connection.get_image

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -261,7 +261,7 @@ class EC2Connection(AWSQueryConnection):
         """
         try:
             return self.get_all_images(image_ids=[image_id], dry_run=dry_run)[0]
-        except (IndexError, EC2ResponseError):  # None of those images available
+        except (IndexError, EC2ResponseError):  # Failed or did not find any images
             return None
 
     def register_image(self, name=None, description=None, image_location=None,

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -261,7 +261,7 @@ class EC2Connection(AWSQueryConnection):
         """
         try:
             return self.get_all_images(image_ids=[image_id], dry_run=dry_run)[0]
-        except IndexError:  # None of those images available
+        except (IndexError, EC2ResponseError):  # None of those images available
             return None
 
     def register_image(self, name=None, description=None, image_location=None,


### PR DESCRIPTION
Inspired by the now closed:
https://github.com/firesh/boto/commit/9779706f628b5a2ef7c3a73da1a463b9019c1edd