### PR TITLE
Minor indentation fix in Key._get_file_internal()

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1552,7 +1552,7 @@ class Key(object):
         if cb and (cb_count <= 1 or i > 0) and data_len > 0:
             cb(data_len, cb_size)
         for alg in digesters:
-          self.local_hashes[alg] = digesters[alg].digest()
+            self.local_hashes[alg] = digesters[alg].digest()
         if self.size is None and not torrent and "Range" not in headers:
             self.size = data_len
         self.close()


### PR DESCRIPTION
I was scanning through the source code of `Key._get_file_internal()` for something else, and noticed a two-space indentation, so thought I might as well fix it, as GitHub makes editing and submitting a pull request super easy.