### PR TITLE
[security] - Replace yaml.load() with yaml.safe_load() for security reasons.

### DIFF
--- a/boto/contrib/ymlmessage.py
+++ b/boto/contrib/ymlmessage.py
@@ -47,7 +47,7 @@ class YAMLMessage(Message):
         super(YAMLMessage, self).__init__(queue, body)
 
     def set_body(self, body):
-        self.data = yaml.load(body)
+        self.data = yaml.safe_load(body)
 
     def get_body(self):
         return yaml.dump(self.data)


### PR DESCRIPTION
```yaml.load()``` has well known security weaknesses that can led to remote code execution if untrusted data is used with ```yaml.load()``` [0].

Instead, ```yaml.safe_load``` should be used - there are good examples of how ```yaml.load()``` can be abused at [0].

This PR replaces the one instance of ```yaml.load()``` with ```yaml.safe_load()```. I also checked the boto3 development repo, but didn't see any instances of ```yaml.load()```

[0] https://github.com/hyakuhei/OSSG-Security-Practices/blob/master/bandit/yaml.md