### PR TITLE
Add explanation of tags parameter format to RDS2 documentation.

### DIFF
--- a/boto/rds2/layer1.py
+++ b/boto/rds2/layer1.py
@@ -192,6 +192,8 @@ class RDSConnection(AWSQueryConnection):
 
         :type tags: list
         :param tags: The tags to be assigned to the Amazon RDS resource.
+            Tags must be passed as tuples in the form
+            [('key1', 'valueForKey1'), ('key2', 'valueForKey2')]
 
         """
         params = {'ResourceName': resource_name, }
@@ -301,8 +303,8 @@ class RDSConnection(AWSQueryConnection):
         Example: `my-db-snapshot`
 
         :type tags: list
-        :param tags: A list of tags.
-
+        :param tags: A list of tags. Tags must be passed as tuples in the form
+            [('key1', 'valueForKey1'), ('key2', 'valueForKey2')]
         """
         params = {
             'SourceDBSnapshotIdentifier': source_db_snapshot_identifier,
@@ -645,7 +647,8 @@ class RDSConnection(AWSQueryConnection):
             has not been set, the DB instance will be private.
 
         :type tags: list
-        :param tags: A list of tags.
+        :param tags: A list of tags. Tags must be passed as tuples in the form
+            [('key1', 'valueForKey1'), ('key2', 'valueForKey2')]
 
         """
         params = {
@@ -799,7 +802,8 @@ class RDSConnection(AWSQueryConnection):
             has not been set, the DB instance will be private.
 
         :type tags: list
-        :param tags: A list of tags.
+        :param tags: A list of tags. Tags must be passed as tuples in the form
+            [('key1', 'valueForKey1'), ('key2', 'valueForKey2')]
 
         """
         params = {
@@ -874,7 +878,8 @@ class RDSConnection(AWSQueryConnection):
         :param description: The description for the DB parameter group.
 
         :type tags: list
-        :param tags: A list of tags.
+        :param tags: A list of tags. Tags must be passed as tuples in the form
+            [('key1', 'valueForKey1'), ('key2', 'valueForKey2')]
 
         """
         params = {
@@ -918,7 +923,8 @@ class RDSConnection(AWSQueryConnection):
             security group.
 
         :type tags: list
-        :param tags: A list of tags.
+        :param tags: A list of tags. Tags must be passed as tuples in the form
+            [('key1', 'valueForKey1'), ('key2', 'valueForKey2')]
 
         """
         params = {
@@ -967,7 +973,8 @@ class RDSConnection(AWSQueryConnection):
         + Cannot end with a hyphen or contain two consecutive hyphens
 
         :type tags: list
-        :param tags: A list of tags.
+        :param tags: A list of tags. Tags must be passed as tuples in the form
+            [('key1', 'valueForKey1'), ('key2', 'valueForKey2')]
 
         """
         params = {
@@ -1007,7 +1014,8 @@ class RDSConnection(AWSQueryConnection):
         :param subnet_ids: The EC2 Subnet IDs for the DB subnet group.
 
         :type tags: list
-        :param tags: A list of tags into tuples.
+        :param tags: A list of tags. Tags must be passed as tuples in the form
+            [('key1', 'valueForKey1'), ('key2', 'valueForKey2')]
 
         """
         params = {
@@ -1106,7 +1114,8 @@ class RDSConnection(AWSQueryConnection):
             active it.
 
         :type tags: list
-        :param tags: A list of tags.
+        :param tags: A list of tags. Tags must be passed as tuples in the form
+            [('key1', 'valueForKey1'), ('key2', 'valueForKey2')]
 
         """
         params = {
@@ -1168,7 +1177,8 @@ class RDSConnection(AWSQueryConnection):
         :param option_group_description: The description of the option group.
 
         :type tags: list
-        :param tags: A list of tags.
+        :param tags: A list of tags. Tags must be passed as tuples in the form
+            [('key1', 'valueForKey1'), ('key2', 'valueForKey2')]
 
         """
         params = {
@@ -3109,7 +3119,8 @@ class RDSConnection(AWSQueryConnection):
         Default: `1`
 
         :type tags: list
-        :param tags: A list of tags.
+        :param tags: A list of tags. Tags must be passed as tuples in the form
+            [('key1', 'valueForKey1'), ('key2', 'valueForKey2')]
 
         """
         params = {
@@ -3438,7 +3449,8 @@ class RDSConnection(AWSQueryConnection):
             DB instance
 
         :type tags: list
-        :param tags: A list of tags.
+        :param tags: A list of tags. Tags must be passed as tuples in the form
+            [('key1', 'valueForKey1'), ('key2', 'valueForKey2')]
 
         """
         params = {
@@ -3646,7 +3658,8 @@ class RDSConnection(AWSQueryConnection):
             DB instance
 
         :type tags: list
-        :param tags: A list of tags.
+        :param tags: A list of tags. Tags must be passed as tuples in the form
+            [('key1', 'valueForKey1'), ('key2', 'valueForKey2')]
 
         """
         params = {


### PR DESCRIPTION
The `tags` parameter used in several places in the `rds` module is undocumented except to say "list of tags." This PR explains the expected format of the parameter in the docstring.