### PR TITLE
fix the bug of 403 InvalidSignatureException when there are LWS in x-amz-archive-description

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -326,6 +326,14 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         headers_to_sign = {'Host': host_header_value}
         for name, value in http_request.headers.items():
             lname = name.lower()
+
+            # if the description contain LWS (linear white spaces),
+            # AWS will convert it to a single space before calculate signature
+            # this will lead to 403 InvalidSignatureException
+            # it's better not to include description in the signing list
+            if lname == 'x-amz-archive-description':
+                continue
+
             if lname.startswith('x-amz'):
                 if isinstance(value, bytes):
                     value = value.decode('utf-8')


### PR DESCRIPTION
If the description contain LWS (linear white spaces),
AWS will convert it to a single space before calculate signature
This will lead to 403 InvalidSignatureException.
It's better not to include description in the signing list