### PR TITLE
Fix key.set_contents_from_file() if fp.name is int

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1241,7 +1241,7 @@ class Key(object):
                 headers[provider.storage_class_header] = self.storage_class
                 # TODO - What if provider doesn't support reduced reduncancy?
                 # What if different providers provide different classes?
-        if hasattr(fp, 'name'):
+        if hasattr(fp, 'name') and not isinstance(fp.name, int):
             self.path = fp.name
         if self.bucket is not None:
             if not md5 and provider.supports_chunked_transfer():


### PR DESCRIPTION
set_contents_from_file uses fp.name as a path if it exists.

However, fp.name may be a file descriptor (an integer), which is not suitable
as a path, and leads to an error when guess_type is called.

See https://docs.python.org/3/library/io.html#io.FileIO