### PR TITLE
fix for throughput not showing correctly

### DIFF
--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -305,6 +305,12 @@ class Table(object):
                     "https://github.com/boto/boto/issues." % \
                     field['Projection']['ProjectionType']
                 )
+                
+            if 'ProvisionedThroughput' in field:
+                raw_throughput = field['ProvisionedThroughput']
+                kwargs['throughput'] = {}
+                kwargs['throughput']['read'] = int(raw_throughput['ReadCapacityUnits'])
+                kwargs['throughput']['write'] = int(raw_throughput['WriteCapacityUnits'])
 
             name = field['IndexName']
             kwargs['parts'] = self._introspect_schema(field['KeySchema'], None)


### PR DESCRIPTION
recommendation from https://github.com/boto/boto/issues/3349

calling `table.global_indexes[0].throughput` always returns
```
{'read': 5, 'write': 5}
```

same results when you look at `index.schema()`:
```
{u'BatchServerAliasIndex': {'IndexName': u'BatchServerAliasIndex', 'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': [u'log_filename', u'workflow']}, 'ProvisionedThroughput': {'WriteCapacityUnits': 5, 'ReadCapacityUnits': 5}, 'KeySchema': [{'KeyType': 'HASH', 'AttributeName': u'batch_id'}, {'KeyType': 'RANGE', 'AttributeName': u'server_alias'}]}}
```

I've tracked it down to these lines: I've been able to track the issue to these lines:
https://github.com/boto/boto/blob/master/boto/dynamodb2/fields.py#L222
https://github.com/boto/boto/blob/master/boto/dynamodb2/table.py#L110