### PR TITLE
fix skip_proxy add stripping name

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -714,7 +714,7 @@ class AWSAuthConnection(object):
         hostonly = host
         hostonly = host.split(':')[0]
 
-        for name in self.no_proxy.split(','):
+        for name in [name.strip() for name in self.no_proxy.split(',')]:
             if name and (hostonly.endswith(name) or host.endswith(name)):
                 return True
 


### PR DESCRIPTION
Useful fix for users having whitespaces between the domains specified in no_proxy variable.