### PR TITLE
Retain literal wildcard characters in CF invalidation paths

### DIFF
--- a/boto/cloudfront/invalidation.py
+++ b/boto/cloudfront/invalidation.py
@@ -68,10 +68,10 @@ class InvalidationBatch(object):
         self.paths[k] = v
 
     def escape(self, p):
-        """Escape a path, make sure it begins with a slash and contains no invalid characters"""
+        """Escape a path, make sure it begins with a slash and contains no invalid characters. Retain literal wildcard characters."""
         if not p[0] == "/":
             p = "/%s" % p
-        return urllib.parse.quote(p)
+        return urllib.parse.quote(p, safe = "/*")
 
     def to_xml(self):
         """Get this batch as XML"""

--- a/tests/unit/cloudfront/test_invalidation.py
+++ b/tests/unit/cloudfront/test_invalidation.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+from tests.compat import unittest
+
+import boto.cloudfront as cf
+
+class CFInvalidationTest(unittest.TestCase):
+
+    cloudfront = True
+
+    def test_wildcard_escape(self):
+        """
+        Test that wildcards are retained as literals
+        See: http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html#invalidation-specifying-objects-paths
+        """
+        batch = cf.invalidation.InvalidationBatch()
+        self.assertEqual(batch.escape("/*"), "/*")
+        self.assertEqual(batch.escape("/foo*"), "/foo*")
+        self.assertEqual(batch.escape("/foo/bar/*"), "/foo/bar/*")
+        self.assertEqual(batch.escape("/nowildcard"), "/nowildcard")
+        self.assertEqual(batch.escape("/other special characters"), "/other%20special%20characters")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is to support recently introduced wildcards for partial path matching in CF (see: http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html).
Without this any wildcard path provided is encoded and the wildcards do not work when encoded.