### PR TITLE
Fixup section headers so underline is same length as header text.  While...

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -152,7 +152,7 @@ into nosetests.
 
 
 Testing Supported Python Versions
-==================================
+=================================
 
 Boto supports python 2.6 and 2.7. An easy way to verify functionality
 across multiple python versions is to use tox_. A tox.ini file is included

--- a/docs/source/route53_tut.rst
+++ b/docs/source/route53_tut.rst
@@ -86,7 +86,7 @@ When the status has changed to *INSYNC*, the change has been propagated to
 remote servers
 
 Working with Change Sets
------------------------
+------------------------
 
 You can also do bulk updates using ResourceRecordSets. For example updating the TTL
 

--- a/docs/source/s3_tut.rst
+++ b/docs/source/s3_tut.rst
@@ -96,7 +96,7 @@ bucket in that location.  For example::
 will create the bucket in the EU region (assuming the name is available).
 
 Storing Data
-----------------
+------------
 
 Once you have a bucket, presumably you will want to store some data
 in it.  S3 doesn't care what kind of information you store in your objects

--- a/docs/source/simpledb_tut.rst
+++ b/docs/source/simpledb_tut.rst
@@ -78,7 +78,7 @@ an exception if the domain you are looking for doesn't exist. If you set it to f
 :py:class:`Domain <boto.sdb.domain.Domain>` object blindly regardless of its existence.
 
 Getting Domain Metadata
-------------------------
+-----------------------
 There are times when you might want to know your domains' machine usage, aprox. item count and other such data.
 To this end, boto offers a simple and convenient way to do so as shown below::
 
@@ -141,7 +141,7 @@ parameter.
 
 
 Retrieving Items
------------------
+----------------
 To retrieve an item along with its attributes is a fairly straight forward operation and can be accomplished as follows::
 
     >>> dom.get_item('item1')
@@ -190,7 +190,7 @@ delete_item() method, boto will take care of the rest::
 
 
 Deleting Domains
------------------------------------
+----------------
 To delete a domain and all items under it (i.e. be very careful), you can do it as follows::
 
     >>> conn.delete_domain('test-domain')


### PR DESCRIPTION
... the standard says the underline needs to be "at least as long as the title text" some editors flag it as an error if it is not the same length.