### PR TITLE
Raise an exception for but input.  Raise an exception if someone is t…

### DIFF
--- a/boto/route53/record.py
+++ b/boto/route53/record.py
@@ -301,15 +301,20 @@ class Record(object):
 
         weight = ""
 
-        if self.identifier is not None and self.weight is not None:
-            weight = self.WRRBody % {"identifier": self.identifier,
+	if self.identifier is not None:
+		if self.weight is not None:
+            		weight = self.WRRBody % {"identifier": self.identifier,
                                      "weight": self.weight}
-        elif self.identifier is not None and self.region is not None:
-            weight = self.RRRBody % {"identifier": self.identifier,
+		elif self.region is not None:
+            		weight = self.RRRBody % {"identifier": self.identifier,
                                      "region": self.region}
-        elif self.identifier is not None and self.failover is not None:
-            weight = self.FailoverBody % {"identifier": self.identifier,
+        	elif self.failover is not None:
+            		weight = self.FailoverBody % {"identifier": self.identifier,
                                           "failover": self.failover}
+		else:
+			raise Exception('Identifier should only be set with one of weight, region or failover.');
+	elif self.weight is not None or self.region is not None or self.failover is not None:
+		raise Exception('If you choose weight, region or failover routing policy you have to specify identifier.');
 
         health_check = ""
         if self.health_check is not None:


### PR DESCRIPTION
…rying to user identifier without weight,region or failover, or opposite way failover etc. without identifier. AWS is going to return an error in this situation which is not very easy to undestand (for example refering to specifing health_check without additional filed).