### PR TITLE
Fix non-pr travis builds of master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 env:
   - BOTO_CONFIG=/tmp/nowhere
 before_install:
-  - if [ "$TRAVIS_PULL_REQUEST" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
       echo "No pull requests can be sent to the master branch" 1>&2;
       exit 1;
     fi


### PR DESCRIPTION
The environment variable is "false" if it is a PR. However that equates to
true as it is interpreted as a string

cc @jamesls @mtdowling @rayluo @JordonPhillips 