### PR TITLE
fixes #3409 - RDS2 - add support for DescribeAccountAttributes API action

### DIFF
--- a/boto/rds2/layer1.py
+++ b/boto/rds2/layer1.py
@@ -58,7 +58,7 @@ class RDSConnection(AWSQueryConnection):
     more information on Amazon RDS concepts and usage scenarios, go to
     the `Amazon RDS User Guide`_.
     """
-    APIVersion = "2013-09-09"
+    APIVersion = "2014-10-31"
     DefaultRegionName = "us-east-1"
     DefaultRegionEndpoint = "rds.us-east-1.amazonaws.com"
     ResponseError = JSONResponseError
@@ -1390,6 +1390,19 @@ class RDSConnection(AWSQueryConnection):
             action='DeleteOptionGroup',
             verb='POST',
             path='/', params=params)
+
+    def describe_account_attributes(self):
+        """
+        Lists all of the attributes for a customer account. The attributes
+        include Amazon RDS quotas for the account, such as the number of DB
+        instances allowed. The description for a quota includes the quota name,
+        current usage toward that quota, and the quota's maximum value.
+        """
+        return self._make_request(
+            action='DescribeAccountAttributes',
+            verb='POST',
+            path='/', params={}
+        )
 
     def describe_db_engine_versions(self, engine=None, engine_version=None,
                                     db_parameter_group_family=None,


### PR DESCRIPTION
This fixes #3409 by adding support for the RDS [DescribeAccountAttributes](http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeAccountAttributes.html) API action.

Sample response (it's just a dict, keeping with the rest of rds2):

```
{'DescribeAccountAttributesResponse': {'DescribeAccountAttributesResult': {'AccountQuotas': [{'AccountQuotaName': 'DBInstances',
                                                                                              'Max': 40,
                                                                                              'Used': 0},
                                                                                             {'AccountQuotaName': 'ReservedDBInstances',
                                                                                              'Max': 40,
                                                                                              'Used': 0},
                                                                                             {'AccountQuotaName': 'AllocatedStorage',
                                                                                              'Max': 100000,
                                                                                              'Used': 0},
                                                                                             {'AccountQuotaName': 'DBSecurityGroups',
                                                                                              'Max': 25,
                                                                                              'Used': 0},
                                                                                             {'AccountQuotaName': 'AuthorizationsPerDBSecurityGroup',
                                                                                              'Max': 20,
                                                                                              'Used': 0},
                                                                                             {'AccountQuotaName': 'DBParameterGroups',
                                                                                              'Max': 50,
                                                                                              'Used': 0},
                                                                                             {'AccountQuotaName': 'ManualSnapshots',
                                                                                              'Max': 50,
                                                                                              'Used': 0},
                                                                                             {'AccountQuotaName': 'EventSubscriptions',
                                                                                              'Max': 20,
                                                                                              'Used': 0},
                                                                                             {'AccountQuotaName': 'DBSubnetGroups',
                                                                                              'Max': 20,
                                                                                              'Used': 2},
                                                                                             {'AccountQuotaName': 'OptionGroups',
                                                                                              'Max': 20,
                                                                                              'Used': 0},
                                                                                             {'AccountQuotaName': 'SubnetsPerDBSubnetGroup',
                                                                                              'Max': 20,
                                                                                              'Used': 4},
                                                                                             {'AccountQuotaName': 'ReadReplicasPerMaster',
                                                                                              'Max': 5,
                                                                                              'Used': 0},
                                                                                             {'AccountQuotaName': 'DBClusters',
                                                                                              'Max': 40,
                                                                                              'Used': 0},
                                                                                             {'AccountQuotaName': 'DBClusterParameterGroups',
                                                                                              'Max': 50,
                                                                                              'Used': 0}]},
                                       'ResponseMetadata': {'RequestId': 'xxxx'}}}
```