### PR TITLE
Fix incorrect passing of session token for swf

### DIFF
--- a/boto/swf/layer1.py
+++ b/boto/swf/layer1.py
@@ -82,7 +82,8 @@ class Layer1(AWSAuthConnection):
         super(Layer1, self).__init__(self.region.endpoint,
                                    aws_access_key_id, aws_secret_access_key,
                                    is_secure, port, proxy, proxy_port,
-                                   debug, session_token, profile_name=profile_name)
+                                   debug, security_token=session_token,
+                                   profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['hmac-v4']

--- a/tests/unit/swf/test_layer1.py
+++ b/tests/unit/swf/test_layer1.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2015 Amazon.com, Inc. or its affiliates.  All Rights Reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+from tests.unit import unittest
+
+from boto.swf.layer1 import Layer1
+
+
+class TestLayer1(unittest.TestCase):
+    def test_pass_session_token_correctly(self):
+        conn = Layer1(session_token='foo')
+        self.assertEqual(conn.provider.security_token, 'foo')


### PR DESCRIPTION
The positional arguments did not match up so the session token was not passed to the ``AWSAuthConnection`` properly.

cc @jamesls @mtdowling @rayluo 