### PR TITLE
get_all_reservations: check kwarg with `is not None`

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -720,7 +720,7 @@ class EC2Connection(AWSQueryConnection):
         :return: A list of instances that have maintenance scheduled.
         """
         params = {}
-        if instance_ids:
+        if instance_ids is not None:
             self.build_list_params(params, instance_ids, 'InstanceId')
         if max_results:
             params['MaxResults'] = max_results


### PR DESCRIPTION
this bit us when we expected `get_all_instances` to return no instances if we passed it `instance_ids=[]`. we were surprised when it returned us all of our instances instead. :P

i know boto is currently in maintenance mode in favor of boto3, so up to you if you want to merge.

cc @justinwang189