### PR TITLE
add cloudtrail support to us-gov-west-1 [issue #3277]

### DIFF
--- a/boto/endpoints.json
+++ b/boto/endpoints.json
@@ -77,6 +77,7 @@
         "eu-west-1": "cloudtrail.eu-west-1.amazonaws.com",
         "sa-east-1": "cloudtrail.sa-east-1.amazonaws.com",
         "us-east-1": "cloudtrail.us-east-1.amazonaws.com",
+        "us-gov-west-1": "cloudtrail.us-gov-west-1.amazonaws.com",
         "us-west-1": "cloudtrail.us-west-1.amazonaws.com",
         "us-west-2": "cloudtrail.us-west-2.amazonaws.com",
         "eu-central-1": "cloudtrail.eu-central-1.amazonaws.com"


### PR DESCRIPTION
CloudTrail has been available in GovCloud since Dec 16, 2014

Fixes issue #3277

http://aws.amazon.com/about-aws/whats-new/2014/12/16/aws-cloudtrail-is-now-available-in-the-aws-govcloud-us-region/
http://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-endpoints.html