### PR TITLE
Remove the artificial limit of 25 layout parameters for mechanical turk

### DIFF
--- a/boto/mturk/layoutparam.py
+++ b/boto/mturk/layoutparam.py
@@ -31,7 +31,6 @@ class LayoutParameters(object):
 
     def get_as_params(self):
         params = {}
-        assert(len(self.layoutParameters) <= 25)
         for n, layoutParameter in enumerate(self.layoutParameters):
             kv = layoutParameter.get_as_params()
             for key in kv:


### PR DESCRIPTION
This limit is articial as having more than 25 parameters does work
