### PR TITLE
Add EUCentral1 (Frankfurt) to S3 Location

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -138,7 +138,8 @@ class ProtocolIndependentOrdinaryCallingFormat(OrdinaryCallingFormat):
 class Location(object):
 
     DEFAULT = ''  # US Classic Region
-    EU = 'EU'
+    EU = 'EU'  # Ireland
+    EUCentral1 = 'eu-central-1'  # Frankfurt
     USWest = 'us-west-1'
     USWest2 = 'us-west-2'
     SAEast = 'sa-east-1'

--- a/docs/source/s3_tut.rst
+++ b/docs/source/s3_tut.rst
@@ -81,6 +81,7 @@ boto.s3.connection module, like this::
     APSoutheast2
     DEFAULT
     EU
+    EUCentral1
     SAEast
     USWest
     USWest2

--- a/tests/integration/s3/test_connect_to_region.py
+++ b/tests/integration/s3/test_connect_to_region.py
@@ -57,6 +57,11 @@ class S3SpecifyHost(unittest.TestCase):
         self.assertEquals('s3.amazonaws.com', connection.host)
         self.assertIsInstance(connection, S3Connection)
 
+    def testSuccessWithDefaultEUCentral1(self):
+        connection = connect_to_region('eu-central-1')
+        self.assertEquals('s3.eu-central-1.amazonaws.com', connection.host)
+        self.assertIsInstance(connection, S3Connection)
+
     def testDefaultWithInvalidHost(self):
         connect_args = dict({'host':''})
         connection = connect_to_region('us-west-2', **connect_args)

--- a/tests/unit/s3/test_bucket.py
+++ b/tests/unit/s3/test_bucket.py
@@ -6,7 +6,7 @@ from tests.unit import unittest
 from tests.unit import AWSMockServiceTestCase
 
 from boto.exception import BotoClientError
-from boto.s3.connection import S3Connection
+from boto.s3.connection import Location, S3Connection
 from boto.s3.bucket import Bucket
 from boto.s3.deletemarker import DeleteMarker
 from boto.s3.key import Key
@@ -24,6 +24,14 @@ class TestS3Bucket(AWSMockServiceTestCase):
         self.set_http_response(status_code=200)
         bucket = self.service_connection.create_bucket('mybucket_create')
         self.assertEqual(bucket.name, 'mybucket_create')
+
+    def test_bucket_create_eu_central_1_location(self):
+        self.set_http_response(status_code=200)
+        bucket = self.service_connection.create_bucket(
+            'eu_central_1_bucket',
+            location=Location.EUCentral1
+        )
+        self.assertEqual(bucket.name, 'eu_central_1_bucket')
 
     def test_bucket_constructor(self):
         self.set_http_response(status_code=200)


### PR DESCRIPTION
## Purpose
Add the EUCentral1 Region to S3 `Location`

## Changes
Updated `Location` object, S3 tutorial docs, and added a test.

Closes-issue: #3089 