### PR TITLE
Make EMR endpoints consistent with AWS API doc

### DIFF
--- a/boto/endpoints.json
+++ b/boto/endpoints.json
@@ -194,16 +194,16 @@
         "eu-central-1": "elasticloadbalancing.eu-central-1.amazonaws.com"
     },
     "elasticmapreduce": {
-        "ap-northeast-1": "ap-northeast-1.elasticmapreduce.amazonaws.com",
-        "ap-southeast-1": "ap-southeast-1.elasticmapreduce.amazonaws.com",
-        "ap-southeast-2": "ap-southeast-2.elasticmapreduce.amazonaws.com",
+        "ap-northeast-1": "elasticmapreduce.ap-northeast-1.amazonaws.com",
+        "ap-southeast-1": "elasticmapreduce.ap-southeast-1.amazonaws.com",
+        "ap-southeast-2": "elasticmapreduce.ap-southeast-2.amazonaws.com",
         "cn-north-1": "elasticmapreduce.cn-north-1.amazonaws.com.cn",
         "eu-west-1": "elasticmapreduce.eu-west-1.amazonaws.com",
-        "sa-east-1": "sa-east-1.elasticmapreduce.amazonaws.com",
+        "sa-east-1": "elasticmapreduce.sa-east-1.amazonaws.com",
         "us-east-1": "elasticmapreduce.us-east-1.amazonaws.com",
-        "us-gov-west-1": "us-gov-west-1.elasticmapreduce.amazonaws.com",
-        "us-west-1": "us-west-1.elasticmapreduce.amazonaws.com",
-        "us-west-2": "us-west-2.elasticmapreduce.amazonaws.com",
+        "us-gov-west-1": "elasticmapreduce.us-gov-west-1.amazonaws.com",
+        "us-west-1": "elasticmapreduce.us-west-1.amazonaws.com",
+        "us-west-2": "elasticmapreduce.us-west-2.amazonaws.com",
         "eu-central-1": "elasticmapreduce.eu-central-1.amazonaws.com"
     },
     "elastictranscoder": {


### PR DESCRIPTION
EMR endpoints are not consistent with AWS documentation. I'm not sure why only EMR is in this style, but this patch makes a bit less confusing when looking at endpoints.

- http://docs.aws.amazon.com/general/latest/gr/rande.html#emr_region
