### PR TITLE
SNS: implemented get_subscription_attributes and set_subscription_attributes

### DIFF
--- a/boto/sns/connection.py
+++ b/boto/sns/connection.py
@@ -751,6 +751,49 @@ class SNSConnection(AWSQueryConnection):
         return self._make_request(action='GetEndpointAttributes',
                                   params=params)
 
+    def get_subscription_attributes(self, subscription_arn):
+        """
+        The `SetSubscriptionAttributes` action returns all of the
+        properties of a subscription.
+
+        :type subscription_arn: string
+        :param subscription_arn: The ARN of the subscription whose properties you want to get.
+        """
+        params = {'SubscriptionArn': subscription_arn}
+        return self._make_request(action='GetSubscriptionAttributes',
+                                  params=params)
+
+    def set_subscription_attributes(self, subscription_arn, attribute_name, attribute_value):
+        """
+        The `SetSubscriptionAttributes` action Allows a subscription
+        owner to set an attribute of the topic to a new value.
+
+        :type subscription_arn: string
+        :param subscription_arn: The ARN of the subscription to modify.
+
+        :type attribute_name: string
+        :param attribute_name: The name of the attribute you want to set.
+            Only a subset of the subscriptions attributes are mutable.  Valid values:
+
+
+        + `DeliveryPolicy` (attribute_value must be a dictionary)
+
+        + `RawMessageDelivery` (attribute_value must be a boolean)
+
+        :type attribute_value: dict or bool
+        :param attribute_value: The new value for the attribute. For `DeliveryPolicy`
+            it is a dict for, `RawMessageDelivery` it's a bool.
+        """
+        if attribute_name == 'RawMessageDelivery' and not isinstance(attribute_value, bool):
+            raise TypeError("'attribute_value' must be boolean type for 'RawMessageDelivery' attribute value")
+        params = {
+            'AttributeName': attribute_name,
+            'SubscriptionArn': subscription_arn,
+            'AttributeValue': json.dumps(attribute_value)
+        }
+        return self._make_request(action='SetSubscriptionAttributes',
+                                  params=params)
+
     def _make_request(self, action, params, path='/', verb='GET'):
         params['ContentType'] = 'JSON'
         response = self.make_request(action=action, verb=verb,

--- a/tests/unit/sns/test_connection.py
+++ b/tests/unit/sns/test_connection.py
@@ -276,6 +276,37 @@ class TestSNSConnection(AWSMockServiceTestCase):
             'MessageAttributes.entry.2.Value.StringValue': 'Bob',
         }, ignore_params_values=['Version', 'ContentType'])
 
+    def test_get_subscription_attributes(self):
+        self.set_http_response(status_code=200)
+
+        self.service_connection.get_subscription_attributes(subscription_arn='test_arn')
+        self.assert_request_parameters({
+            'Action': 'GetSubscriptionAttributes',
+            'SubscriptionArn': 'test_arn'
+        }, ignore_params_values=['ContentType', 'Version'])
+
+    def test_set_subscription_delivery_policy(self):
+        self.set_http_response(status_code=200)
+        self.service_connection.set_subscription_attributes(
+            subscription_arn='test_arn',
+            attribute_name='DeliveryPolicy',
+            attribute_value={"healthyRetryPolicy": {"numRetries": 5}}
+        )
+        self.assert_request_parameters({
+            'Action': 'SetSubscriptionAttributes',
+            'SubscriptionArn': 'test_arn',
+            'AttributeName': 'DeliveryPolicy',
+            'AttributeValue': '{"healthyRetryPolicy": {"numRetries": 5}}'
+        }, ignore_params_values=['ContentType', 'Version'])
+
+    def test_set_subscription_incorrect_params(self):
+        with self.assertRaises(TypeError):
+            self.service_connection.set_subscription_attributes(
+                subscription_arn='test_arn',
+                attribute_name='RawMessageDelivery',
+                attribute_value='incorrect_type'
+            )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added two new APIs to the SNS module. get and set subscription attributes as well as new unit tests for these functions.