### PR TITLE
fix the bug 403 SignatureDoesNotMatch when the key name is ~

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -574,6 +574,8 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         unquoted = urllib.parse.unquote(path.path)
         # Requote, this time addressing all characters.
         encoded = urllib.parse.quote(unquoted)
+        # %7E -> ~ (convert %7E back to ~ to fix key name == ~)
+        encoded = encoded.replace('%7E', '~')
         return encoded
 
     def canonical_query_string(self, http_request):


### PR DESCRIPTION
If I want to upload a file to a S3 key with name "~",
I'll always get 403 SignatureDoesNotMatch

<pre><code>
conn = boto.s3.connection.S3Connection(**params)
bucket_obj = conn.get_bucket('test_bucket')
key_obj = boto.s3.key.Key(bucket_obj)
key_obj.key = '~'
key_obj.set_contents_from_filename('./test_file')
</code></pre>