### PR TITLE
Don't generate auth in url for public files

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -377,7 +377,7 @@ class S3Connection(AWSAuthConnection):
     def generate_url(self, expires_in, method, bucket='', key='', headers=None,
                      query_auth=True, force_http=False, response_headers=None,
                      expires_in_absolute=False, version_id=None):
-        if self._auth_handler.capability[0] == 'hmac-v4-s3':
+        if self._auth_handler.capability[0] == 'hmac-v4-s3' and query_auth:
             # Handle the special sigv4 case
             return self.generate_url_sigv4(expires_in, method, bucket=bucket,
                 key=key, headers=headers, force_http=force_http,


### PR DESCRIPTION
Using hmac-v4-s3 authentication causes all URLs to be presigned. Actually we don't need this when generating URL for public bucket.  I have added AWS_QUERYSTRING_AUTH flag support in this scenario.