### PR TITLE
Fix key name for EMR list_instances filtering

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -242,7 +242,7 @@ class EmrConnection(AWSQueryConnection):
 
         if instance_group_types:
             self.build_list_params(params, instance_group_types,
-                                   'InstanceGroupTypeList.member')
+                                   'InstanceGroupTypes.member')
 
         return self.get_object('ListInstances', params, InstanceList)
 

--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -23,8 +23,6 @@
 """
 Represents a connection to the EMR service
 """
-import types
-
 import boto
 import boto.utils
 from boto.ec2.regioninfo import RegionInfo

--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -25,17 +25,16 @@ Represents a connection to the EMR service
 """
 import boto
 import boto.utils
-from boto.ec2.regioninfo import RegionInfo
-from boto.emr.emrobject import AddInstanceGroupsResponse, BootstrapActionList, \
-                               Cluster, ClusterSummaryList, HadoopStep, \
-                               InstanceGroupList, InstanceList, JobFlow, \
-                               JobFlowStepList, \
-                               ModifyInstanceGroupsResponse, \
-                               RunJobFlowResponse, StepSummaryList
-from boto.emr.step import JarStep
-from boto.connection import AWSQueryConnection
-from boto.exception import EmrResponseError
 from boto.compat import six
+from boto.connection import AWSQueryConnection
+from boto.ec2.regioninfo import RegionInfo
+from boto.emr.emrobject import (AddInstanceGroupsResponse, BootstrapActionList,
+                                Cluster, ClusterSummaryList, HadoopStep,
+                                InstanceGroupList, InstanceList, JobFlow,
+                                JobFlowStepList, ModifyInstanceGroupsResponse,
+                                RunJobFlowResponse, StepSummaryList)
+from boto.emr.step import JarStep
+from boto.exception import EmrResponseError
 
 
 class EmrConnection(AWSQueryConnection):
@@ -59,15 +58,16 @@ class EmrConnection(AWSQueryConnection):
             region = RegionInfo(self, self.DefaultRegionName,
                                 self.DefaultRegionEndpoint)
         self.region = region
-        super(EmrConnection, self).__init__(aws_access_key_id,
-                                    aws_secret_access_key,
-                                    is_secure, port, proxy, proxy_port,
-                                    proxy_user, proxy_pass,
-                                    self.region.endpoint, debug,
-                                    https_connection_factory, path,
-                                    security_token,
-                                    validate_certs=validate_certs,
-                                    profile_name=profile_name)
+        super(EmrConnection, self).__init__(
+            aws_access_key_id,
+            aws_secret_access_key,
+            is_secure, port, proxy, proxy_port,
+            proxy_user, proxy_pass,
+            self.region.endpoint, debug,
+            https_connection_factory, path,
+            security_token,
+            validate_certs=validate_certs,
+            profile_name=profile_name)
         # Many of the EMR hostnames are of the form:
         #     <region>.<service_name>.amazonaws.com
         # rather than the more common:
@@ -104,7 +104,7 @@ class EmrConnection(AWSQueryConnection):
             return jobflows[0]
 
     def describe_jobflows(self, states=None, jobflow_ids=None,
-                           created_after=None, created_before=None):
+                          created_after=None, created_before=None):
         """
         Retrieve all the Elastic MapReduce job flows on your account
 
@@ -388,8 +388,8 @@ class EmrConnection(AWSQueryConnection):
             # could be wrong - the example amazon gives uses
             # InstanceRequestCount, while the api documentation
             # says InstanceCount
-            params['InstanceGroups.member.%d.InstanceGroupId' % (k+1) ] = ig[0]
-            params['InstanceGroups.member.%d.InstanceCount' % (k+1) ] = ig[1]
+            params['InstanceGroups.member.%d.InstanceGroupId' % (k+1)] = ig[0]
+            params['InstanceGroups.member.%d.InstanceCount' % (k+1)] = ig[1]
 
         return self.get_object('ModifyInstanceGroups', params,
                                ModifyInstanceGroupsResponse, verb='POST')
@@ -520,9 +520,9 @@ class EmrConnection(AWSQueryConnection):
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
-                                                        num_instances)
+                master_instance_type,
+                slave_instance_type,
+                num_instances)
             params.update(instance_params)
         else:
             # Instance group args (for spot instances or a heterogenous cluster)
@@ -547,7 +547,8 @@ class EmrConnection(AWSQueryConnection):
             params.update(self._build_step_list(step_args))
 
         if bootstrap_actions:
-            bootstrap_action_args = [self._build_bootstrap_action_args(bootstrap_action) for bootstrap_action in bootstrap_actions]
+            bootstrap_action_args = [self._build_bootstrap_action_args(bootstrap_action)
+                                     for bootstrap_action in bootstrap_actions]
             params.update(self._build_bootstrap_action_list(bootstrap_action_args))
 
         if ami_version:

--- a/tests/unit/emr/test_connection.py
+++ b/tests/unit/emr/test_connection.py
@@ -370,8 +370,8 @@ class TestListInstances(AWSMockServiceTestCase):
         self.assert_request_parameters({
             'Action': 'ListInstances',
             'ClusterId': 'j-123',
-            'InstanceGroupTypeList.member.1': 'MASTER',
-            'InstanceGroupTypeList.member.2': 'TASK',
+            'InstanceGroupTypes.member.1': 'MASTER',
+            'InstanceGroupTypes.member.2': 'TASK',
             'Version': '2009-03-31'
         })
 


### PR DESCRIPTION
```list_instances``` with ```instance_group_types``` parameter doesn't work well using ```InstanceGroupTypeList.member```. Using ```InstanceGroupTypes.member``` fixes this problem instead of ```InstanceGroupTypeList.member```.

https://github.com/boto/boto/issues/2350

The following is the quick check script.

```python
# -*- coding: utf-8 -*-
from datetime import datetime

from boto.emr import connect_to_region
from boto.emr.instance_group import InstanceGroup
from boto.emr.step import InstallHiveStep

_yourbucket = 'yourbucket'
_yourkey = 'yourkey'
_yoursecret = 'yoursecret'
_yoursshkey = 'yoursshkey'

if __name__ == '__main__':
    bucket_name = _yourbucket
    install_hive = InstallHiveStep(hive_versions='0.13.1')

    setup_steps = [install_hive]
    instance_group = [
        InstanceGroup(
            1, 'MASTER', 'r3.xlarge',
            'SPOT', 'emr-master', bidprice="0.09"),
        InstanceGroup(
            2, 'CORE', 'r3.xlarge',
            'SPOT', 'emr-core', bidprice="0.09"),
    ]

    conn = connect_to_region(
        'ap-northeast-1',
        aws_access_key_id=_yourkey,
        aws_secret_access_key=_yoursecret)
    jobid = conn.run_jobflow(
        name='boto_test_{}'.format(datetime.today().strftime('%Y%m%d%H%m%s')),
        ami_version='3.5.0',
        ec2_keyname=_yoursshkey,
        instance_groups=instance_group,
        action_on_failure='TERMINATE_JOB_FLOW',
        log_uri='s3://{0}/jobflow_logs/'.format(bucket_name),
        keep_alive=True,
        enable_debugging=False,
        steps=setup_steps,
        additional_info=None,
        api_params=None,
        visible_to_all_users=True,
        job_flow_role='EMR_EC2_DefaultRole',
        service_role='EMR_DefaultRole'
    )

    instance_list = conn.list_instances(
        jobid, instance_group_types=['MASTER'])
    instance_ids = []
    for i in instance_list.instances:
        instance_ids.append(i.ec2instanceid)

    print instance_ids  # this only should one MASTER instance but currently it shows MASTER and CORE
    print jobid

```
