### PR TITLE
fix documentation for get_shard_iterator

### DIFF
--- a/boto/kinesis/layer1.py
+++ b/boto/kinesis/layer1.py
@@ -410,7 +410,11 @@ class KinesisConnection(AWSQueryConnection):
         :param starting_sequence_number: The sequence number of the data record
             in the shard from which to start reading from.
 
+        :returns: A dictionary containing:
+
+            1) a `ShardIterator` with the value being the shard-iterator object
         """
+
         params = {
             'StreamName': stream_name,
             'ShardId': shard_id,


### PR DESCRIPTION
The documentation of get_shard_iterator is not correct. It implies that you can directly use the return value of get_shard_iterator() in a get_records call.

If you do that, you will get an error from kinesis api. That is because the output of get_shard_iterator is actually a dictionary, and not the real shard. 

The attached pull request fixes the documentation.