### PR TITLE
Adds __enter__ and __exit__ methods to AWSAuthConnection

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -574,6 +574,12 @@ class AWSAuthConnection(object):
     def __repr__(self):
         return '%s:%s' % (self.__class__.__name__, self.host)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
     def _required_auth_capability(self):
         return []
 

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -203,6 +203,15 @@ class TestAWSAuthConnection(unittest.TestCase):
         conn.set_host_header(request)
         self.assertEqual(request.headers['Host'], 'testhost:8773')
 
+    def test_connection_enter_exit(self):
+        with AWSAuthConnection(
+            'mockservice.cc-zone-1.amazonaws.com',
+            aws_access_key_id='access_key',
+            aws_secret_access_key='secret',
+            suppress_consec_slashes=False
+        ) as conn:
+            pass
+
 
 class V4AuthConnection(AWSAuthConnection):
     def __init__(self, host, aws_access_key_id, aws_secret_access_key, port=443):


### PR DESCRIPTION
This allows users to use connections like this:
```python
import boto.ec2

with boto.ec2.connect_to_region('us-west-2',
                                aws_access_key_id=<AWS_ACCESS_KEY_ID>,
                                aws_secret_access_key=<AWS_SECRET_ACCESS_KEY>) as conn:
    conn.do_some_stuff()
```
and the connection will be automatically closed for them.