### PR TITLE
Fix whitespace-collapsing for canonical headers

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -374,10 +374,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         for header in headers_to_sign:
             c_name = header.lower().strip()
             raw_value = str(headers_to_sign[header])
-            if '"' in raw_value:
-                c_value = raw_value.strip()
-            else:
-                c_value = ' '.join(raw_value.strip().split())
+            c_value = ' '.join(raw_value.strip().split())
             canonical.append('%s:%s' % (c_name, c_value))
         return '\n'.join(sorted(canonical))
 

--- a/tests/unit/auth/test_sigv4.py
+++ b/tests/unit/auth/test_sigv4.py
@@ -66,7 +66,7 @@ class TestSigV4Handler(unittest.TestCase):
                          'host:glacier.us-east-1.amazonaws.com\n'
                          'x-amz-archive-description:two spaces\n'
                          'x-amz-glacier-version:2012-06-01\n'
-                         'x-amz-quoted-string:"a   b   c"')
+                         'x-amz-quoted-string:"a b c"')
 
     def test_canonical_query_string(self):
         auth = HmacAuthV4Handler('glacier.us-east-1.amazonaws.com',


### PR DESCRIPTION
This is related to #2142 -- presumably the docs were updated, as http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html now reads:

> **Original headers**
>```
>   Host:iam.amazonaws.com\n
>   Content-Type:application/x-www-form-urlencoded; charset=utf-8\n
>   My-header1:    a   b   c  \n
>   X-Amz-Date:20150830T123600Z\n
>   My-Header2:    "a   b   c"  \n
>```
> **Canonical form**
>```
>   content-type:application/x-www-form-urlencoded; charset=utf-8\n
>   host:iam.amazonaws.com\n
>   my-header1:a b c\n
>   my-header2:"a b c"\n
>   x-amz-date:20150830T123600Z\n
>```

Tested against s3-us-west-2, the old behavior (preserve spaces within quotes) resulted in SignatureDoesNotMatch errors, while the old-old behavior (convert sequential spaces to a single space, regardless of quote marks) was accepted.