### PR TITLE
Authentication Issue with Python issue #21159

### DIFF
--- a/boto/pyami/config.py
+++ b/boto/pyami/config.py
@@ -137,9 +137,9 @@ class Config(ConfigParser):
     def get_value(self, section, name, default=None):
         return self.get(section, name, default)
 
-    def get(self, section, name, default=None):
+    def get(self, section, name, default=None, **kwargs):
         try:
-            val = ConfigParser.get(self, section, name)
+            val = ConfigParser.get(self, section, name, **kwargs)
         except:
             val = default
         return val


### PR DESCRIPTION
I had a problem with the login on Ubuntu 15.10.

```
Error while configuring coast-staging: Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/sevenseconds/cli.py", line 148, in configure
    configure_account(account_name, cfg, trusted_addresses, dry_run)
  File "/usr/local/lib/python3.4/dist-packages/sevenseconds/aws.py", line 691, in configure_account
    configure_iam(account_name, dns_domain, cfg)
  File "/usr/local/lib/python3.4/dist-packages/sevenseconds/aws.py", line 407, in configure_iam
    conn = boto.iam.connect_to_region('eu-west-1')
  File "/usr/local/lib/python3.4/dist-packages/boto/iam/__init__.py", line 85, in connect_to_region
    return region.connect(**kw_params)
  File "/usr/local/lib/python3.4/dist-packages/boto/iam/__init__.py", line 43, in connect
    return self.connection_cls(host=self.endpoint, **kw_params)
  File "/usr/local/lib/python3.4/dist-packages/boto/iam/connection.py", line 73, in __init__
    profile_name=profile_name)
  File "/usr/local/lib/python3.4/dist-packages/boto/connection.py", line 1103, in __init__
    provider=provider)
  File "/usr/local/lib/python3.4/dist-packages/boto/connection.py", line 572, in __init__
    host, config, self.provider, self._required_auth_capability())
  File "/usr/local/lib/python3.4/dist-packages/boto/auth.py", line 987, in get_auth_handler
    'Check your credentials' % (len(names), str(names)))
boto.exception.NoAuthHandlerFound: No handler was ready to authenticate. 1 handlers were checked. ['HmacAuthV4Handler'] Check your credentials
```

I found the cause in the diff from https://bugs.python.org/issue21159

They make a `parser.get(section, option, raw=True, fallback=rest)`, but `parser` isn't a configparser-instance.