### PR TITLE
Get all unit tests passing on python3.

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -878,8 +878,8 @@ class QuerySignatureV1AuthHandler(QuerySignatureHelper, AuthHandler):
     def _calc_signature(self, params, *args):
         boto.log.debug('using _calc_signature_1')
         hmac = self._get_hmac()
-        keys = params.keys()
-        keys.sort(cmp=lambda x, y: cmp(x.lower(), y.lower()))
+        keys = list(params.keys())
+        keys.sort(key=lambda x: x.lower())
         pairs = []
         for key in keys:
             hmac.update(key.encode('utf-8'))

--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -844,7 +844,7 @@ class MTurkConnection(AWSQueryConnection):
         body = response.read()
         if self.debug == 2:
             print(body)
-        if '<Errors>' not in body:
+        if '<Errors>' not in body.decode('utf-8'):
             rs = ResultSet(marker_elems)
             h = handler.XmlHandler(rs, self)
             xml.sax.parseString(body, h)

--- a/boto/rds/__init__.py
+++ b/boto/rds/__init__.py
@@ -451,7 +451,7 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
 
         # Remove any params set to None
-        for k, v in params.items():
+        for k, v in list(params.items()):
           if v is None: del(params[k])
 
         return self.get_object('CreateDBInstance', params, DBInstance)

--- a/tests/test.py
+++ b/tests/test.py
@@ -28,52 +28,7 @@ import sys
 from nose.core import run
 
 
-# This is a whitelist of unit tests that support Python 3.
-# When porting a new module to Python 3, please update this
-# list so that its tests will run by default. See the
-# `default` target below for more information.
-# We use this instead of test attributes/tags because in
-# order to filter on tags nose must load each test - many
-# will fail to import with Python 3.
-PY3_WHITELIST = (
-    'tests/unit/auth',
-    'tests/unit/beanstalk',
-    'tests/unit/cloudformation',
-    'tests/unit/cloudfront',
-    'tests/unit/cloudsearch',
-    'tests/unit/cloudsearch2',
-    'tests/unit/cloudtrail',
-    'tests/unit/directconnect',
-    'tests/unit/dynamodb',
-    'tests/unit/dynamodb2',
-    'tests/unit/ecs',
-    'tests/unit/elasticache',
-    'tests/unit/emr',
-    'tests/unit/glacier',
-    'tests/unit/iam',
-    'tests/unit/ec2',
-    'tests/unit/kms',
-    'tests/unit/logs',
-    'tests/unit/manage',
-    'tests/unit/mws',
-    'tests/unit/provider',
-    'tests/unit/rds2',
-    'tests/unit/route53',
-    'tests/unit/s3',
-    'tests/unit/sns',
-    'tests/unit/ses',
-    'tests/unit/sqs',
-    'tests/unit/sts',
-    'tests/unit/swf',
-    'tests/unit/utils',
-    'tests/unit/vpc',
-    'tests/unit/test_connection.py',
-    'tests/unit/test_exception.py',
-    'tests/unit/test_regioninfo.py',
-)
-
-
-def main(whitelist=[]):
+def main():
     description = ("Runs boto unit and/or integration tests. "
                    "Arguments will be passed on to nosetests. "
                    "See nosetests --help for more information.")
@@ -99,11 +54,7 @@ def main(whitelist=[]):
 
         for i, arg in enumerate(remaining_args):
             if arg == 'default':
-                if sys.version_info[0] == 3:
-                    del remaining_args[i]
-                    remaining_args += PY3_WHITELIST
-                else:
-                    remaining_args[i] = 'tests/unit'
+                remaining_args[i] = 'tests/unit'
 
     all_args = [__file__] + attribute_args + remaining_args
     print("nose command:", ' '.join(all_args))

--- a/tests/unit/cloudsearchdomain/test_cloudsearchdomain.py
+++ b/tests/unit/cloudsearchdomain/test_cloudsearchdomain.py
@@ -82,7 +82,8 @@ class CloudSearchDomainConnectionTest(AWSMockServiceTestCase):
 
         }
 
-        self.set_http_response(status_code=200, body=json.dumps(response))
+        self.set_http_response(status_code=200,
+                               body=json.dumps(response).encode('utf-8'))
         search_service.domain_connection = self.service_connection
         resp = search_service.search()
 
@@ -94,7 +95,8 @@ class CloudSearchDomainConnectionTest(AWSMockServiceTestCase):
         layer1 = CloudSearchConnection(aws_access_key_id='aws_access_key_id',
                                        aws_secret_access_key='aws_secret_access_key',
                                        sign_request=True)
-        domain = Domain(layer1=layer1, data=json.loads(self.domain_status))
+        domain = Domain(layer1=layer1,
+                        data=json.loads(self.domain_status))
         document_service = domain.get_document_service()
 
         response = {
@@ -109,7 +111,8 @@ class CloudSearchDomainConnectionTest(AWSMockServiceTestCase):
             "category": ["cat_a", "cat_b", "cat_c"]
         }
 
-        self.set_http_response(status_code=200, body=json.dumps(response))
+        self.set_http_response(status_code=200,
+                               body=json.dumps(response).encode('utf-8'))
         document_service.domain_connection = self.service_connection
         document_service.add("1234", document)
         resp = document_service.commit()


### PR DESCRIPTION
This removed the py3 whitelist.  Now all unit tests pass on python 3.

I did have to make one change to the auth class used by mturk, but it's a pretty mechanical change.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 