### PR TITLE
Mentioning Boto 3 in first page of doc

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,6 +4,15 @@
 boto: A Python interface to Amazon Web Services
 ===============================================
 
+.. note::
+
+  `Boto3 <https://github.com/boto/boto3>`__, the next version of Boto, is now
+  stable and recommended for general use.  It can be used side-by-side with
+  Boto in the same project, so it is easy to start using Boto3 in your existing
+  projects as well as new projects. Going forward, API updates and all new
+  feature work will be focused on Boto3.
+
+
 An integrated interface to current and future infrastructural services
 offered by `Amazon Web Services`_.
 


### PR DESCRIPTION
We have already mentioned Boto 3 in README.rst. Now we also mention Boto 3 in the first page of doc, in order to drive adoption.