### PR TITLE
generate_url_sigv4 ignores response_headers

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -367,6 +367,10 @@ class S3Connection(AWSAuthConnection):
         if version_id is not None:
             params['VersionId'] = version_id
 
+        if response_headers:
+            for k, v in response_headers.items():
+                params[k] = urllib.parse.quote(v)
+
         http_request = self.build_base_http_request(method, path, auth_path,
                                                     headers=headers, host=host,
                                                     params=params)


### PR DESCRIPTION
If using os.environ['S3_USE_SIGV4'] = 'True', response headers will not be included in the signed url.