### PR TITLE
correct return type for list_multipart_uploads

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -355,7 +355,7 @@ class Bucket(object):
             Valid options: ``url``
         :type encoding_type: string
 
-        :rtype: :class:`boto.s3.bucketlistresultset.BucketListResultSet`
+        :rtype: :class:`boto.s3.bucketlistresultset.MultiPartUploadListResultSet`
         :return: an instance of a BucketListResultSet that handles paging, etc
         """
         return MultiPartUploadListResultSet(self, key_marker,


### PR DESCRIPTION
The docs show the wrong return type for boto.s3.bucket.list_multipart_uploads, namely BucketListResultSet instead of MultiPartUploadListResultSet.

http://boto.readthedocs.org/en/latest/ref/s3.html#boto.s3.bucket.Bucket.list_multipart_uploads