### PR TITLE
Update dependency on simplejson (== 3.6.5)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 nose==1.3.3
 requests>=1.2.3,<=2.0.1
 rsa==3.1.4
-simplejson==3.5.2
+simplejson==3.6.5
 argparse==1.2.1
 httpretty>=0.7.0,<=0.8.6
 paramiko>=1.10.0


### PR DESCRIPTION
Very small PR that updates the dependency on simplejson to 3.6.5. There have been several bugfixes since 3.5.2 so it makes sense to update.