### PR TITLE
Autodetect sigv4 for ap-northeast-2

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -55,9 +55,11 @@ except ImportError:
 # by default.
 SIGV4_DETECT = [
     '.cn-',
-    # In eu-central we support both host styles for S3
+    # In eu-central and ap-northeast-2 we support both host styles for S3
     '.eu-central',
     '-eu-central',
+    '.ap-northeast-2',
+    '-ap-northeast-2'
 ]
 
 

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -530,11 +530,23 @@ class TestS3SigV4OptIn(MockServiceWithConfigTestCase):
         self.assertEqual(fake._required_auth_capability(), ['nope'])
 
     def test_sigv4_non_optional(self):
-        # Requires SigV4.
-        for region in ['.cn-north', '.eu-central', '-eu-central']:
+        region_groups = ['.cn-north', '.eu-central', '-eu-central']
+        specific_regions = ['.ap-northeast-2', '-ap-northeast-2']
+
+        # Create a connection for a sample region in each of these groups
+        # and ensure sigv4 is used.
+        for region in region_groups:
             fake = FakeS3Connection(host='s3' + region + '-1.amazonaws.com')
             self.assertEqual(
                 fake._required_auth_capability(), ['hmac-v4-s3'])
+
+        # Create a connection from the specific regions and make sure
+        # that these use sigv4.
+        for region in specific_regions:
+            fake = FakeS3Connection(host='s3' + region + '.amazonaws.com')
+            self.assertEqual(
+                fake._required_auth_capability(), ['hmac-v4-s3'])
+
 
     def test_sigv4_opt_in_config(self):
         # Opt-in via the config.


### PR DESCRIPTION
A supplement to: https://github.com/boto/boto/pull/3454 because ap-northeast-2 is [sigv4 only](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region). Note: Travis tests will not pass till this PR gets merged: https://github.com/boto/boto/pull/3459.

cc @jamesls @mtdowling @rayluo @JordonPhillips 