### PR TITLE
Bugfix: respect max_retry_delay value from config

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -920,7 +920,7 @@ class AWSAuthConnection(object):
         while i <= num_retries:
             # Use binary exponential backoff to desynchronize client requests.
             next_sleep = min(random.random() * (2 ** i),
-                             boto.config.get('Boto', 'max_retry_delay', 60))
+                             boto.config.getfloat('Boto', 'max_retry_delay', 60))
             try:
                 # we now re-sign each request before it is retried
                 boto.log.debug('Token: %s' % self.provider.security_token)


### PR DESCRIPTION
## Bug:

Current code effectively disregards `max_retry_delay` parameter from config, because it is being retrieved as string.
## Fix:

Use `config.getfloat()` instead of `config.get()` to get the numerical value of the parameter. 
## Background:

In Python comparison rules, any number is less than any string. That's why `max(some_num, some_string)` will always return `some_num`, which is what happens in this case: the random value of sleep time is always chosen over the specified `max_retry_delay`.

Issue: https://github.com/boto/boto/issues/3509
