### PR TITLE
Add deprecation notice to emr methods

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -96,6 +96,10 @@ class EmrConnection(AWSQueryConnection):
 
     def describe_jobflow(self, jobflow_id):
         """
+        This method is deprecated. We recommend you use list_clusters,
+        describe_cluster, list_steps, list_instance_groups and
+        list_bootstrap_actions instead.
+
         Describes a single Elastic MapReduce job flow
 
         :type jobflow_id: str
@@ -108,6 +112,10 @@ class EmrConnection(AWSQueryConnection):
     def describe_jobflows(self, states=None, jobflow_ids=None,
                            created_after=None, created_before=None):
         """
+        This method is deprecated. We recommend you use list_clusters,
+        describe_cluster, list_steps, list_instance_groups and
+        list_bootstrap_actions instead.
+
         Retrieve all the Elastic MapReduce job flows on your account
 
         :type states: list


### PR DESCRIPTION
Updated docs to be more in-line with EMR API docs about method deprecation: http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_DescribeJobFlows.html

cc @jamesls @mtdowling @rayluo @JordonPhillips 