### PR TITLE
Remove DisableRollback from being part of the default parameter set for create_stack()

### DIFF
--- a/boto/cloudformation/connection.py
+++ b/boto/cloudformation/connection.py
@@ -224,8 +224,7 @@ class CloudFormationConnection(AWSQueryConnection):
         :rtype: dict
         :return: JSON parameters represented as a Python dict.
         """
-        params = {'ContentType': "JSON", 'StackName': stack_name,
-                'DisableRollback': self.encode_bool(disable_rollback)}
+        params = {'ContentType': "JSON", 'StackName': stack_name}
         if template_body:
             params['TemplateBody'] = template_body
         if template_url:

--- a/boto/cloudformation/connection.py
+++ b/boto/cloudformation/connection.py
@@ -263,6 +263,8 @@ class CloudFormationConnection(AWSQueryConnection):
                 disable_rollback).lower()
         if on_failure is not None:
             params['OnFailure'] = on_failure
+        if disable_rollback is not None:
+            params['DisableRollback'] = self.encode_bool(disable_rollback)
         if stack_policy_body is not None:
             params['StackPolicyBody'] = stack_policy_body
         if stack_policy_url is not None:

--- a/tests/unit/cloudformation/test_connection.py
+++ b/tests/unit/cloudformation/test_connection.py
@@ -96,7 +96,6 @@ class TestCloudFormationCreateStack(CloudFormationConnectionBase):
         self.assert_request_parameters({
             'Action': 'CreateStack',
             'ContentType': 'JSON',
-            'DisableRollback': 'false',
             'StackName': 'stack_name',
             'Version': '2010-05-15',
         })


### PR DESCRIPTION
Remove DisableRollback from being specified, as if you want to call create_stack() like this:

    stack = aws_conn.create_stack(stack_name, template, on_failure='DELETE')

then AWS complains that DisableRollback AND OnFailure are both specified and it doesn't want to actually create the stack.