### PR TITLE
handle 'Content-Length': 0 header case

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -244,7 +244,7 @@ class HmacAuthV3HTTPHandler(AuthHandler, HmacKeys):
         them into a string, separated by newlines.
         """
         l = sorted(['%s:%s' % (n.lower().strip(),
-                    headers_to_sign[n].strip()) for n in headers_to_sign])
+                    str(headers_to_sign[n]).strip()) for n in headers_to_sign])
         return '\n'.join(l)
 
     def string_to_sign(self, http_request):


### PR DESCRIPTION
Hi. I am getting the exception 
AttributeError: 'int' object has no attribute 'strip'
on boto.connection.HTTPRequest objects like this:

method:(GET) protocol:(https) host(ulogs.s3.cn-north-1.amazonaws.com.cn) port(443) path(/?prefix=logs%2Fhp.event.user%2F2015%2F06%2F19%2F) params({u'prefix': u'logs/hp.event.user/2015/06/19/'}) headers({'x-amz-content-sha256': '...', 'Content-Length': 0, 'User-Agent': 'Boto/2.32.1 Python/2.7.3 Linux/3.18.13-031813-generic', 'Host': 'ulogs.s3.cn-north-1.amazonaws.com.cn', 'X-Amz-Date': '20150619T083940Z', 'Authorization': 'AWS4-HMAC-SHA256 Credential=..../20150619/cn-north-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=....'}) body()
