### PR TITLE
fixes #3423 - wrong versionId param in URL generated by generate_url_…

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -365,7 +365,7 @@ class S3Connection(AWSAuthConnection):
 
         params = {}
         if version_id is not None:
-            params['VersionId'] = version_id
+            params['versionId'] = version_id
 
         http_request = self.build_base_http_request(method, path, auth_path,
                                                     headers=headers, host=host,

--- a/tests/unit/s3/test_connection.py
+++ b/tests/unit/s3/test_connection.py
@@ -132,7 +132,7 @@ class TestSigV4Presigned(MockServiceWithConfigTestCase):
         url = conn.generate_url_sigv4(86400, 'GET', bucket='examplebucket',
             key='test.txt', version_id=2)
 
-        self.assertIn('VersionId=2', url)
+        self.assertIn('versionId=2', url)
         self.assertIn('X-Amz-Security-Token=token', url)
 
     def test_sigv4_presign_headers(self):


### PR DESCRIPTION
fixes issue #3423 - wrong versionId param in URL generated by generate_url_sigv4
