### PR TITLE
[SQS]  - Added documentation for Queue.set_attribute set_attribute and SQSConnection.set_queue_attribute

### DIFF
--- a/boto/sqs/connection.py
+++ b/boto/sqs/connection.py
@@ -158,6 +158,65 @@ class SQSConnection(AWSQueryConnection):
                                Attributes, queue.id)
 
     def set_queue_attribute(self, queue, attribute, value):
+        """
+        Set a new value for an attribute of a Queue.
+
+        :type queue: A Queue object
+        :param queue: The SQS queue to get attributes for
+
+        :type attribute: String
+        :param attribute: The name of the attribute you want to set.
+
+        :param value: The new value for the attribute.
+
+            For DelaySeconds the value must be an integer number of
+            seconds from 0 to 900 (15 minutes).
+            >>> queue.set_attribute('DelaySeconds', 900)
+
+            For MaximumMessageSize the value must be an integer number of
+            bytes from 1024 (1 KiB) to 262144 (256 KiB).
+            >>> queue.set_attribute('MaximumMessageSize', 262144)
+
+            For MessageRetentionPeriod the value must be an integer number of
+            seconds from 60 (1 minute) to 1209600 (14 days).
+            >>> queue.set_attribute('MessageRetentionPeriod', 1209600)
+
+            For Policy the value must be an string that contains JSON formatted
+            parameters and values.
+            >>> queue.set_attribute('Policy', json.dumps({
+            ...     'Version': '2008-10-17',
+            ...     'Id': '/123456789012/testQueue/SQSDefaultPolicy',
+            ...     'Statement': [
+            ...        {
+            ...            'Sid': 'Queue1ReceiveMessage',
+            ...            'Effect': 'Allow',
+            ...            'Principal': {
+            ...                'AWS': '*'
+            ...            },
+            ...            'Action': 'SQS:ReceiveMessage',
+            ...            'Resource': 'arn:aws:aws:sqs:us-east-1:123456789012:testQueue'
+            ...        }
+            ...    ]
+            ... }))
+
+            For ReceiveMessageWaitTimeSeconds the value must be an integer number of
+            seconds from 0 to 20.
+            >>> queue.set_attribute('ReceiveMessageWaitTimeSeconds', 20)
+
+            For VisibilityTimeout the value must be an integer number of
+            seconds from 0 to 43200 (12 hours).
+            >>> queue.set_attribute('VisibilityTimeout', 43200)
+
+            For RedrivePolicy the value must be an string that contains JSON formatted
+            parameters and values. You can set maxReceiveCount to a value between 1 and 1000.
+            The deadLetterTargetArn value is the Amazon Resource Name (ARN) of the queue that
+            will receive the dead letter messages.
+            >>> queue.set_attribute('RedrivePolicy', json.dumps({
+            ...    'maxReceiveCount': 5,
+            ...    'deadLetterTargetArn': "arn:aws:aws:sqs:us-east-1:123456789012:testDeadLetterQueue"
+            ... }))
+        """
+
         params = {'Attribute.Name' : attribute, 'Attribute.Value' : value}
         return self.get_status('SetQueueAttributes', params, queue.id)
 

--- a/boto/sqs/connection.py
+++ b/boto/sqs/connection.py
@@ -131,7 +131,7 @@ class SQSConnection(AWSQueryConnection):
         :param queue: The SQS queue to get attributes for
 
         :type attribute: str
-        :type attribute: The specific attribute requested.  If not
+        :param attribute: The specific attribute requested.  If not
             supplied, the default is to return all attributes.  Valid
             attributes are:
 
@@ -167,54 +167,54 @@ class SQSConnection(AWSQueryConnection):
         :type attribute: String
         :param attribute: The name of the attribute you want to set.
 
-        :param value: The new value for the attribute.
+        :param value: The new value for the attribute must be:
 
-            For DelaySeconds the value must be an integer number of
+            * For `DelaySeconds` the value must be an integer number of
             seconds from 0 to 900 (15 minutes).
-            >>> queue.set_attribute('DelaySeconds', 900)
+                >>> queue.set_attribute('DelaySeconds', 900)
 
-            For MaximumMessageSize the value must be an integer number of
+            * For `MaximumMessageSize` the value must be an integer number of
             bytes from 1024 (1 KiB) to 262144 (256 KiB).
-            >>> queue.set_attribute('MaximumMessageSize', 262144)
+                >>> queue.set_attribute('MaximumMessageSize', 262144)
 
-            For MessageRetentionPeriod the value must be an integer number of
+            * For `MessageRetentionPeriod` the value must be an integer number of
             seconds from 60 (1 minute) to 1209600 (14 days).
-            >>> queue.set_attribute('MessageRetentionPeriod', 1209600)
+                >>> queue.set_attribute('MessageRetentionPeriod', 1209600)
 
-            For Policy the value must be an string that contains JSON formatted
+            * For `Policy` the value must be an string that contains JSON formatted
             parameters and values.
-            >>> queue.set_attribute('Policy', json.dumps({
-            ...     'Version': '2008-10-17',
-            ...     'Id': '/123456789012/testQueue/SQSDefaultPolicy',
-            ...     'Statement': [
-            ...        {
-            ...            'Sid': 'Queue1ReceiveMessage',
-            ...            'Effect': 'Allow',
-            ...            'Principal': {
-            ...                'AWS': '*'
-            ...            },
-            ...            'Action': 'SQS:ReceiveMessage',
-            ...            'Resource': 'arn:aws:aws:sqs:us-east-1:123456789012:testQueue'
-            ...        }
-            ...    ]
-            ... }))
+                >>> queue.set_attribute('Policy', json.dumps({
+                ...     'Version': '2008-10-17',
+                ...     'Id': '/123456789012/testQueue/SQSDefaultPolicy',
+                ...     'Statement': [
+                ...        {
+                ...            'Sid': 'Queue1ReceiveMessage',
+                ...            'Effect': 'Allow',
+                ...            'Principal': {
+                ...                'AWS': '*'
+                ...            },
+                ...            'Action': 'SQS:ReceiveMessage',
+                ...            'Resource': 'arn:aws:aws:sqs:us-east-1:123456789012:testQueue'
+                ...        }
+                ...    ]
+                ... }))
 
-            For ReceiveMessageWaitTimeSeconds the value must be an integer number of
+            * For `ReceiveMessageWaitTimeSeconds` the value must be an integer number of
             seconds from 0 to 20.
-            >>> queue.set_attribute('ReceiveMessageWaitTimeSeconds', 20)
+                >>> queue.set_attribute('ReceiveMessageWaitTimeSeconds', 20)
 
-            For VisibilityTimeout the value must be an integer number of
+            * For `VisibilityTimeout` the value must be an integer number of
             seconds from 0 to 43200 (12 hours).
-            >>> queue.set_attribute('VisibilityTimeout', 43200)
+                >>> queue.set_attribute('VisibilityTimeout', 43200)
 
-            For RedrivePolicy the value must be an string that contains JSON formatted
+            * For `RedrivePolicy` the value must be an string that contains JSON formatted
             parameters and values. You can set maxReceiveCount to a value between 1 and 1000.
             The deadLetterTargetArn value is the Amazon Resource Name (ARN) of the queue that
             will receive the dead letter messages.
-            >>> queue.set_attribute('RedrivePolicy', json.dumps({
-            ...    'maxReceiveCount': 5,
-            ...    'deadLetterTargetArn': "arn:aws:aws:sqs:us-east-1:123456789012:testDeadLetterQueue"
-            ... }))
+                >>> queue.set_attribute('RedrivePolicy', json.dumps({
+                ...    'maxReceiveCount': 5,
+                ...    'deadLetterTargetArn': "arn:aws:aws:sqs:us-east-1:123456789012:testDeadLetterQueue"
+                ... }))
         """
 
         params = {'Attribute.Name' : attribute, 'Attribute.Value' : value}

--- a/boto/sqs/connection.py
+++ b/boto/sqs/connection.py
@@ -171,19 +171,19 @@ class SQSConnection(AWSQueryConnection):
 
             * For `DelaySeconds` the value must be an integer number of
             seconds from 0 to 900 (15 minutes).
-                >>> queue.set_attribute('DelaySeconds', 900)
+                >>> connection.set_queue_attribute(queue, 'DelaySeconds', 900)
 
             * For `MaximumMessageSize` the value must be an integer number of
             bytes from 1024 (1 KiB) to 262144 (256 KiB).
-                >>> queue.set_attribute('MaximumMessageSize', 262144)
+                >>> connection.set_queue_attribute(queue, 'MaximumMessageSize', 262144)
 
             * For `MessageRetentionPeriod` the value must be an integer number of
             seconds from 60 (1 minute) to 1209600 (14 days).
-                >>> queue.set_attribute('MessageRetentionPeriod', 1209600)
+                >>> connection.set_queue_attribute(queue, 'MessageRetentionPeriod', 1209600)
 
             * For `Policy` the value must be an string that contains JSON formatted
             parameters and values.
-                >>> queue.set_attribute('Policy', json.dumps({
+                >>> connection.set_queue_attribute(queue, 'Policy', json.dumps({
                 ...     'Version': '2008-10-17',
                 ...     'Id': '/123456789012/testQueue/SQSDefaultPolicy',
                 ...     'Statement': [
@@ -201,17 +201,17 @@ class SQSConnection(AWSQueryConnection):
 
             * For `ReceiveMessageWaitTimeSeconds` the value must be an integer number of
             seconds from 0 to 20.
-                >>> queue.set_attribute('ReceiveMessageWaitTimeSeconds', 20)
+                >>> connection.set_queue_attribute(queue, 'ReceiveMessageWaitTimeSeconds', 20)
 
             * For `VisibilityTimeout` the value must be an integer number of
             seconds from 0 to 43200 (12 hours).
-                >>> queue.set_attribute('VisibilityTimeout', 43200)
+                >>> connection.set_queue_attribute(queue, 'VisibilityTimeout', 43200)
 
             * For `RedrivePolicy` the value must be an string that contains JSON formatted
             parameters and values. You can set maxReceiveCount to a value between 1 and 1000.
             The deadLetterTargetArn value is the Amazon Resource Name (ARN) of the queue that
             will receive the dead letter messages.
-                >>> queue.set_attribute('RedrivePolicy', json.dumps({
+                >>> connection.set_queue_attribute(queue, 'RedrivePolicy', json.dumps({
                 ...    'maxReceiveCount': 5,
                 ...    'deadLetterTargetArn': "arn:aws:aws:sqs:us-east-1:123456789012:testDeadLetterQueue"
                 ... }))

--- a/boto/sqs/queue.py
+++ b/boto/sqs/queue.py
@@ -107,12 +107,56 @@ class Queue(object):
         Set a new value for an attribute of the Queue.
 
         :type attribute: String
-        :param attribute: The name of the attribute you want to set.  The
-                           only valid value at this time is: VisibilityTimeout
-        :type value: int
+        :param attribute: The name of the attribute you want to set.
+
         :param value: The new value for the attribute.
-            For VisibilityTimeout the value must be an
-            integer number of seconds from 0 to 86400.
+
+            For DelaySeconds the value must be an integer number of
+            seconds from 0 to 900 (15 minutes).
+            >>> queue.set_attribute('DelaySeconds', 900)
+
+            For MaximumMessageSize the value must be an integer number of
+            bytes from 1024 (1 KiB) to 262144 (256 KiB).
+            >>> queue.set_attribute('MaximumMessageSize', 262144)
+
+            For MessageRetentionPeriod the value must be an integer number of
+            seconds from 60 (1 minute) to 1209600 (14 days).
+            >>> queue.set_attribute('MessageRetentionPeriod', 1209600)
+
+            For Policy the value must be an string that contains JSON formatted
+            parameters and values.
+            >>> queue.set_attribute('Policy', json.dumps({
+            ...     'Version': '2008-10-17',
+            ...     'Id': '/123456789012/testQueue/SQSDefaultPolicy',
+            ...     'Statement': [
+            ...        {
+            ...            'Sid': 'Queue1ReceiveMessage',
+            ...            'Effect': 'Allow',
+            ...            'Principal': {
+            ...                'AWS': '*'
+            ...            },
+            ...            'Action': 'SQS:ReceiveMessage',
+            ...            'Resource': 'arn:aws:aws:sqs:us-east-1:123456789012:testQueue'
+            ...        }
+            ...    ]
+            ... }))
+
+            For ReceiveMessageWaitTimeSeconds the value must be an integer number of
+            seconds from 0 to 20.
+            >>> queue.set_attribute('ReceiveMessageWaitTimeSeconds', 20)
+
+            For VisibilityTimeout the value must be an integer number of
+            seconds from 0 to 43200 (12 hours).
+            >>> queue.set_attribute('VisibilityTimeout', 43200)
+
+            For RedrivePolicy the value must be an string that contains JSON formatted
+            parameters and values. You can set maxReceiveCount to a value between 1 and 1000.
+            The deadLetterTargetArn value is the Amazon Resource Name (ARN) of the queue that
+            will receive the dead letter messages.
+            >>> queue.set_attribute('RedrivePolicy', json.dumps({
+            ...    'maxReceiveCount': 5,
+            ...    'deadLetterTargetArn': "arn:aws:aws:sqs:us-east-1:123456789012:testDeadLetterQueue"
+            ... }))
 
         :rtype: bool
         :return: True if successful, otherwise False.

--- a/boto/sqs/queue.py
+++ b/boto/sqs/queue.py
@@ -109,54 +109,55 @@ class Queue(object):
         :type attribute: String
         :param attribute: The name of the attribute you want to set.
 
-        :param value: The new value for the attribute.
+        :param value: The new value for the attribute must be:
 
-            For DelaySeconds the value must be an integer number of
+
+            * For `DelaySeconds` the value must be an integer number of
             seconds from 0 to 900 (15 minutes).
-            >>> queue.set_attribute('DelaySeconds', 900)
+                >>> queue.set_attribute('DelaySeconds', 900)
 
-            For MaximumMessageSize the value must be an integer number of
+            * For `MaximumMessageSize` the value must be an integer number of
             bytes from 1024 (1 KiB) to 262144 (256 KiB).
-            >>> queue.set_attribute('MaximumMessageSize', 262144)
+                >>> queue.set_attribute('MaximumMessageSize', 262144)
 
-            For MessageRetentionPeriod the value must be an integer number of
+            * For `MessageRetentionPeriod` the value must be an integer number of
             seconds from 60 (1 minute) to 1209600 (14 days).
-            >>> queue.set_attribute('MessageRetentionPeriod', 1209600)
+                >>> queue.set_attribute('MessageRetentionPeriod', 1209600)
 
-            For Policy the value must be an string that contains JSON formatted
+            * For `Policy` the value must be an string that contains JSON formatted
             parameters and values.
-            >>> queue.set_attribute('Policy', json.dumps({
-            ...     'Version': '2008-10-17',
-            ...     'Id': '/123456789012/testQueue/SQSDefaultPolicy',
-            ...     'Statement': [
-            ...        {
-            ...            'Sid': 'Queue1ReceiveMessage',
-            ...            'Effect': 'Allow',
-            ...            'Principal': {
-            ...                'AWS': '*'
-            ...            },
-            ...            'Action': 'SQS:ReceiveMessage',
-            ...            'Resource': 'arn:aws:aws:sqs:us-east-1:123456789012:testQueue'
-            ...        }
-            ...    ]
-            ... }))
+                >>> queue.set_attribute('Policy', json.dumps({
+                ...     'Version': '2008-10-17',
+                ...     'Id': '/123456789012/testQueue/SQSDefaultPolicy',
+                ...     'Statement': [
+                ...        {
+                ...            'Sid': 'Queue1ReceiveMessage',
+                ...            'Effect': 'Allow',
+                ...            'Principal': {
+                ...                'AWS': '*'
+                ...            },
+                ...            'Action': 'SQS:ReceiveMessage',
+                ...            'Resource': 'arn:aws:aws:sqs:us-east-1:123456789012:testQueue'
+                ...        }
+                ...    ]
+                ... }))
 
-            For ReceiveMessageWaitTimeSeconds the value must be an integer number of
+            * For `ReceiveMessageWaitTimeSeconds` the value must be an integer number of
             seconds from 0 to 20.
-            >>> queue.set_attribute('ReceiveMessageWaitTimeSeconds', 20)
+                >>> queue.set_attribute('ReceiveMessageWaitTimeSeconds', 20)
 
-            For VisibilityTimeout the value must be an integer number of
+            * For `VisibilityTimeout` the value must be an integer number of
             seconds from 0 to 43200 (12 hours).
-            >>> queue.set_attribute('VisibilityTimeout', 43200)
+                >>> queue.set_attribute('VisibilityTimeout', 43200)
 
-            For RedrivePolicy the value must be an string that contains JSON formatted
+            * For `RedrivePolicy` the value must be an string that contains JSON formatted
             parameters and values. You can set maxReceiveCount to a value between 1 and 1000.
             The deadLetterTargetArn value is the Amazon Resource Name (ARN) of the queue that
             will receive the dead letter messages.
-            >>> queue.set_attribute('RedrivePolicy', json.dumps({
-            ...    'maxReceiveCount': 5,
-            ...    'deadLetterTargetArn': "arn:aws:aws:sqs:us-east-1:123456789012:testDeadLetterQueue"
-            ... }))
+                >>> queue.set_attribute('RedrivePolicy', json.dumps({
+                ...    'maxReceiveCount': 5,
+                ...    'deadLetterTargetArn': "arn:aws:aws:sqs:us-east-1:123456789012:testDeadLetterQueue"
+                ... }))
 
         :rtype: bool
         :return: True if successful, otherwise False.


### PR DESCRIPTION
As pointed on issue #3128, the documentation regarding to set_attributes wasn't updated. I hope it helps further boto users in the future.

I've also thought about adding a couple more parameters to create_queue method which is currently only taking the visibility_timeout parameter but I guess this is out of the scope of this PR so I'll do it in a different one.

Cheers