### PR TITLE
Bugfix: For binary data, the message value encode and decode function…

### DIFF
--- a/boto/sqs/message.py
+++ b/boto/sqs/message.py
@@ -170,7 +170,9 @@ class Message(RawMessage):
 
     def decode(self, value):
         try:
-            value = base64.b64decode(value.encode('utf-8')).decode('utf-8')
+            value = base64.b64decode(value.encode('utf-8'))
+            if not isinstance(value, six.binary_type):
+                value = value.decode('utf-8')
         except:
             boto.log.warning('Unable to decode message')
             return value


### PR DESCRIPTION
# My testing script

c = boto.sqs.connect_to_region('us-west-2')
q = c.get_queue('test_queue')
m = Message()
data = zlib.compress('This is my first message.')
m.set_body(data)
q.write(m)
ms = q.get_messages()
if len(ms) > 0:
    zlib.decompress(ms[0].get_body()) # error


class Message(RawMessage):

    # if value is binary data, it will not be encoded with utf-8.
    # so decode also needs to check if the value is binary data or not.
    # Or else the data sent to sqs and got from sqs are not the same.

    def encode(self, value):
        if not isinstance(value, six.binary_type):
            value = value.encode('utf-8')
        return base64.b64encode(value).decode('utf-8')

    def decode(self, value):
        try:
            value = base64.b64decode(value.encode('utf-8'))
            if not isinstance(value, six.binary_type):
                value = value.decode('utf-8')
        except:
            boto.log.warning('Unable to decode message')
            return value
        return value