### PR TITLE
Fix ECS connect_to_region()

### DIFF
--- a/boto/ec2containerservice/__init__.py
+++ b/boto/ec2containerservice/__init__.py
@@ -20,7 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import get_regions
+from .layer1 import EC2ContainerServiceConnection
 
 
 def regions():
@@ -30,8 +31,8 @@ def regions():
     :rtype: list
     :return: A list of :class:`boto.regioninfo.RegionInfo`
     """
-    from boto.ec2containerservice import EC2ContainerServiceConnection
-    return get_regions('', connection_cls=EC2ContainerServiceConnection)
+    return get_regions('ec2containerservice',
+                       connection_cls=EC2ContainerServiceConnection)
 
 
 def connect_to_region(region_name, **kw_params):

--- a/boto/endpoints.json
+++ b/boto/endpoints.json
@@ -155,7 +155,11 @@
         "eu-central-1": "ec2.eu-central-1.amazonaws.com"
     },
     "ec2containerservice": {
-        "us-east-1": "ecs.us-east-1.amazonaws.com"
+        "us-east-1": "ecs.us-east-1.amazonaws.com",
+        "us-west-2": "ecs.us-west-2.amazonaws.com",
+        "eu-west-1": "ecs.eu-west-1.amazonaws.com",
+        "ap-northeast-1": "ecs.ap-northeast-1.amazonaws.com",
+        "ap-southeast-2": "ecs.ap-southeast-2.amazonaws.com"
     },
     "elasticache": {
         "ap-northeast-1": "elasticache.ap-northeast-1.amazonaws.com",

--- a/tests/unit/ec2containerservice/test_connection.py
+++ b/tests/unit/ec2containerservice/test_connection.py
@@ -20,23 +20,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-from boto.regioninfo import get_regions
+from tests.unit import unittest
+
+import boto.ec2containerservice
+from boto.ec2containerservice.layer1 import EC2ContainerServiceConnection
 
 
-def regions():
-    """
-    Get all available regions for the Amazon EC2 Container Service.
+class TestConnectToRegion(unittest.TestCase):
 
-    :rtype: list
-    :return: A list of :class:`boto.regioninfo.RegionInfo`
-    """
-    from boto.ec2containerservice.layer1 import EC2ContainerServiceConnection
-    return get_regions('ec2containerservice',
-                       connection_cls=EC2ContainerServiceConnection)
-
-
-def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    def test_aws_region(self):
+        ecs = boto.ec2containerservice.connect_to_region('us-east-1')
+        self.assertIsInstance(ecs, EC2ContainerServiceConnection)


### PR DESCRIPTION
This pulls in https://github.com/boto/boto/pull/3143 and adds a test, and makes the implementation consistent with other services connect_to_region() functions.

cc @kyleknap @mtdowling