### PR TITLE
subclassing HTTPS rather than HTTP object. simply specifying port 443…

### DIFF
--- a/boto/https_connection.py
+++ b/boto/https_connection.py
@@ -83,7 +83,7 @@ def ValidateCertificateHostname(cert, hostname):
     return False
 
 
-class CertValidatingHTTPSConnection(http_client.HTTPConnection):
+class CertValidatingHTTPSConnection(http_client.HTTPSConnection):
     """An HTTPConnection that connects over SSL and validates certificates."""
 
     default_port = http_client.HTTPS_PORT
@@ -108,7 +108,8 @@ class CertValidatingHTTPSConnection(http_client.HTTPConnection):
             # we conditionally add it here.
             kwargs['strict'] = strict
 
-        http_client.HTTPConnection.__init__(self, host=host, port=port, **kwargs)
+        http_client.HTTPSConnection.__init__(self, host=host, port=port,
+                            key_file=key_file, cert_file=cert_file, **kwargs)
         self.key_file = key_file
         self.cert_file = cert_file
         self.ca_certs = ca_certs


### PR DESCRIPTION
… is not enough to get an HTTPSConnection. now works on GAE. Please consider subclassing HTTPSConnection in more parts of this file.

This answers a handful of forum posts where people were not able to talk to AWS from Google App Engine, across various versions. I assume there were more errors in other domains, and don't have the knowledge or resources to unit-test the rest of the object in a state that subclasses HTTPSConnection. I hope someone out there does. I was using python 2.7.