### PR TITLE
Avoiding exception in clean-up file removal

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1710,9 +1710,12 @@ class Key(object):
                                           version_id=version_id,
                                           res_download_handler=res_download_handler,
                                           response_headers=response_headers)
-        except Exception:
-            os.remove(filename)
-            raise
+        except Exception as e:
+            try:
+                os.remove(filename)
+            except Exception:
+                pass
+            raise e
         # if last_modified date was sent from s3, try to set file's timestamp
         if self.last_modified is not None:
             try:


### PR DESCRIPTION
If Key.get_contents_to_filename() fails for some reason, it tries to remove `filename` as a clean-up step, before actually raising the exception. However, if _that_ call also raises a second exception (for instance, if the open() call a few lines above fails), the latter gets raised, rather than the former.

This PR silently ignores errors in the clean-up call.
