### PR TITLE
WebsiteConfiguration with complex RoutingRules need fixes

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -41,7 +41,6 @@ from boto.s3.tagging import Tags
 from boto.s3.cors import CORSConfiguration
 from boto.s3.bucketlogging import BucketLogging
 from boto.s3 import website
-import boto.jsonresponse
 import boto.utils
 import xml.sax
 import xml.sax.saxutils
@@ -1517,9 +1516,7 @@ class Bucket(object):
         """
 
         body = self.get_website_configuration_xml(headers=headers)
-        e = boto.jsonresponse.Element()
-        h = boto.jsonresponse.XmlHandler(e, None)
-        h.parse(body)
+        e = website.WebsiteConfiguration.xml_to_dict(body)
         return e, body
 
     def get_website_configuration_xml(self, headers=None):

--- a/boto/s3/website.py
+++ b/boto/s3/website.py
@@ -20,6 +20,9 @@
 # IN THE SOFTWARE.
 #
 
+from boto.jsonresponse import Element
+from boto.jsonresponse import XmlHandler
+
 def tag(key, value):
     start = '<%s>' % key
     end = '</%s>' % key
@@ -88,6 +91,15 @@ class WebsiteConfiguration(object):
         parts.append('</WebsiteConfiguration>')
         return ''.join(parts)
 
+    def to_dict(self):
+        return WebsiteConfiguration.xml_to_dict(self.to_xml())
+
+    @staticmethod
+    def xml_to_dict(xml):
+        e = Element(list_marker=('RoutingRules',), item_marker=('RoutingRule', ))
+        h = XmlHandler(e, None)
+        h.parse(xml)
+        return e
 
 class _XMLKeyValue(object):
     def __init__(self, translator, container=None):


### PR DESCRIPTION
As noted in issue #3108, the dict conversion of RoutingRules does not correctly output cases with multiple RoutingRule entries in RoutingRules.

As part of tracing this, I added many more tests (both unit and integration) for more complex RoutingRules.

Fixes: #3108 
Signed-off-by: Robin H. Johnson robbat2@gentoo.org
