### PR TITLE
Fix travis CI builds for PY3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - "3.3"
   - "3.4"
   - "pypy"
+env:
+  - BOTO_CONFIG=/tmp/nowhere
 before_install:
   - sudo apt-get update
   - sudo apt-get --reinstall install -qq language-pack-en language-pack-de


### PR DESCRIPTION
Tracking issue here: https://github.com/travis-ci/travis-ci/issues/5246.
What's happening is that the global boto config on the travis CI
systems is telling boto to load a plugin that is not compatible with
python3.

In the meantime, our workaround is to set the BOTO_CONFIG to some bogus
value so we don't load the global config.

Verified we get a clean run through travis CI.