### PR TITLE
Fix line-ending bug in auth variables

### DIFF
--- a/boto/provider.py
+++ b/boto/provider.py
@@ -278,7 +278,7 @@ class Provider(object):
             self.access_key = access_key
             boto.log.debug("Using access key provided by client.")
         elif access_key_name.upper() in os.environ:
-            self.access_key = os.environ[access_key_name.upper()]
+            self.access_key = os.environ[access_key_name.upper()].strip()
             boto.log.debug("Using access key found in environment variable.")
         elif profile_name is not None:
             if shared.has_option(profile_name, access_key_name):
@@ -305,7 +305,7 @@ class Provider(object):
             self.secret_key = secret_key
             boto.log.debug("Using secret key provided by client.")
         elif secret_key_name.upper() in os.environ:
-            self.secret_key = os.environ[secret_key_name.upper()]
+            self.secret_key = os.environ[secret_key_name.upper()].strip()
             boto.log.debug("Using secret key found in environment variable.")
         elif profile_name is not None:
             if shared.has_option(profile_name, secret_key_name):
@@ -349,7 +349,7 @@ class Provider(object):
             # environment/config token could be paired with a
             # different set of credentials provided by the caller
             if security_token_name.upper() in os.environ:
-                self.security_token = os.environ[security_token_name.upper()]
+                self.security_token = os.environ[security_token_name.upper()].strip()
                 boto.log.debug("Using security token found in environment"
                                " variable.")
             elif shared.has_option(profile_name or 'default',


### PR DESCRIPTION
One of my students had the following amusing heistenbug:

```
$ cat keys.sh
export AWS_ACCESS_KEY_ID=blahblahblah
export AWS_SECRET_ACCESS_KEY=blahblahblah
$ source keys.sh
$ aws iam get-user

A client error (SignatureDoesNotMatch) occurred when calling the
GetUser operation: The request signature we calculated does not match
the signature you provided. Check your AWS Secret Access Key and
signing method. Consult the service documentation for details.

The Canonical String for this request should have been
blah blah blah
```

After some digging, it turned out that the student had copied the CSV file downloaded from the AWS console, editing it in place. This resulted in a bash script with CRLF line endings, meaning that:

```
$ python -c "import os;print repr(os.environ['AWS_ACCESS_KEY_ID']), repr(os.environ['AWS_SECRET_ACCESS_KEY'])"
"BLAHBLAHBLAH\r" "BLAHBLAHBLAH\r"
```

Needless to say, because the CR was invisible when regularly printed, this resulted in considerable heartache. In the interest of usability, I propose the attached change. It's fairly minimal (if somebody really wants to add whitespace to their keys, they're still free to do so via direct configuration) and I think fits in with my own mental model of how environment variables _should_ work.

(Since it looks like I should add some tests, I'll pop on another commit tomorrow.)

Thoughts?