### PR TITLE
Fix canonical URI path quoting for S3

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -573,7 +573,7 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         # Because some quoting may have already been applied, let's back it out.
         unquoted = urllib.parse.unquote(path.path)
         # Requote, this time addressing all characters.
-        encoded = urllib.parse.quote(unquoted)
+        encoded = urllib.parse.quote(unquoted, safe="/~")
         return encoded
 
     def canonical_query_string(self, http_request):


### PR DESCRIPTION
There is currently a signature bug with paths that contain TIDLE ~.

Boto quotes the TILDE before computing the signature. [AWS](http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html) doesn't:

> Normalize URI paths according to RFC 3986 by removing redundant and relative path components. Each path segment must be URI-encoded.

In [RFC 3986](http://tools.ietf.org/html/rfc3986#section-2.3) TILDE is considered an unreserved character.

I hope it's helping.