### PR TITLE
Fix for listing EMR steps based on cluster_states filter

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -265,7 +265,7 @@ class EmrConnection(AWSQueryConnection):
             params['Marker'] = marker
 
         if step_states:
-            self.build_list_params(params, step_states, 'StepStateList.member')
+            self.build_list_params(params, step_states, 'StepStates.member')
 
         return self.get_object('ListSteps', params, StepSummaryList)
 

--- a/tests/unit/emr/test_connection.py
+++ b/tests/unit/emr/test_connection.py
@@ -500,8 +500,8 @@ class TestListSteps(AWSMockServiceTestCase):
         self.assert_request_parameters({
             'Action': 'ListSteps',
             'ClusterId': 'j-123',
-            'StepStateList.member.1': 'COMPLETED',
-            'StepStateList.member.2': 'FAILED',
+            'StepStates.member.1': 'COMPLETED',
+            'StepStates.member.2': 'FAILED',
             'Version': '2009-03-31'
         })
         self.assertTrue(isinstance(response, StepSummaryList))


### PR DESCRIPTION
Fixes #3389 

This patch fixes the parameter name to StepStates.member.N as required by ListSteps API [1] 

[1] - http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_ListSteps.html