### PR TITLE
Fixing deepcopy issue - Issue #3314

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -571,6 +571,11 @@ class AWSAuthConnection(object):
             self.auth_service_name = self.AuthServiceName
         self.request_hook = None
 
+    def __deepcopy__(self, memo):
+        newObject = type(self)()
+        newObject.__dict__.update(self.__dict__)
+        return newObject
+
     def __repr__(self):
         return '%s:%s' % (self.__class__.__name__, self.host)
 


### PR DESCRIPTION
Fixing issue cannot deepcopy VPCConnection in python 2.7(.5) #3314.

Got the simple __deepcopy__  (__copy__)  from: http://stackoverflow.com/questions/1500718/what-is-the-right-way-to-override-the-copy-deepcopy-operations-on-an-object-in-p