### PR TITLE
Decode request bodies before passing them to json

### DIFF
--- a/tests/unit/kinesis/test_kinesis.py
+++ b/tests/unit/kinesis/test_kinesis.py
@@ -36,7 +36,7 @@ class TestKinesis(AWSMockServiceTestCase):
         self.service_connection.put_record('stream-name',
             b'\x00\x01\x02\x03\x04\x05', 'partition-key')
 
-        body = json.loads(self.actual_request.body)
+        body = json.loads(self.actual_request.body.decode('utf-8'))
         self.assertEqual(body['Data'], 'AAECAwQF')
 
         target = self.actual_request.headers['X-Amz-Target']
@@ -47,7 +47,7 @@ class TestKinesis(AWSMockServiceTestCase):
         self.service_connection.put_record('stream-name',
             'data', 'partition-key')
 
-        body = json.loads(self.actual_request.body)
+        body = json.loads(self.actual_request.body.decode('utf-8'))
         self.assertEqual(body['Data'], 'ZGF0YQ==')
 
         target = self.actual_request.headers['X-Amz-Target']
@@ -66,7 +66,7 @@ class TestKinesis(AWSMockServiceTestCase):
         self.service_connection.put_records(stream_name='stream-name',
             records=[record_binary, record_str])
 
-        body = json.loads(self.actual_request.body)
+        body = json.loads(self.actual_request.body.decode('utf-8'))
         self.assertEqual(body['Records'][0]['Data'], 'AAECAwQF')
         self.assertEqual(body['Records'][1]['Data'], 'ZGF0YQ==')
 


### PR DESCRIPTION
AWSAuthConnection._mexe encodes request bodies as UTF-8, mutating the
original request object in the process.  This breaks kinesis's unit
tests on at least python 3.4 and 3.5 on Fedora because those unit tests
call json.loads, which expects str objects rather than the bytes objects
that _mexe converted them to.

Frankly, I'm a little confused as to how those tests manage to pass on
travis-ci.  If they somehow on this branch fail I guess I might find out why.

This commit makes the test cases decode request bodies before feeding
them to json.loads.