### PR TITLE
Round SQS float arguments up, not down, when an int is required

### DIFF
--- a/boto/sqs/connection.py
+++ b/boto/sqs/connection.py
@@ -19,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+import math
+
 import boto
 from boto.connection import AWSQueryConnection
 from boto.sqs.regioninfo import SQSRegionInfo
@@ -92,7 +94,7 @@ class SQSConnection(AWSQueryConnection):
         params = {'QueueName': queue_name}
         if visibility_timeout:
             params['Attribute.1.Name'] = 'VisibilityTimeout'
-            params['Attribute.1.Value'] = int(visibility_timeout)
+            params['Attribute.1.Value'] = int(math.ceil(visibility_timeout))
         return self.get_object('CreateQueue', params, Queue)
 
     def delete_queue(self, queue, force_deletion=False):
@@ -304,7 +306,7 @@ class SQSConnection(AWSQueryConnection):
         """
         params = {'MessageBody' : message_content}
         if delay_seconds:
-            params['DelaySeconds'] = int(delay_seconds)
+            params['DelaySeconds'] = int(math.ceil(delay_seconds))
 
         if message_attributes is not None:
             keys = sorted(message_attributes.keys())


### PR DESCRIPTION
Currently, parts of the SQS module related to delay and visibility timeouts cast their arguments to `int` within the SQS connection. A Python `int` cast rounds down, e.g. `int(3.99) == 3`. This causes unexpected behavior, as a developer who tries to delay an item for 3.99 seconds and receives a successful response surely will not expect that item to be made available in the queue after only 3 seconds.

This commit uses `math.ceil` to forcibly round up these arguments before casting them to `int` type. This incurs more delay than the developer may have expected, but the spirit of the constraints provided by SQS will remain true, e.g. "The item will not be made available before X seconds have passed," where X is whatever the developer passed in.

I would argue that the best behavior here would be to throw a `TypeError` if a `float` is passed to a function which expects an `int`, but this commit eschews that approach in favor of deviating as little as possible from current functionality.
