### PR TITLE
Make run_instances user_data param docs match the (correct) descripiton for request_spot_instances

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -772,8 +772,7 @@ class EC2Connection(AWSQueryConnection):
             with which to associate instances
 
         :type user_data: string
-        :param user_data: The Base64-encoded MIME user data to be made
-            available to the instance(s) in this reservation.
+        :param user_data: The user data passed to the launched instances
 
         :type instance_type: string
         :param instance_type: The type of instance to run:


### PR DESCRIPTION
The current wording was introduced back in 773ce5eb84115ed55daf44c018683900262c95c8, and implies that the data being passed in should already be base64-encoded; that encoding is actually handled by this method already. Updated to have the param description match what's used for request_spot_instances.