### PR TITLE
use boto.config.getint() for max_retry_delay

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -920,7 +920,7 @@ class AWSAuthConnection(object):
         while i <= num_retries:
             # Use binary exponential backoff to desynchronize client requests.
             next_sleep = min(random.random() * (2 ** i),
-                             boto.config.get('Boto', 'max_retry_delay', 60))
+                             config.getint('Boto', 'max_retry_delay', 60))
             try:
                 # we now re-sign each request before it is retried
                 boto.log.debug('Token: %s' % self.provider.security_token)

--- a/boto/dynamodb/layer1.py
+++ b/boto/dynamodb/layer1.py
@@ -174,7 +174,7 @@ class Layer1(AWSAuthConnection):
             next_sleep = 0
         else:
             next_sleep = min(0.05 * (2 ** i),
-                             boto.config.get('Boto', 'max_retry_delay', 60))
+                             boto.config.getint('Boto', 'max_retry_delay', 60))
         return next_sleep
 
     def list_tables(self, limit=None, start_table=None):

--- a/boto/dynamodb2/layer1.py
+++ b/boto/dynamodb2/layer1.py
@@ -2900,5 +2900,5 @@ class DynamoDBConnection(AWSQueryConnection):
             next_sleep = 0
         else:
             next_sleep = min(0.05 * (2 ** i),
-                             boto.config.get('Boto', 'max_retry_delay', 60))
+                             boto.config.getint('Boto', 'max_retry_delay', 60))
         return next_sleep

--- a/boto/route53/connection.py
+++ b/boto/route53/connection.py
@@ -600,8 +600,10 @@ class Route53Connection(AWSAuthConnection):
                     error,
                     i
                 )
-                next_sleep = min(random.random() * (2 ** i),
-                                 boto.config.get('Boto', 'max_retry_delay', 60))
+                next_sleep = min(
+                    random.random() * (2 ** i),
+                    boto.config.getint('Boto', 'max_retry_delay', 60)
+                )
                 i += 1
                 status = (msg, i, next_sleep)
 

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -225,7 +225,7 @@ def retry_url(url, retry_on_404=True, num_retries=10, timeout=None):
         # If not on the last iteration of the loop then sleep.
         if i + 1 != num_retries:
             time.sleep(min(2 ** i,
-                           boto.config.get('Boto', 'max_retry_delay', 60)))
+                           boto.config.getint('Boto', 'max_retry_delay', 60)))
     boto.log.error('Unable to read instance data, giving up')
     return ''
 
@@ -313,7 +313,7 @@ class LazyLoadMetadata(dict):
                 if i + 1 != self._num_retries:
                     next_sleep = min(
                         random.random() * 2 ** i,
-                        boto.config.get('Boto', 'max_retry_delay', 60))
+                        boto.config.getint('Boto', 'max_retry_delay', 60))
                     time.sleep(next_sleep)
             else:
                 boto.log.error('Unable to read meta data, giving up')


### PR DESCRIPTION
The `max_retry_delay` config setting is used within calls to `min()`, e.g.:

```time.sleep(min(2 ** i, boto.config.get('Boto', 'max_retry_delay', 60)))```

When `max_retry_delay` is set in the config file, the *string* value returned by `boto.config.get()` will never be less than the other integer value supplied (`2 ** i` in this case) and will never be used. So, it is impossible to set the `max_retry_delay` value via config file right now.

This replaces `boto.config.get()` with `boto.config.getint()`.