### PR TITLE
Fix misnamed Stack.stack_name_reason attribute

### DIFF
--- a/boto/cloudformation/stack.py
+++ b/boto/cloudformation/stack.py
@@ -16,8 +16,8 @@ class Stack(object):
         self.tags = []
         self.stack_id = None
         self.stack_status = None
+        self.stack_status_reason = None
         self.stack_name = None
-        self.stack_name_reason = None
         self.timeout_in_minutes = None
 
     def startElement(self, name, attrs, connection):

--- a/tests/unit/cloudformation/test_connection.py
+++ b/tests/unit/cloudformation/test_connection.py
@@ -444,7 +444,7 @@ class TestCloudFormationDescribeStacks(CloudFormationConnectionBase):
         self.assertEqual(stack.stack_id, 'arn:aws:cfn:us-east-1:1:stack')
         self.assertEqual(stack.stack_status, 'CREATE_COMPLETE')
         self.assertEqual(stack.stack_name, 'MyStack')
-        self.assertEqual(stack.stack_name_reason, None)
+        self.assertEqual(stack.stack_status_reason, '')
         self.assertEqual(stack.timeout_in_minutes, None)
 
         self.assertEqual(len(stack.outputs), 1)


### PR DESCRIPTION
Rename this attribute to `stack_status_reason`.

Fixes #3227.