### PR TITLE
Route53 TCP healthcheck

### DIFF
--- a/boto/route53/healthcheck.py
+++ b/boto/route53/healthcheck.py
@@ -56,7 +56,7 @@ class HealthCheck(object):
             %(ip_addr_part)s
             <Port>%(port)s</Port>
             <Type>%(type)s</Type>
-            <ResourcePath>%(resource_path)s</ResourcePath>
+            %(resource_path_part)s
             %(fqdn_part)s
             %(string_match_part)s
             %(request_interval)s
@@ -66,6 +66,8 @@ class HealthCheck(object):
 
     XMLIpAddrPart = """<IPAddress>%(ip_addr)s</IPAddress>"""
 
+    XMLResourcePathPart = """<ResourcePath>%(resource_path)s</ResourcePath>"""
+
     XMLFQDNPart = """<FullyQualifiedDomainName>%(fqdn)s</FullyQualifiedDomainName>"""
 
     XMLStringMatchPart = """<SearchString>%(string_match)s</SearchString>"""
@@ -74,7 +76,7 @@ class HealthCheck(object):
 
     valid_request_intervals = (10, 30)
 
-    def __init__(self, ip_addr, port, hc_type, resource_path, fqdn=None, string_match=None, request_interval=30, failure_threshold=3):
+    def __init__(self, ip_addr, port, hc_type, resource_path=None, fqdn=None, string_match=None, request_interval=30, failure_threshold=3):
         """
         HealthCheck object
 
@@ -109,11 +111,10 @@ class HealthCheck(object):
         self.resource_path = resource_path
         self.fqdn = fqdn
         self.string_match = string_match
+        self.request_interval = request_interval
         self.failure_threshold = failure_threshold
 
-        if request_interval in self.valid_request_intervals:
-            self.request_interval = request_interval
-        else:
+        if request_interval not in self.valid_request_intervals:
             raise AttributeError(
                 "Valid values for request_interval are: %s" %
                 ",".join(str(i) for i in self.valid_request_intervals))
@@ -127,18 +128,22 @@ class HealthCheck(object):
             'ip_addr_part': '',
             'port': self.port,
             'type': self.hc_type,
-            'resource_path': self.resource_path,
+            'resource_path_part': "",
             'fqdn_part': "",
             'string_match_part': "",
             'request_interval': (self.XMLRequestIntervalPart %
                                  {'request_interval': self.request_interval}),
             'failure_threshold': self.failure_threshold,
         }
-        if self.fqdn is not None:
-            params['fqdn_part'] = self.XMLFQDNPart % {'fqdn': self.fqdn}
 
         if self.ip_addr:
             params['ip_addr_part'] = self.XMLIpAddrPart % {'ip_addr': self.ip_addr}
+
+        if self.resource_path:
+            params['resource_path_part'] = self.XMLResourcePathPart % {'resource_path': self.resource_path}
+
+        if self.fqdn is not None:
+            params['fqdn_part'] = self.XMLFQDNPart % {'fqdn': self.fqdn}
 
         if self.string_match is not None:
             params['string_match_part'] = self.XMLStringMatchPart % {'string_match': self.string_match}

--- a/tests/unit/route53/test_connection.py
+++ b/tests/unit/route53/test_connection.py
@@ -602,17 +602,24 @@ class TestCreateHealthCheckRoute53IpAddress(AWSMockServiceTestCase):
         hc_xml = hc.to_xml()
         self.assertFalse('<FullyQualifiedDomainName>' in hc_xml)
         self.assertTrue('<IPAddress>' in hc_xml)
+        self.assertTrue('<ResourcePath>' in hc_xml)
 
         response = self.service_connection.create_health_check(hc)
         hc_resp = response['CreateHealthCheckResponse']['HealthCheck']['HealthCheckConfig']
         self.assertEqual(hc_resp['IPAddress'], '74.125.228.81')
-        self.assertEqual(hc_resp['ResourcePath'], '/health_check')
         self.assertEqual(hc_resp['Type'], 'HTTPS_STR_MATCH')
         self.assertEqual(hc_resp['Port'], '443')
         self.assertEqual(hc_resp['ResourcePath'], '/health_check')
         self.assertEqual(hc_resp['SearchString'], 'OK')
         self.assertEqual(response['CreateHealthCheckResponse']['HealthCheck']['Id'], '34778cf8-e31e-4974-bad0-b108bd1623d3')
 
+    def test_create_health_check_tcp(self):
+        self.set_http_response(status_code=201)
+        hc = HealthCheck(ip_addr='74.125.228.81', port=22, hc_type='TCP')
+        hc_xml = hc.to_xml()
+        self.assertFalse('<FullyQualifiedDomainName>' in hc_xml)
+        self.assertTrue('<IPAddress>' in hc_xml)
+        self.assertFalse('<ResourcePath>' in hc_xml)
 
 @attr(route53=True)
 class TestGetCheckerIpRanges(AWSMockServiceTestCase):


### PR DESCRIPTION
Health checks with type TCP couldn't be defined because the ResourcePath was always provided