### PR TITLE
fix V4 auth in one edge case

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -377,7 +377,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
             else:
                 c_value = ' '.join(raw_value.strip().split())
             canonical.append('%s:%s' % (c_name, c_value))
-        return '\n'.join(sorted(canonical))
+        return '\n'.join(sorted(canonical, key=lambda h: h.split(':')[0]))
 
     def signed_headers(self, headers_to_sign):
         l = ['%s' % n.lower().strip() for n in headers_to_sign]

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -288,6 +288,8 @@ class TestS3HmacAuthV4Handler(unittest.TestCase):
                 'User-Agent': 'Boto',
                 'X-AMZ-Content-sha256': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
                 'X-AMZ-Date': '20130605T193245Z',
+                'X-AMZ-Copy-Source-Range': 'bytes=0-999999999',
+                'X-AMZ-Copy-Source': 'some/key',
             },
             body=''
         )
@@ -454,9 +456,11 @@ max-keys=0
 host:awesome-bucket.s3-us-west-2.amazonaws.com
 user-agent:Boto
 x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-copy-source:some/key
+x-amz-copy-source-range:bytes=0-999999999
 x-amz-date:20130605T193245Z
 
-host;user-agent;x-amz-content-sha256;x-amz-date
+host;user-agent;x-amz-content-sha256;x-amz-copy-source;x-amz-copy-source-range;x-amz-date
 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"""
 
         authed_req = self.auth.canonical_request(self.awesome_bucket_request)
@@ -472,9 +476,11 @@ max-keys=0
 host:awesome-bucket.s3-us-west-2.amazonaws.com
 user-agent:Boto
 x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-copy-source:some/key
+x-amz-copy-source-range:bytes=0-999999999
 x-amz-date:20130605T193245Z
 
-host;user-agent;x-amz-content-sha256;x-amz-date
+host;user-agent;x-amz-content-sha256;x-amz-copy-source;x-amz-copy-source-range;x-amz-date
 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"""
 
         # Pre-mangle it. In practice, this happens as part of ``add_auth``,
@@ -493,6 +499,8 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"""
             'user-agent:Boto\n'
             'x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae'
             '41e4649b934ca495991b7852b855\n'
+            'x-amz-copy-source:some/key\n'
+            'x-amz-copy-source-range:bytes=0-999999999\n'
             'x-amz-date:20130605T193245Z'
         )
 


### PR DESCRIPTION
The headers `x-amz-copy-source` and `x-amz-copy-source-range`, which are sent in the copy part S3 operation, sort differently than the header/value strings that are included in the canonical request for the V4 signature. This is because the colon character which joins the header name and the header value sorts after the dash character in `x-amz-copy-source-range`. For example python sorts the list `['x-amz-copy-source:some/key', 'x-amz-copy-source-range:bytes=0-999']` in reverse. This leads to an incorrect signature being calculated. This PR fixes the problem by sorting the header/value strings only according to the prefix before the colon.