### PR TITLE
BF(PY3): use except ... as   syntax instead of except ...,

### DIFF
--- a/bin/cfadmin
+++ b/bin/cfadmin
@@ -103,6 +103,6 @@ if __name__ == "__main__":
         cmd = help
     try:
         cmd(cf, *args)
-    except TypeError, e:
+    except TypeError as e:
         print e
         help(cf, cmd.__name__)

--- a/bin/cq
+++ b/bin/cq
@@ -65,7 +65,7 @@ def main():
     if queue_name:
         try:
             rs = [c.create_queue(queue_name)]
-        except SQSError, e:
+        except SQSError as e:
             print 'An Error Occurred:'
             print '%s: %s' % (e.status, e.reason)
             print e.body
@@ -73,7 +73,7 @@ def main():
     else:
         try:
             rs = c.get_all_queues()
-        except SQSError, e:
+        except SQSError as e:
             print 'An Error Occurred:'
             print '%s: %s' % (e.status, e.reason)
             print e.body

--- a/bin/cwutil
+++ b/bin/cwutil
@@ -135,6 +135,6 @@ if __name__ == "__main__":
         cmd = help
     try:
         cmd(*args)
-    except TypeError, e:
+    except TypeError as e:
         print e
         help(cmd.__name__)

--- a/bin/route53
+++ b/bin/route53
@@ -200,6 +200,6 @@ if __name__ == "__main__":
         cmd = help
     try:
         cmd(conn, *args)
-    except TypeError, e:
+    except TypeError as e:
         print e
         help(conn, cmd.__name__)

--- a/boto/glacier/concurrent.py
+++ b/boto/glacier/concurrent.py
@@ -237,7 +237,7 @@ class UploadWorkerThread(TransferThread):
             except self._retry_exceptions as e:
                 log.error("Exception caught uploading part number %s for "
                           "vault %s, attempt: (%s / %s), filename: %s, "
-                          "exception: %s, msg: %s",
+                          "exception: %s as msg: %s",
                           work[0], self._vault_name, i + 1, self._num_retries + 1,
                           self._filename, e.__class__, e)
                 time.sleep(self._time_between_retries)

--- a/boto/pyami/installers/ubuntu/ebs.py
+++ b/boto/pyami/installers/ubuntu/ebs.py
@@ -64,10 +64,10 @@ class Backup(ScriptBase):
             self.run("/usr/sbin/xfs_freeze -f ${mount_point}", exit_on_error = True)
             snapshot = ec2.create_snapshot('${volume_id}')
             boto.log.info("Snapshot created: %s " %  snapshot)
-        except Exception, e:
+        except Exception as e:
             self.notify(subject="${instance_id} Backup Failed", body=traceback.format_exc())
             boto.log.info("Snapshot created: ${volume_id}")
-        except Exception, e:
+        except Exception as e:
             self.notify(subject="${instance_id} Backup Failed", body=traceback.format_exc())
         finally:
             self.run("/usr/sbin/xfs_freeze -u ${mount_point}")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,7 @@ github_project_url = 'https://github.com/boto/boto/'
 try:
     release = os.environ.get('SVN_REVISION', 'HEAD')
     print release
-except Exception, e:
+except Exception as e:
     print e
 
 html_title = "boto v%s" % version

--- a/docs/source/swf_tut.rst
+++ b/docs/source/swf_tut.rst
@@ -338,7 +338,7 @@ The workers only need to know which task lists to poll.
                 try:
                     print 'working on activity from tasklist %s at %i' % (self.task_list, time.time())
                     self.activity(activity_task.get('input'))
-                except Exception, error:
+                except Exception as error:
                     self.fail(reason=str(error))
                     raise error
     

--- a/tests/fps/test.py
+++ b/tests/fps/test.py
@@ -88,7 +88,7 @@ class FPSTestCase(unittest.TestCase):
         try:
             self.fps.write_off_debt(CreditInstrumentId='foo',
                                     AdjustmentAmount=123.45)
-        except Exception, e:
+        except Exception as e:
             print e
 
     @unittest.skip('cosmetic')

--- a/tests/integration/gs/test_resumable_downloads.py
+++ b/tests/integration/gs/test_resumable_downloads.py
@@ -102,7 +102,7 @@ class ResumableDownloadTests(GSTestCase):
                 dst_fp, cb=harness.call,
                 res_download_handler=res_download_handler)
             self.fail('Did not get expected ResumableDownloadException')
-        except ResumableDownloadException, e:
+        except ResumableDownloadException as e:
             # We'll get a ResumableDownloadException at this point because
             # of CallbackTestHarness (above). Check that the tracker file was
             # created correctly.
@@ -164,7 +164,7 @@ class ResumableDownloadTests(GSTestCase):
                 dst_fp, cb=harness.call,
                 res_download_handler=res_download_handler)
             self.fail('Did not get expected OSError')
-        except OSError, e:
+        except OSError as e:
             # Ensure the error was re-raised.
             self.assertEqual(e.errno, 13)
 
@@ -228,7 +228,7 @@ class ResumableDownloadTests(GSTestCase):
                 dst_fp, cb=harness.call,
                 res_download_handler=res_download_handler)
             self.fail('Did not get expected ResumableDownloadException')
-        except ResumableDownloadException, e:
+        except ResumableDownloadException as e:
             self.assertEqual(e.disposition,
                              ResumableTransferDisposition.ABORT_CUR_PROCESS)
             # Ensure a tracker file survived.
@@ -345,7 +345,7 @@ class ResumableDownloadTests(GSTestCase):
             os.chmod(tmp_dir, 0)
             res_download_handler = ResumableDownloadHandler(
                 tracker_file_name=tracker_file_name)
-        except ResumableDownloadException, e:
+        except ResumableDownloadException as e:
             self.assertEqual(e.disposition, ResumableTransferDisposition.ABORT)
             self.assertNotEqual(
                 e.message.find('Couldn\'t write URI tracker file'), -1)

--- a/tests/integration/gs/test_resumable_uploads.py
+++ b/tests/integration/gs/test_resumable_uploads.py
@@ -120,7 +120,7 @@ class ResumableUploadTests(GSTestCase):
                 small_src_file, cb=harness.call,
                 res_upload_handler=res_upload_handler)
             self.fail('Did not get expected ResumableUploadException')
-        except ResumableUploadException, e:
+        except ResumableUploadException as e:
             # We'll get a ResumableUploadException at this point because
             # of CallbackTestHarness (above). Check that the tracker file was
             # created correctly.
@@ -185,7 +185,7 @@ class ResumableUploadTests(GSTestCase):
                 small_src_file, cb=harness.call,
                 res_upload_handler=res_upload_handler)
             self.fail('Did not get expected OSError')
-        except OSError, e:
+        except OSError as e:
             # Ensure the error was re-raised.
             self.assertEqual(e.errno, 13)
 
@@ -247,7 +247,7 @@ class ResumableUploadTests(GSTestCase):
                 larger_src_file, cb=harness.call,
                 res_upload_handler=res_upload_handler)
             self.fail('Did not get expected ResumableUploadException')
-        except ResumableUploadException, e:
+        except ResumableUploadException as e:
             self.assertEqual(e.disposition,
                              ResumableTransferDisposition.ABORT_CUR_PROCESS)
             # Ensure a tracker file survived.
@@ -351,7 +351,7 @@ class ResumableUploadTests(GSTestCase):
                 larger_src_file, cb=harness.call,
                 res_upload_handler=res_upload_handler)
             self.fail('Did not get expected ResumableUploadException')
-        except ResumableUploadException, e:
+        except ResumableUploadException as e:
             # First abort (from harness-forced failure) should be
             # ABORT_CUR_PROCESS.
             self.assertEqual(e.disposition, ResumableTransferDisposition.ABORT_CUR_PROCESS)
@@ -368,7 +368,7 @@ class ResumableUploadTests(GSTestCase):
             dst_key.set_contents_from_file(
                 largest_src_file, res_upload_handler=res_upload_handler)
             self.fail('Did not get expected ResumableUploadException')
-        except ResumableUploadException, e:
+        except ResumableUploadException as e:
             # This abort should be a hard abort (file size changing during
             # transfer).
             self.assertEqual(e.disposition, ResumableTransferDisposition.ABORT)
@@ -391,7 +391,7 @@ class ResumableUploadTests(GSTestCase):
                 test_file, cb=harness.call,
                 res_upload_handler=res_upload_handler)
             self.fail('Did not get expected ResumableUploadException')
-        except ResumableUploadException, e:
+        except ResumableUploadException as e:
             self.assertEqual(e.disposition, ResumableTransferDisposition.ABORT)
             self.assertNotEqual(
                 e.message.find('File changed during upload'), -1)
@@ -411,7 +411,7 @@ class ResumableUploadTests(GSTestCase):
                     test_file, cb=harness.call,
                     res_upload_handler=res_upload_handler)
                 return False
-            except ResumableUploadException, e:
+            except ResumableUploadException as e:
                 self.assertEqual(e.disposition, ResumableTransferDisposition.ABORT)
                 # Ensure the file size didn't change.
                 test_file.seek(0, os.SEEK_END)
@@ -422,7 +422,7 @@ class ResumableUploadTests(GSTestCase):
                 try:
                     dst_key_uri.get_key()
                     self.fail('Did not get expected InvalidUriError')
-                except InvalidUriError, e:
+                except InvalidUriError as e:
                     pass
             return True
 
@@ -477,7 +477,7 @@ class ResumableUploadTests(GSTestCase):
                 small_src_file, res_upload_handler=res_upload_handler,
                 headers={'Content-Length' : SMALL_KEY_SIZE})
             self.fail('Did not get expected ResumableUploadException')
-        except ResumableUploadException, e:
+        except ResumableUploadException as e:
             self.assertEqual(e.disposition, ResumableTransferDisposition.ABORT)
             self.assertNotEqual(
                 e.message.find('Attempt to specify Content-Length header'), -1)
@@ -543,7 +543,7 @@ class ResumableUploadTests(GSTestCase):
             os.chmod(tmp_dir, 0)
             res_upload_handler = ResumableUploadHandler(
                 tracker_file_name=tracker_file_name)
-        except ResumableUploadException, e:
+        except ResumableUploadException as e:
             self.assertEqual(e.disposition, ResumableTransferDisposition.ABORT)
             self.assertNotEqual(
                 e.message.find('Couldn\'t write URI tracker file'), -1)

--- a/tests/integration/gs/testcase.py
+++ b/tests/integration/gs/testcase.py
@@ -61,11 +61,11 @@ class GSTestCase(unittest.TestCase):
                     for k in bucket.list_versions():
                         try:
                             bucket.delete_key(k.name, generation=k.generation)
-                        except GSResponseError, e:
+                        except GSResponseError as e:
                             if e.status != 404:
                                 raise
                 bucket.delete()
-            except GSResponseError, e:
+            except GSResponseError as e:
                 if e.status != 404:
                     raise
             self._buckets.pop()

--- a/tests/integration/gs/util.py
+++ b/tests/integration/gs/util.py
@@ -70,7 +70,7 @@ def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, logger=None):
                     return f(*args, **kwargs)
                     try_one_last_time = False
                     break
-                except ExceptionToCheck, e:
+                except ExceptionToCheck as e:
                     msg = "%s, Retrying in %d seconds..." % (str(e), mdelay)
                     if logger:
                         logger.warning(msg)

--- a/tests/mturk/selenium_support.py
+++ b/tests/mturk/selenium_support.py
@@ -17,7 +17,7 @@ def has_selenium():
 		# a little trick to see if the server is responding
 		try:
 			sel.do_command('shutdown', '')
-		except Exception, e:
+		except Exception as e:
 			if not 'Server Exception' in str(e):
 				raise
 		result = True


### PR DESCRIPTION
mass BF was done via cmdline

```bash
git grep -l 'except.*, [a-z]\+:' | xargs sed -ie 's|\(except.*\), \([a-z]*:\)|\1 as \2|g'
```

I am not quite sure how those didn't pop out whenever testing was done on python3, but there you go ;-)