### PR TITLE
Fix broken example in docs

### DIFF
--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -178,7 +178,8 @@ class Table(object):
             ...     'write': 10,
             ... }, indexes=[
             ...     KeysOnlyIndex('MostRecentlyJoined', parts=[
-            ...         RangeKey('date_joined')
+            ...         HashKey('username'),
+            ...         RangeKey('date_joined'),
             ... ]), global_indexes=[
             ...     GlobalAllIndex('UsersByZipcode', parts=[
             ...         HashKey('zipcode'),


### PR DESCRIPTION
Must specify the primary hash key in local indexes, or you get `boto.dynamodb2.exceptions.ValidationException: ValidationException: 400 Bad Request`.