### PR TITLE
py3 compatibility on bin scripts

### DIFF
--- a/bin/dynamodb_dump
+++ b/bin/dynamodb_dump
@@ -6,6 +6,7 @@ import os
 
 import boto
 from boto.compat import json
+from boto.compat import six
 
 
 DESCRIPTION = """Dump the contents of one or more DynamoDB tables to the local filesystem.
@@ -39,7 +40,7 @@ def dump_table(table, out_dir):
         for item in table.scan():
             # JSON can't serialize sets -- convert those to lists.
             data = {}
-            for k, v in item.iteritems():
+            for k, v in six.iteritems(item):
                 if isinstance(v, (set, frozenset)):
                     data[k] = list(v)
                 else:

--- a/bin/dynamodb_load
+++ b/bin/dynamodb_load
@@ -5,6 +5,7 @@ import os
 
 import boto
 from boto.compat import json
+from boto.compat import six
 from boto.dynamodb.schema import Schema
 
 
@@ -61,7 +62,7 @@ def load_table(table, in_fd):
     for i in _json_iterload(in_fd):
         # Convert lists back to sets.
         data = {}
-        for k, v in i.iteritems():
+        for k, v in six.iteritems(i):
             if isinstance(v, list):
                 data[k] = set(v)
             else:

--- a/bin/elbadmin
+++ b/bin/elbadmin
@@ -113,6 +113,7 @@ def get(elb, name):
 
         # Make map of all instance Id's to Name tags
         import boto
+        from boto.compat.six import iteritems
         if not options.region:
             ec2 = boto.connect_ec2()
         else:
@@ -127,7 +128,7 @@ def get(elb, name):
             if i.id in instances:
                 names[i.id] = i.tags.get('Name', '')
 
-        name_column_width = max([4] + [len(v) for k,v in names.iteritems()]) + 2
+        name_column_width = max([4] + [len(v) for k,v in iteritems(names)]) + 2
 
         print "Instances"
         print "---------"


### PR DESCRIPTION
In `bin/**` scripts, fix Python versions compatibility just like other boto's scripts.

This fix covers to #3230