### PR TITLE
Partial glacier json response

### DIFF
--- a/boto/glacier/response.py
+++ b/boto/glacier/response.py
@@ -36,7 +36,7 @@ class GlacierResponse(dict):
         if response_headers:
             for header_name, item_name in response_headers:
                 self[item_name] = http_response.getheader(header_name)
-        if http_response.status != 204: 
+        if not (http_response.status == 204 or http_response.status == 206):
             if http_response.getheader('Content-Type') == 'application/json':
                 body = json.loads(http_response.read().decode('utf-8'))
                 self.update(body)

--- a/tests/unit/glacier/test_response.py
+++ b/tests/unit/glacier/test_response.py
@@ -31,5 +31,13 @@ class TestResponse(AWSMockServiceTestCase):
         result = GlacierResponse(response,response.getheaders())
         self.assertEquals(result.status, response.status)
 
+    def test_206_incomplete_body_isnt_passed_to_json(self):
+        incomplete_json_body = """{
+            "incomplete_json": {
+                "some_id": "incomplete string"""
+        response = self.create_response(status_code=206, header=[('Content-Type','application/json')], body=incomplete_json_body)
+        result = GlacierResponse(response,response.getheaders())
+        self.assertEquals(result.status, response.status)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Handle partial glacier json responses - don't parse the json.

* Don't parse the json when making partial requests -
  this results in the Json parser barfing on incomplete json.
* Test for incomplete body created.

This change was done because I have a glacier vault which has an inventory size of 2.69 GB (just the inventory alone!), and thus cannot be downloaded in one go.