### PR TITLE
Add better error messages when we can't retrieve creds

### DIFF
--- a/boto/exception.py
+++ b/boto/exception.py
@@ -571,3 +571,15 @@ class PleaseRetryException(Exception):
             self.message,
             self.response
         )
+
+
+class InvalidInstanceMetadataError(Exception):
+    MSG = (
+        "You can set the 'metadata_service_num_attempts' "
+        "in your boto config file to increase the number "
+        "of times boto will attempt to retrieve "
+        "credentials from the instance metadata service."
+    )
+    def __init__(self, msg):
+        final_msg = msg + '\n' + self.MSG
+        super(InvalidInstanceMetadataError, self).__init__(final_msg)

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -220,10 +220,10 @@ def retry_url(url, retry_on_404=True, num_retries=10, timeout=None):
             if code == 404 and not retry_on_404:
                 return ''
         except Exception as e:
-            pass
-        boto.log.exception('Caught exception reading instance data')
+            boto.log.exception('Caught exception reading instance data')
         # If not on the last iteration of the loop then sleep.
         if i + 1 != num_retries:
+            boto.log.debug('Sleeping before retrying')
             time.sleep(min(2 ** i,
                            boto.config.get('Boto', 'max_retry_delay', 60)))
     boto.log.error('Unable to read instance data, giving up')
@@ -393,6 +393,8 @@ def get_instance_metadata(version='latest', url='http://169.254.169.254',
         metadata_url = _build_instance_metadata_url(url, version, data)
         return _get_instance_metadata(metadata_url, num_retries=num_retries, timeout=timeout)
     except urllib.error.URLError:
+        boto.log.exception("Exception caught when trying to retrieve "
+                           "instance metadata for: %s", data)
         return None
 
 


### PR DESCRIPTION
When boto retrieves credentials from the instance metadata
service, there appear to be times when we're just returning an empty
string back to the user.  When this happens, we need to raise
a much more clear error message about what's going on.

There's a rare chance that we're actually seeing a 200 OK response
with text data that isn't the credentials in JSON format.  If that's
the case we'll need another change that counts that condition as a
failed attempt.

More background info in: https://github.com/boto/boto/issues/3378#issuecomment-186004836

Fixes #3378.

cc @kyleknap @rayluo @JordonPhillips 