### PR TITLE
Fix import path for ec2container connection

### DIFF
--- a/boto/ec2containerservice/__init__.py
+++ b/boto/ec2containerservice/__init__.py
@@ -20,7 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import get_regions
+from .layer1 import EC2ContainerServiceConnection
 
 
 def regions():
@@ -30,8 +31,8 @@ def regions():
     :rtype: list
     :return: A list of :class:`boto.regioninfo.RegionInfo`
     """
-    from boto.ec2containerservice import EC2ContainerServiceConnection
-    return get_regions('', connection_cls=EC2ContainerServiceConnection)
+    return get_regions('ec2containerservice',
+                       connection_cls=EC2ContainerServiceConnection)
 
 
 def connect_to_region(region_name, **kw_params):

--- a/boto/endpoints.json
+++ b/boto/endpoints.json
@@ -155,7 +155,11 @@
         "eu-central-1": "ec2.eu-central-1.amazonaws.com"
     },
     "ec2containerservice": {
-        "us-east-1": "ecs.us-east-1.amazonaws.com"
+        "us-east-1": "ecs.us-east-1.amazonaws.com",
+        "us-west-2": "ecs.us-west-2.amazonaws.com",
+        "eu-west-1": "ecs.eu-west-1.amazonaws.com",
+        "ap-northeast-1": "ecs.ap-northeast-1.amazonaws.com",
+        "ap-southeast-2": "ecs.ap-southeast-2.amazonaws.com"
     },
     "elasticache": {
         "ap-northeast-1": "elasticache.ap-northeast-1.amazonaws.com",


### PR DESCRIPTION
Also add new endpoints for ECS.

This is missing a test case, but the test case would mostly be that import works, and that seems a bit excessive.