### PR TITLE
Adding unique_request_token to create_hit

### DIFF
--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -179,13 +179,14 @@ class MTurkConnection(AWSQueryConnection):
         return self._process_request(request_type, params)
 
     def create_hit(self, hit_type=None, question=None, hit_layout=None,
-                   lifetime=datetime.timedelta(days=7),
-                   max_assignments=1,
-                   title=None, description=None, keywords=None,
-                   reward=None, duration=datetime.timedelta(days=7),
-                   approval_delay=None, annotation=None,
-                   questions=None, qualifications=None,
-                   layout_params=None, response_groups=None):
+                    lifetime=datetime.timedelta(days=7),
+                    max_assignments=1,
+                    title=None, description=None, keywords=None,
+                    reward=None, duration=datetime.timedelta(days=7),
+                    approval_delay=None, annotation=None,
+                    questions=None, qualifications=None,
+                    layout_params=None, response_groups=None,
+                    unique_request_token=None):
         """
         Creates a new HIT.
         Returns a ResultSet
@@ -252,6 +253,10 @@ class MTurkConnection(AWSQueryConnection):
         # add the annotation if specified
         if annotation is not None:
             params['RequesterAnnotation'] = annotation
+
+       # add the unique request token if specified
+        if unique_request_token is not None:
+            params['UniqueRequestToken'] = unique_request_token
 
         # Add the Qualifications if specified
         if qualifications is not None:

--- a/tests/mturk/common.py
+++ b/tests/mturk/common.py
@@ -37,6 +37,7 @@ class MTurkCommon(unittest.TestCase):
                         duration=datetime.timedelta(minutes=6),
                         approval_delay=60*60,
                         annotation='An annotation from boto create_hit test',
+                        unique_requst_token='A unique token',
                         response_groups=['Minimal',
                                 'HITDetail',
                                 'HITQuestion',

--- a/tests/mturk/create_free_text_question_regex.doctest
+++ b/tests/mturk/create_free_text_question_regex.doctest
@@ -38,6 +38,7 @@
 ...                                 duration=60*6,
 ...                                 approval_delay=60*60,
 ...                                 annotation='An annotation from boto create_hit test',
+...									unique_request_token='A unique token',
 ...                                 response_groups=['Minimal',
 ...                                                  'HITDetail',
 ...                                                  'HITQuestion',
@@ -95,6 +96,10 @@ u'Boto create_hit description'
 # annotation is correct
 >>> hit.RequesterAnnotation
 u'An annotation from boto create_hit test'
+
+# unique request token is correct
+>>> hit.UniqueRequestToken
+u'A unique token'
 
 >>> hit.HITReviewStatus
 u'NotReviewed'

--- a/tests/mturk/create_hit.doctest
+++ b/tests/mturk/create_hit.doctest
@@ -29,6 +29,7 @@
 ...                                 duration=60*6,
 ...                                 approval_delay=60*60,
 ...                                 annotation='An annotation from boto create_hit test',
+...                                 unique_request_token='A unique token',
 ...                                 response_groups=['Minimal',
 ...                                                  'HITDetail',
 ...                                                  'HITQuestion',
@@ -87,6 +88,10 @@ u'Boto create_hit description'
 # annotation is correct
 >>> hit.RequesterAnnotation
 u'An annotation from boto create_hit test'
+
+# unique request token is correct
+>>> hit.UniqueRequestToken
+u'A unique token'
 
 >>> hit.HITReviewStatus
 u'NotReviewed'

--- a/tests/mturk/create_hit_binary.doctest
+++ b/tests/mturk/create_hit_binary.doctest
@@ -31,6 +31,7 @@
 ...                                 duration=60*6,
 ...                                 approval_delay=60*60,
 ...                                 annotation='An annotation from boto create_hit test',
+...                                 unique_request_token='A unique token',
 ...                                 response_groups=['Minimal',
 ...                                                  'HITDetail',
 ...                                                  'HITQuestion',
@@ -89,6 +90,10 @@ u'Boto create_hit description'
 # annotation is correct
 >>> hit.RequesterAnnotation
 u'An annotation from boto create_hit test'
+
+# unique request token is correct
+>>> hit.UniqueRequestToken
+u'A unique token'
 
 >>> hit.HITReviewStatus
 u'NotReviewed'

--- a/tests/mturk/create_hit_external.py
+++ b/tests/mturk/create_hit_external.py
@@ -14,8 +14,7 @@ class Test(unittest.TestCase):
                 q = ExternalQuestion(external_url=external_url, frame_height=800)
                 conn = SetHostMTurkConnection()
                 keywords=['boto', 'test', 'doctest']
-                create_hit_rs = conn.create_hit(question=q, lifetime=60*65, max_assignments=2, title="Boto External Question Test", keywords=keywords, reward = 0.05, duration=60*6, approval_delay=60*60, annotation='An annotation from boto external question test', response_groups=['Minimal', 'HITDetail', 'HITQuestion', 'HITAssignmentSummary',])
-                assert(create_hit_rs.status == True)
+                create_hit_rs = conn.create_hit(question=q, lifetime=60*65, max_assignments=2, title="Boto External Question Test", keywords=keywords, reward = 0.05, duration=60*6, approval_delay=60*60, annotation='An annotation from boto external question test', unique_request_token='test' + str(datetime.datetime.now()), response_groups=['Minimal', 'HITDetail', 'HITQuestion', 'HITAssignmentSummary',])                assert(create_hit_rs.status == True)
 
 if __name__ == "__main__":
         unittest.main()

--- a/tests/mturk/create_hit_external.py
+++ b/tests/mturk/create_hit_external.py
@@ -15,6 +15,7 @@ class Test(unittest.TestCase):
                 conn = SetHostMTurkConnection()
                 keywords=['boto', 'test', 'doctest']
                 create_hit_rs = conn.create_hit(question=q, lifetime=60*65, max_assignments=2, title="Boto External Question Test", keywords=keywords, reward = 0.05, duration=60*6, approval_delay=60*60, annotation='An annotation from boto external question test', unique_request_token='test' + str(datetime.datetime.now()), response_groups=['Minimal', 'HITDetail', 'HITQuestion', 'HITAssignmentSummary',])                assert(create_hit_rs.status == True)
+                assert(create_hit_rs.status == True)
 
 if __name__ == "__main__":
         unittest.main()

--- a/tests/mturk/create_hit_from_hit_type.doctest
+++ b/tests/mturk/create_hit_from_hit_type.doctest
@@ -2,7 +2,7 @@
 >>> import datetime
 >>> from _init_environment import MTurkConnection, mturk_host
 >>> from boto.mturk.question import Question, QuestionContent, AnswerSpecification, FreeTextAnswer
->>> 
+>>>
 >>> conn = MTurkConnection(host=mturk_host)
 >>> keywords=['boto', 'test', 'doctest']
 >>> hit_type_rs = conn.register_hit_type('Boto Test HIT type',
@@ -38,6 +38,7 @@ u'...'
 ...                                 lifetime=60*65,
 ...                                 max_assignments=2,
 ...                                 annotation='An annotation from boto create_hit_from_hit_type test',
+...                                 unique_request_token='A unique token',
 ...                                 response_groups=['Minimal',
 ...                                                  'HITDetail',
 ...                                                  'HITQuestion',
@@ -97,6 +98,10 @@ u'HIT Type for testing Boto'
 # annotation is correct
 >>> hit.RequesterAnnotation
 u'An annotation from boto create_hit_from_hit_type test'
+
+# unique request token is correct
+>>> hit.UniqueRequestToken
+u'A unique token'
 
 # not reviewed yet
 >>> hit.HITReviewStatus


### PR DESCRIPTION
adding a unique identifier so that same hit is not uploaded multiple times