### PR TITLE
Fixes Issue #3126 EMR list_instances when fitlering by instance_group_types

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -242,7 +242,7 @@ class EmrConnection(AWSQueryConnection):
 
         if instance_group_types:
             self.build_list_params(params, instance_group_types,
-                                   'InstanceGroupTypeList.member')
+                                   'InstanceGroupTypes.member')
 
         return self.get_object('ListInstances', params, InstanceList)
 

--- a/tests/unit/emr/test_connection.py
+++ b/tests/unit/emr/test_connection.py
@@ -370,8 +370,8 @@ class TestListInstances(AWSMockServiceTestCase):
         self.assert_request_parameters({
             'Action': 'ListInstances',
             'ClusterId': 'j-123',
-            'InstanceGroupTypeList.member.1': 'MASTER',
-            'InstanceGroupTypeList.member.2': 'TASK',
+            'InstanceGroupTypes.member.1': 'MASTER',
+            'InstanceGroupTypes.member.2': 'TASK',
             'Version': '2009-03-31'
         })
 


### PR DESCRIPTION
Issue #3126 fixes EMR list_instances when fitlering by instance_group_types