### PR TITLE
Fix exponential backoff min function

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -920,7 +920,7 @@ class AWSAuthConnection(object):
         while i <= num_retries:
             # Use binary exponential backoff to desynchronize client requests.
             next_sleep = min(random.random() * (2 ** i),
-                             boto.config.get('Boto', 'max_retry_delay', 60))
+                             boto.config.getint('Boto', 'max_retry_delay', 60))
             try:
                 # we now re-sign each request before it is retried
                 boto.log.debug('Token: %s' % self.provider.security_token)


### PR DESCRIPTION
TL;DR
Adding custom max_retry_delay to boto config causes no max delay at all (not even 60s)

If you add `max_retry_delay` to your ~/.boto:

``` ini
[Boto]
max_retry_delay = 1
```

and according to [boto/connection.py#L923](https://github.com/boto/boto/blob/5785d978c06cc48a5d4448e801832d31c9b2d018/boto/connection.py#L923)

``` python
next_sleep = min(random.random() * (2 ** i),
                boto.config.getint('Boto', 'max_retry_delay', 60))
```

`next_sleep` always be the value of `random.random() * (2 ** i)` 
cause `min` of string and int always returns the value of int

``` python
min(5, "3") == 5
>> True
```
