### PR TITLE
support IPV6 addresses when creating connections

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -726,7 +726,7 @@ class AWSAuthConnection(object):
 
         # Make sure the host is really just the host, not including
         # the port number
-        host = host.split(':', 1)[0]
+        host = boto.utils.parse_host(host)
 
         http_connection_kwargs = self.http_connection_kwargs.copy()
 

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -1056,7 +1056,7 @@ def host_is_ipv6(hostname):
     Detect (naively) if the hostname is an IPV6 host.
     Return a boolean.
     """
-    # empty strins or anything that is not a string is automatically not an
+    # empty strings or anything that is not a string is automatically not an
     # IPV6 address
     if not hostname or not isinstance(hostname, str):
         return False

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -1049,3 +1049,41 @@ class RequestHook(object):
     """
     def handle_request_data(self, request, response, error=False):
         pass
+
+
+def host_is_ipv6(hostname):
+    """
+    Detect (naively) if the hostname is an IPV6 host.
+    Return a boolean.
+    """
+    # empty strins or anything that is not a string is automatically not an
+    # IPV6 address
+    if not hostname or not isinstance(hostname, str):
+        return False
+
+    if hostname.startswith('['):
+        return True
+
+    if len(hostname.split(':')) > 2:
+        return True
+
+    # Anything else that doesn't start with brackets or doesn't have more than
+    # one ':' should not be an IPV6 address. This is very naive but the rest of
+    # the connection chain should error accordingly for typos or ill formed
+    # addresses
+    return False
+
+
+def parse_host(hostname):
+    """
+    Given a hostname that may have a port name, ensure that the port is trimmed
+    returning only the host, including hostnames that are IPV6 and may include
+    brackets.
+    """
+    # ensure that hostname does not have any whitespaces
+    hostname = hostname.strip()
+
+    if host_is_ipv6(hostname):
+        return hostname.split(']:', 1)[0].strip('[]')
+    else:
+        return hostname.split(':', 1)[0]

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -317,5 +317,56 @@ class TestStringToDatetimeParsing(unittest.TestCase):
         self.assertEqual(6, result.minute)
 
 
+class TestHostIsIPV6(unittest.TestCase):
+
+    def test_is_ipv6_no_brackets(self):
+        hostname = 'bf1d:cb48:4513:d1f1:efdd:b290:9ff9:64be'
+        result = boto.utils.host_is_ipv6(hostname)
+        self.assertTrue(result)
+
+    def test_is_ipv6_with_brackets(self):
+        hostname = '[bf1d:cb48:4513:d1f1:efdd:b290:9ff9:64be]'
+        result = boto.utils.host_is_ipv6(hostname)
+        self.assertTrue(result)
+
+    def test_is_ipv6_with_brackets_and_port(self):
+        hostname = '[bf1d:cb48:4513:d1f1:efdd:b290:9ff9:64be]:8080'
+        result = boto.utils.host_is_ipv6(hostname)
+        self.assertTrue(result)
+
+    def test_is_ipv6_no_brackets_abbreviated(self):
+        hostname = 'bf1d:cb48:4513::'
+        result = boto.utils.host_is_ipv6(hostname)
+        self.assertTrue(result)
+
+    def test_is_ipv6_with_brackets_abbreviated(self):
+        hostname = '[bf1d:cb48:4513::'
+        result = boto.utils.host_is_ipv6(hostname)
+        self.assertTrue(result)
+
+    def test_is_ipv6_with_brackets_and_port_abbreviated(self):
+        hostname = '[bf1d:cb48:4513::]:8080'
+        result = boto.utils.host_is_ipv6(hostname)
+        self.assertTrue(result)
+
+    def test_empty_string(self):
+        result = boto.utils.host_is_ipv6('')
+        self.assertFalse(result)
+
+    def test_not_of_string_type(self):
+        hostnames = [None, 0, False, [], {}]
+        for h in hostnames:
+            result = boto.utils.host_is_ipv6(h)
+            self.assertFalse(result)
+
+    def test_ipv4_no_port(self):
+        result = boto.utils.host_is_ipv6('192.168.1.1')
+        self.assertFalse(result)
+
+    def test_ipv4_with_port(self):
+        result = boto.utils.host_is_ipv6('192.168.1.1:8080')
+        self.assertFalse(result)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -367,6 +367,51 @@ class TestHostIsIPV6(unittest.TestCase):
         result = boto.utils.host_is_ipv6('192.168.1.1:8080')
         self.assertFalse(result)
 
+    def test_hostnames_are_not_ipv6_with_port(self):
+        result = boto.utils.host_is_ipv6('example.org:8080')
+        self.assertFalse(result)
+
+    def test_hostnames_are_not_ipv6_without_port(self):
+        result = boto.utils.host_is_ipv6('example.org')
+        self.assertFalse(result)
+
+
+class TestParseHost(unittest.TestCase):
+
+    def test_parses_ipv6_hosts_no_brackets(self):
+        host = 'bf1d:cb48:4513:d1f1:efdd:b290:9ff9:64be'
+        result = boto.utils.parse_host(host)
+        self.assertEquals(result, host)
+
+    def test_parses_ipv6_hosts_with_brackets_stripping_them(self):
+        host = '[bf1d:cb48:4513:d1f1:efdd:b290:9ff9:64be]'
+        result = boto.utils.parse_host(host)
+        self.assertEquals(result, 'bf1d:cb48:4513:d1f1:efdd:b290:9ff9:64be')
+
+    def test_parses_ipv6_hosts_with_brackets_and_port(self):
+        host = '[bf1d:cb48:4513:d1f1:efdd:b290:9ff9:64be]:8080'
+        result = boto.utils.parse_host(host)
+        self.assertEquals(result, 'bf1d:cb48:4513:d1f1:efdd:b290:9ff9:64be')
+
+    def test_parses_ipv4_hosts(self):
+        host = '10.0.1.1'
+        result = boto.utils.parse_host(host)
+        self.assertEquals(result, host)
+
+    def test_parses_ipv4_hosts_with_port(self):
+        host = '192.168.168.200:8080'
+        result = boto.utils.parse_host(host)
+        self.assertEquals(result, '192.168.168.200')
+
+    def test_parses_hostnames_with_port(self):
+        host = 'example.org:8080'
+        result = boto.utils.parse_host(host)
+        self.assertEquals(result, 'example.org')
+
+    def test_parses_hostnames_without_port(self):
+        host = 'example.org'
+        result = boto.utils.parse_host(host)
+        self.assertEquals(result, host)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes issue #3232 by properly detecting the different variations of IPV6 addresses (with ports and brackets, just brackets, and no brackets).

The thorough test cases ensure that backwards compatibility is kept (IPV4 hosts will work just as before).

Since there is a chance the detection code will be needed for other parts of the code, they were split out into `boto/utils.py`

For some reason I couldn't get pypy tests started, but everything else passed with tox (2.6, 2.7, 3.3, and 3.4)