### PR TITLE
Fix #3119. Use response headers in presigned urls.

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -366,6 +366,10 @@ class S3Connection(AWSAuthConnection):
         if version_id is not None:
             params['VersionId'] = version_id
 
+        if response_headers is not None:
+            for header, value in response_headers.items():
+                params[header] = value
+
         http_request = self.build_base_http_request(method, path, auth_path,
                                                     headers=headers, host=host,
                                                     params=params)

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -367,8 +367,7 @@ class S3Connection(AWSAuthConnection):
             params['VersionId'] = version_id
 
         if response_headers is not None:
-            for header, value in response_headers.items():
-                params[header] = value
+            params.update(response_headers)
 
         http_request = self.build_base_http_request(method, path, auth_path,
                                                     headers=headers, host=host,

--- a/tests/unit/s3/test_connection.py
+++ b/tests/unit/s3/test_connection.py
@@ -155,6 +155,26 @@ class TestSigV4Presigned(MockServiceWithConfigTestCase):
         self.assertIn('host', url)
         self.assertIn('x-amz-meta-key', url)
 
+    def test_sigv4_presign_response_headers(self):
+        self.config = {
+            's3': {
+                'use-sigv4': True,
+            }
+        }
+
+        conn = self.connection_class(
+            aws_access_key_id='less',
+            aws_secret_access_key='more',
+            host='s3.amazonaws.com'
+        )
+
+        response_headers = {'response-content-disposition': 'attachment; filename="file.ext"'}
+        url = conn.generate_url_sigv4(86400, 'GET', bucket='examplebucket',
+                                      key='test.txt', response_headers=response_headers)
+
+        self.assertIn('host', url)
+        self.assertIn('response-content-disposition', url)
+
 
 class TestUnicodeCallingFormat(AWSMockServiceTestCase):
     connection_class = S3Connection


### PR DESCRIPTION
Response headers are now added to the query path like in the regular
[`s3.connection.generate_url`](https://github.com/boto/boto/blob/develop/boto/s3/connection.py#L397-399).