### PR TITLE
Fix corner case when returning DynamoDB results.

### DIFF
--- a/boto/dynamodb2/results.py
+++ b/boto/dynamodb2/results.py
@@ -185,10 +185,11 @@ class BatchGetResultSet(ResultSet):
 
         results = self.the_callable(*args, **kwargs)
 
-        if not len(results.get('results', [])):
+        # Can return early iff both lists are empty
+        if not len(results.get('results', [])) and not len(results.get('unprocessed_keys', [])):
             return
 
-        self._results.extend(results['results'])
+        self._results.extend(results.get('results', []))
 
         for offset, key_data in enumerate(results.get('unprocessed_keys', [])):
             # We've got an unprocessed key. Reinsert it into the list.


### PR DESCRIPTION
When reading from an overloaded DynamoDB table, it's possible for AWS to process
no results. As a result, we must check both the results and unprocessed_results
from AWS to avoid returning early and missing unprocessed_results.
