### PR TITLE
Update directconnect/exceptions.py

### DIFF
--- a/boto/directconnect/exceptions.py
+++ b/boto/directconnect/exceptions.py
@@ -19,11 +19,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
+from boto.exception import JSONResponseError
 
-
-class DirectConnectClientException(Exception):
+class DirectConnectClientException(JSONResponseError):
     pass
 
 
-class DirectConnectServerException(Exception):
+class DirectConnectServerException(JSONResponseError):
     pass


### PR DESCRIPTION
Corrected two exception types in directconnect/exceptions.py from generic Exception types to specific JSONResponseError types.

This bug was discovered when testing my code. Specifically, it was causing an exception to be raised in "layer1.py", but I was unable to catch the specific exception (DirectConnectClientException) because it wasn't inheriting the JSONResponseError base type and the error messages getting passed back were getting swallowed up.

By importing JSONResponseError from boto.exception and changing the parent class of both Exception types to JSONResponseError, other code seems to work properly again.