### PR TITLE
Python 3.5.1 compatibilty

### DIFF
--- a/boto/pyami/config.py
+++ b/boto/pyami/config.py
@@ -137,23 +137,23 @@ class Config(ConfigParser):
     def get_value(self, section, name, default=None):
         return self.get(section, name, default)
 
-    def get(self, section, name, default=None):
+    def get(self, section, name, default=None, **kwargs):
         try:
-            val = ConfigParser.get(self, section, name)
+            val = ConfigParser.get(self, section, name, **kwargs)
         except:
             val = default
         return val
 
-    def getint(self, section, name, default=0):
+    def getint(self, section, name, default=0, **kwargs):
         try:
-            val = ConfigParser.getint(self, section, name)
+            val = ConfigParser.getint(self, section, name, **kwargs)
         except:
             val = int(default)
         return val
 
-    def getfloat(self, section, name, default=0.0):
+    def getfloat(self, section, name, default=0.0, **kwargs):
         try:
-            val = ConfigParser.getfloat(self, section, name)
+            val = ConfigParser.getfloat(self, section, name, **kwargs)
         except:
             val = float(default)
         return val


### PR DESCRIPTION
Better compatibility with the current ConfigParser interface to avoid `TypeError: get() got an unexpected keyword argument 'raw'` after http://bugs.python.org/issue21159 introduced in Python 3.5.1.

See also #3433