### PR TITLE
Parse error type before getting the exception class from __faults mappings

### DIFF
--- a/boto/cloudhsm/layer1.py
+++ b/boto/cloudhsm/layer1.py
@@ -24,7 +24,7 @@ import boto
 from boto.compat import json
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import get_error_name, JSONResponseError
 from boto.cloudhsm import exceptions
 
 
@@ -270,7 +270,7 @@ class CloudHSMConnection(AWSQueryConnection):
         Lists the Availability Zones that have available AWS CloudHSM
         capacity.
 
-        
+
         """
         params = {}
         return self.make_request(action='ListAvailableZones',
@@ -441,7 +441,7 @@ class CloudHSMConnection(AWSQueryConnection):
                 return json.loads(response_body)
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = get_error_name(json_body.get('__type', None))
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)

--- a/boto/cloudtrail/layer1.py
+++ b/boto/cloudtrail/layer1.py
@@ -23,7 +23,7 @@
 import boto
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import get_error_name, JSONResponseError
 from boto.cloudtrail import exceptions
 from boto.compat import json
 
@@ -368,7 +368,7 @@ class CloudTrailConnection(AWSQueryConnection):
                 return json.loads(response_body)
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = boto.exception.get_error_name(json_body.get('__type', None))
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)

--- a/boto/codedeploy/layer1.py
+++ b/boto/codedeploy/layer1.py
@@ -24,7 +24,7 @@ import boto
 from boto.compat import json
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import get_error_name, JSONResponseError
 from boto.codedeploy import exceptions
 
 
@@ -892,7 +892,7 @@ class CodeDeployConnection(AWSQueryConnection):
                 return json.loads(response_body)
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = get_error_name(json_body.get('__type', None))
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)

--- a/boto/cognito/identity/layer1.py
+++ b/boto/cognito/identity/layer1.py
@@ -24,7 +24,7 @@ import boto
 from boto.compat import json
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import get_error_name, JSONResponseError
 from boto.cognito.identity import exceptions
 
 
@@ -543,7 +543,7 @@ class CognitoIdentityConnection(AWSQueryConnection):
                 return json.loads(response_body)
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = get_error_name(json_body.get('__type', None))
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)

--- a/boto/configservice/layer1.py
+++ b/boto/configservice/layer1.py
@@ -24,7 +24,7 @@ import boto
 from boto.compat import json
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import get_error_name, JSONResponseError
 from boto.configservice import exceptions
 
 
@@ -378,7 +378,7 @@ class ConfigServiceConnection(AWSQueryConnection):
                 return json.loads(response_body)
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = get_error_name(json_body.get('__type', None))
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)

--- a/boto/datapipeline/layer1.py
+++ b/boto/datapipeline/layer1.py
@@ -24,7 +24,7 @@ import boto
 from boto.compat import json
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import get_error_name, JSONResponseError
 from boto.datapipeline import exceptions
 
 
@@ -633,7 +633,7 @@ class DataPipelineConnection(AWSQueryConnection):
                 return json.loads(response_body)
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = get_error_name(json_body.get('__type', None))
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)

--- a/boto/directconnect/layer1.py
+++ b/boto/directconnect/layer1.py
@@ -23,7 +23,7 @@
 import boto
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import get_error_name, JSONResponseError
 from boto.directconnect import exceptions
 from boto.compat import json
 
@@ -621,7 +621,7 @@ class DirectConnectConnection(AWSQueryConnection):
                 return json.loads(response_body)
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = get_error_name(json_body.get('__type', None))
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)

--- a/boto/dynamodb2/layer1.py
+++ b/boto/dynamodb2/layer1.py
@@ -25,7 +25,7 @@ import boto
 from boto.compat import json
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import get_error_name, JSONResponseError
 from boto.dynamodb2 import exceptions
 
 
@@ -2847,7 +2847,7 @@ class DynamoDBConnection(AWSQueryConnection):
                 return json.loads(response_body)
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = get_error_name(json_body.get('__type', None))
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)

--- a/boto/exception.py
+++ b/boto/exception.py
@@ -33,6 +33,10 @@ from boto import handler
 from boto.compat import json, StandardError
 from boto.resultset import ResultSet
 
+def get_error_name(error_type):
+    if error_type:
+        return error_type.split('#')[-1]
+    return error_type
 
 class BotoClientError(StandardError):
     """
@@ -378,9 +382,7 @@ class JSONResponseError(BotoServerError):
         self.body = body
         if self.body:
             self.error_message = self.body.get('message', None)
-            self.error_code = self.body.get('__type', None)
-            if self.error_code:
-                self.error_code = self.error_code.split('#')[-1]
+            self.error_code = get_error_name(self.body.get('__type', None))
 
 
 class DynamoDBResponseError(JSONResponseError):

--- a/boto/kinesis/layer1.py
+++ b/boto/kinesis/layer1.py
@@ -25,7 +25,7 @@ import boto
 
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import get_error_name, JSONResponseError
 from boto.kinesis import exceptions
 from boto.compat import json
 from boto.compat import six
@@ -868,7 +868,7 @@ class KinesisConnection(AWSQueryConnection):
                 return json.loads(response_body)
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = get_error_name(json_body.get('__type', None))
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)

--- a/boto/kms/layer1.py
+++ b/boto/kms/layer1.py
@@ -24,7 +24,7 @@ import boto
 from boto.compat import json
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import get_error_name, JSONResponseError
 from boto.kms import exceptions
 from boto.compat import six
 import base64
@@ -782,7 +782,7 @@ class KMSConnection(AWSQueryConnection):
 
     def update_key_description(self, key_id, description):
         """
-        
+
 
         :type key_id: string
         :param key_id:
@@ -814,7 +814,7 @@ class KMSConnection(AWSQueryConnection):
                 return json.loads(response_body)
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = get_error_name(json_body.get('__type', None))
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)

--- a/boto/logs/layer1.py
+++ b/boto/logs/layer1.py
@@ -23,7 +23,7 @@
 import boto
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import get_error_name, JSONResponseError
 from boto.logs import exceptions
 from boto.compat import json
 
@@ -221,7 +221,7 @@ class CloudWatchLogsConnection(AWSQueryConnection):
 
     def delete_retention_policy(self, log_group_name):
         """
-        
+
 
         :type log_group_name: string
         :param log_group_name:
@@ -490,7 +490,7 @@ class CloudWatchLogsConnection(AWSQueryConnection):
 
     def put_retention_policy(self, log_group_name, retention_in_days):
         """
-        
+
 
         :type log_group_name: string
         :param log_group_name:
@@ -570,7 +570,7 @@ class CloudWatchLogsConnection(AWSQueryConnection):
                 return json.loads(response_body)
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = get_error_name(json_body.get('__type', None))
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)

--- a/boto/machinelearning/layer1.py
+++ b/boto/machinelearning/layer1.py
@@ -24,7 +24,7 @@ import boto
 from boto.compat import json, urlsplit
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import get_error_name, JSONResponseError
 from boto.machinelearning import exceptions
 
 
@@ -1401,7 +1401,7 @@ class MachineLearningConnection(AWSQueryConnection):
                 return json.loads(response_body)
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = get_error_name(json_body.get('__type', None))
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)

--- a/boto/opsworks/layer1.py
+++ b/boto/opsworks/layer1.py
@@ -24,7 +24,7 @@ import boto
 from boto.compat import json
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import get_error_name, JSONResponseError
 from boto.opsworks import exceptions
 
 
@@ -1645,7 +1645,7 @@ class OpsWorksConnection(AWSQueryConnection):
         explicitly grants permissions. For more information on user
         permissions, see `Managing User Permissions`_.
 
-        
+
         """
         params = {}
         return self.make_request(action='DescribeMyUserProfile',
@@ -3087,7 +3087,7 @@ class OpsWorksConnection(AWSQueryConnection):
                 return json.loads(response_body)
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = get_error_name(json_body.get('__type', None))
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)

--- a/boto/route53/domains/layer1.py
+++ b/boto/route53/domains/layer1.py
@@ -24,13 +24,13 @@ import boto
 from boto.compat import json
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import get_error_name, JSONResponseError
 from boto.route53.domains import exceptions
 
 
 class Route53DomainsConnection(AWSQueryConnection):
     """
-    
+
     """
     APIVersion = "2014-05-15"
     DefaultRegionName = "us-east-1"
@@ -861,7 +861,7 @@ class Route53DomainsConnection(AWSQueryConnection):
                 return json.loads(response_body)
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = get_error_name(json_body.get('__type', None))
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)

--- a/boto/support/layer1.py
+++ b/boto/support/layer1.py
@@ -24,7 +24,7 @@ import boto
 from boto.compat import json
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo
-from boto.exception import JSONResponseError
+from boto.exception import get_error_name, JSONResponseError
 from boto.support import exceptions
 
 
@@ -668,7 +668,7 @@ class SupportConnection(AWSQueryConnection):
                 return json.loads(response_body)
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = get_error_name(json_body.get('__type', None))
             exception_class = self._faults.get(fault_name, self.ResponseError)
             raise exception_class(response.status, response.reason,
                                   body=json_body)

--- a/boto/swf/layer1.py
+++ b/boto/swf/layer1.py
@@ -27,7 +27,7 @@ import time
 import boto
 from boto.connection import AWSAuthConnection
 from boto.provider import Provider
-from boto.exception import SWFResponseError
+from boto.exception import get_error_name, SWFResponseError
 from boto.swf import exceptions as swf_exceptions
 from boto.compat import json
 
@@ -139,7 +139,7 @@ class Layer1(AWSAuthConnection):
                 return None
         else:
             json_body = json.loads(response_body)
-            fault_name = json_body.get('__type', None)
+            fault_name = get_error_name(json_body.get('__type', None))
             # Certain faults get mapped to more specific exception classes.
             excp_cls = self._fault_excp.get(fault_name, self.ResponseError)
             raise excp_cls(response.status, response.reason, body=json_body)


### PR DESCRIPTION
Fixes boto/boto#3159

Now a `com.amazonaws.dynamodb.v20120810#ResourceInUseException` error type should be raised as `ResourceInUseException`.