### PR TITLE
Fixed to make previous commit python3 safe

### DIFF
--- a/boto/dynamodb/types.py
+++ b/boto/dynamodb/types.py
@@ -333,7 +333,7 @@ class Dynamizer(object):
         the appropriate python type.
 
         """
-        if len(attr) > 1 or not attr or isinstance(attr, basestring):
+        if len(attr) > 1 or not attr or is_str(attr):
             return attr
         dynamodb_type = list(attr.keys())[0]
         if dynamodb_type.lower() == dynamodb_type:

--- a/tests/unit/dynamodb/test_types.py
+++ b/tests/unit/dynamodb/test_types.py
@@ -23,7 +23,7 @@
 from decimal import Decimal
 from tests.compat import unittest
 
-from boto.compat import six
+from boto.compat import six, json
 from boto.dynamodb import types
 from boto.dynamodb.exceptions import DynamoDBNumberError
 
@@ -94,6 +94,13 @@ class TestDynamizer(unittest.TestCase):
                          {'NS': ['1.1']})
         self.assertEqual(dynamizer.decode({'NS': ['1.1', '2.2', '3.3']}),
                          set([1.1, 2.2, 3.3]))
+
+    def test_decoding_full_doc(self):
+        '''Simple List decoding that had caused some errors'''
+        dynamizer = types.Dynamizer()
+        doc = '{"__type__":{"S":"Story"},"company_tickers":{"SS":["NASDAQ-TSLA","NYSE-F","NYSE-GM"]},"modified_at":{"N":"1452525162"},"created_at":{"N":"1452525162"},"version":{"N":"1"},"categories":{"SS":["AUTOMTVE","LTRTR","MANUFCTU","PN","PRHYPE","TAXE","TJ","TL"]},"provider_categories":{"L":[{"S":"F"},{"S":"GM"},{"S":"TSLA"}]},"received_at":{"S":"2016-01-11T11:26:31Z"}}'
+        output_doc = {'provider_categories': ['F', 'GM', 'TSLA'], '__type__': 'Story', 'company_tickers': set(['NASDAQ-TSLA', 'NYSE-GM', 'NYSE-F']), 'modified_at': Decimal('1452525162'), 'version': Decimal('1'), 'received_at': '2016-01-11T11:26:31Z', 'created_at': Decimal('1452525162'), 'categories': set(['LTRTR', 'TAXE', 'MANUFCTU', 'TL', 'TJ', 'AUTOMTVE', 'PRHYPE', 'PN'])}
+        self.assertEqual(json.loads(doc, object_hook=dynamizer.decode), output_doc)
 
 
 class TestBinary(unittest.TestCase):


### PR DESCRIPTION
Sorry I hadn't updated my local checkout of boto to make the first commit through a pull-request.

This fix actually fixes my previous commit directly to boto/develop, which is intended to fix in some scenarios where Lists seem to come back from AWS as simple strings.