### PR TITLE
updates the default ttl to be more consistent with the default for the Record class

### DIFF
--- a/boto/route53/zone.py
+++ b/boto/route53/zone.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-default_ttl = 60
+default_ttl = 600
 
 import copy
 from boto.exception import TooManyRecordsException
@@ -108,7 +108,7 @@ class Zone(object):
         else:
             change.add_value(value)
 
-    def add_record(self, resource_type, name, value, ttl=60, identifier=None,
+    def add_record(self, resource_type, name, value, ttl=default_ttl, identifier=None,
                    comment=""):
         """
         Add a new record to this Zone.  See _new_record for parameter


### PR DESCRIPTION
I noticed that the default ttl for the Record class didn't align with the default ttl for creating or changing a record in zone.py. This update aligns zone.py to have the same default ttl as the Record class does.