### PR TITLE
Change run_jobflow in EMR connection to use regional debugging jar wh…

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -48,9 +48,11 @@ class EmrConnection(AWSQueryConnection):
                                             'elasticmapreduce.us-east-1.amazonaws.com')
     ResponseError = EmrResponseError
 
-    # Constants for AWS Console debugging
-    DebuggingJar = 's3n://us-east-1.elasticmapreduce/libs/script-runner/script-runner.jar'
-    DebuggingArgs = 's3n://us-east-1.elasticmapreduce/libs/state-pusher/0.1/fetch'
+
+
+    # Constants for AWS Console debugging    
+    DebuggingJar = 's3://{region_name}.elasticmapreduce/libs/script-runner/script-runner.jar'
+    DebuggingArgs = 's3://{region_name}.elasticmapreduce/libs/state-pusher/0.1/fetch'
 
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,
@@ -411,7 +413,7 @@ class EmrConnection(AWSQueryConnection):
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
-                    steps=[],
+                    steps=None,
                     bootstrap_actions=[],
                     instance_groups=None,
                     additional_info=None,
@@ -508,6 +510,7 @@ class EmrConnection(AWSQueryConnection):
         :rtype: str
         :return: The jobflow id
         """
+        steps = steps or []
         params = {}
         if action_on_failure:
             params['ActionOnFailure'] = action_on_failure
@@ -547,8 +550,8 @@ class EmrConnection(AWSQueryConnection):
             debugging_step = JarStep(name='Setup Hadoop Debugging',
                                      action_on_failure='TERMINATE_JOB_FLOW',
                                      main_class=None,
-                                     jar=self.DebuggingJar,
-                                     step_args=self.DebuggingArgs)
+                                     jar=self.DebuggingJar.format(region_name=self.region.name),    
+                                     step_args=self.DebuggingArgs.format(region_name=self.region.name))
             steps.insert(0, debugging_step)
 
         # Step args

--- a/tests/unit/emr/test_connection.py
+++ b/tests/unit/emr/test_connection.py
@@ -25,20 +25,24 @@ from datetime import datetime
 from time import time
 from tests.unit import AWSMockServiceTestCase
 
+from boto.compat import six
 from boto.emr.connection import EmrConnection
 from boto.emr.emrobject import BootstrapAction, BootstrapActionList, \
-                               ClusterStateChangeReason, ClusterStatus, ClusterSummaryList, \
-                               ClusterSummary, ClusterTimeline, InstanceInfo, \
-                               InstanceList, InstanceGroupInfo, \
-                               InstanceGroup, InstanceGroupList, JobFlow, \
-                               JobFlowStepList, Step, StepSummaryList, \
-                               Cluster, RunJobFlowResponse
+    ClusterStateChangeReason, ClusterStatus, ClusterSummaryList, \
+    ClusterSummary, ClusterTimeline, InstanceInfo, \
+    InstanceList, InstanceGroupInfo, \
+    InstanceGroup, InstanceGroupList, JobFlow, \
+    JobFlowStepList, Step, StepSummaryList, \
+    Cluster, RunJobFlowResponse
+
 
 # These tests are just checking the basic structure of
 # the Elastic MapReduce code, by picking a few calls
 # and verifying we get the expected results with mocked
 # responses.  The integration tests actually verify the
 # API calls interact with the service correctly.
+
+
 class TestListClusters(AWSMockServiceTestCase):
     connection_class = EmrConnection
 
@@ -109,15 +113,22 @@ class TestListClusters(AWSMockServiceTestCase):
         self.assertTrue(isinstance(response.clusters[0].status, ClusterStatus))
         self.assertEqual(response.clusters[0].status.state, 'TERMINATED')
 
-        self.assertTrue(isinstance(response.clusters[0].status.timeline, ClusterTimeline))
+        self.assertTrue(
+            isinstance(response.clusters[0].status.timeline, ClusterTimeline))
 
-        self.assertEqual(response.clusters[0].status.timeline.creationdatetime, '2014-01-24T01:21:21Z')
-        self.assertEqual(response.clusters[0].status.timeline.readydatetime, '2014-01-24T01:25:26Z')
-        self.assertEqual(response.clusters[0].status.timeline.enddatetime, '2014-01-24T02:19:46Z')
+        self.assertEqual(
+            response.clusters[0].status.timeline.creationdatetime, '2014-01-24T01:21:21Z')
+        self.assertEqual(
+            response.clusters[0].status.timeline.readydatetime, '2014-01-24T01:25:26Z')
+        self.assertEqual(
+            response.clusters[0].status.timeline.enddatetime, '2014-01-24T02:19:46Z')
 
-        self.assertTrue(isinstance(response.clusters[0].status.statechangereason, ClusterStateChangeReason))
-        self.assertEqual(response.clusters[0].status.statechangereason.code, 'USER_REQUEST')
-        self.assertEqual(response.clusters[0].status.statechangereason.message, 'Terminated by user request')
+        self.assertTrue(isinstance(
+            response.clusters[0].status.statechangereason, ClusterStateChangeReason))
+        self.assertEqual(
+            response.clusters[0].status.statechangereason.code, 'USER_REQUEST')
+        self.assertEqual(response.clusters[
+                         0].status.statechangereason.message, 'Terminated by user request')
 
     def test_list_clusters_created_before(self):
         self.set_http_response(status_code=200)
@@ -223,7 +234,8 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
         with self.assertRaises(TypeError):
             self.service_connection.list_instance_groups()
 
-        response = self.service_connection.list_instance_groups(cluster_id='j-123')
+        response = self.service_connection.list_instance_groups(
+            cluster_id='j-123')
 
         self.assert_request_parameters({
             'Action': 'ListInstanceGroups',
@@ -233,18 +245,24 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
 
         self.assertTrue(isinstance(response, InstanceGroupList))
         self.assertEqual(len(response.instancegroups), 2)
-        self.assertTrue(isinstance(response.instancegroups[0], InstanceGroupInfo))
+        self.assertTrue(
+            isinstance(response.instancegroups[0], InstanceGroupInfo))
         self.assertEqual(response.instancegroups[0].id, 'ig-aaaaaaaaaaaaa')
-        self.assertEqual(response.instancegroups[0].instancegrouptype, "MASTER")
+        self.assertEqual(
+            response.instancegroups[0].instancegrouptype, "MASTER")
         self.assertEqual(response.instancegroups[0].instancetype, "m1.large")
         self.assertEqual(response.instancegroups[0].market, "ON_DEMAND")
-        self.assertEqual(response.instancegroups[0].name, "Master instance group")
-        self.assertEqual(response.instancegroups[0].requestedinstancecount, '1')
+        self.assertEqual(
+            response.instancegroups[0].name, "Master instance group")
+        self.assertEqual(
+            response.instancegroups[0].requestedinstancecount, '1')
         self.assertEqual(response.instancegroups[0].runninginstancecount, '0')
-        self.assertTrue(isinstance(response.instancegroups[0].status, ClusterStatus))
+        self.assertTrue(
+            isinstance(response.instancegroups[0].status, ClusterStatus))
         self.assertEqual(response.instancegroups[0].status.state, 'TERMINATED')
         # status.statechangereason is not parsed into an object
         #self.assertEqual(response.instancegroups[0].status.statechangereason.code, 'CLUSTER_TERMINATED')
+
 
 class TestListInstances(AWSMockServiceTestCase):
     connection_class = EmrConnection
@@ -334,11 +352,12 @@ class TestListInstances(AWSMockServiceTestCase):
         self.assertTrue(isinstance(response.instances[0], InstanceInfo))
         self.assertEqual(response.instances[0].ec2instanceid, 'i-aaaaaaaa')
         self.assertEqual(response.instances[0].id, 'ci-123456789abc')
-        self.assertEqual(response.instances[0].privatednsname , 'ip-10-0-0-60.us-west-1.compute.internal')
-        self.assertEqual(response.instances[0].privateipaddress , '10.0.0.60')
-        self.assertEqual(response.instances[0].publicdnsname , 'ec2-54-0-0-1.us-west-1.compute.amazonaws.com')
-        self.assertEqual(response.instances[0].publicipaddress , '54.0.0.1')
-
+        self.assertEqual(
+            response.instances[0].privatednsname, 'ip-10-0-0-60.us-west-1.compute.internal')
+        self.assertEqual(response.instances[0].privateipaddress, '10.0.0.60')
+        self.assertEqual(response.instances[
+                         0].publicdnsname, 'ec2-54-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(response.instances[0].publicipaddress, '54.0.0.1')
 
         self.assert_request_parameters({
             'Action': 'ListInstances',
@@ -481,7 +500,7 @@ class TestListSteps(AWSMockServiceTestCase):
         # Check for step config
         step = response.steps[0]
         self.assertEqual(step.config.jar,
-            '/home/hadoop/lib/emr-s3distcp-1.0.jar')
+                         '/home/hadoop/lib/emr-s3distcp-1.0.jar')
         self.assertEqual(len(step.config.args), 4)
         self.assertEqual(step.config.args[0].value, '--src')
         self.assertEqual(step.config.args[1].value, 'hdfs:///data/test/')
@@ -507,6 +526,7 @@ class TestListSteps(AWSMockServiceTestCase):
         self.assertTrue(isinstance(response, StepSummaryList))
         self.assertEqual(response.steps[0].name, 'Step 1')
 
+
 class TestListBootstrapActions(AWSMockServiceTestCase):
     connection_class = EmrConnection
 
@@ -519,7 +539,8 @@ class TestListBootstrapActions(AWSMockServiceTestCase):
         with self.assertRaises(TypeError):
             self.service_connection.list_bootstrap_actions()
 
-        response = self.service_connection.list_bootstrap_actions(cluster_id='j-123')
+        response = self.service_connection.list_bootstrap_actions(
+            cluster_id='j-123')
 
         self.assert_request_parameters({
             'Action': 'ListBootstrapActions',
@@ -593,12 +614,15 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         self.assertEqual(response.name, 'test analytics')
         self.assertEqual(response.requestedamiversion, '2.4.2')
         self.assertEqual(response.terminationprotected, 'false')
-        self.assertEqual(response.ec2instanceattributes.ec2availabilityzone, "us-west-1c")
-        self.assertEqual(response.ec2instanceattributes.ec2keyname, 'my_secret_key')
+        self.assertEqual(
+            response.ec2instanceattributes.ec2availabilityzone, "us-west-1c")
+        self.assertEqual(
+            response.ec2instanceattributes.ec2keyname, 'my_secret_key')
         self.assertEqual(response.status.state, 'TERMINATED')
         self.assertEqual(response.applications[0].name, 'hadoop')
         self.assertEqual(response.applications[0].version, '1.0.3')
-        self.assertEqual(response.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(
+            response.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(response.normalizedinstancehours, '10')
         self.assertEqual(response.servicerole, 'my-service-role')
 
@@ -772,7 +796,8 @@ class TestRemoveTag(AWSMockServiceTestCase):
         with self.assertRaises(AssertionError):
             self.service_connection.add_tags('j-123', [])
 
-        response = self.service_connection.remove_tags('j-123', ['FirstKey', 'SecondKey'])
+        response = self.service_connection.remove_tags(
+            'j-123', ['FirstKey', 'SecondKey'])
 
         self.assertTrue(response)
         self.assert_request_parameters({
@@ -782,6 +807,7 @@ class TestRemoveTag(AWSMockServiceTestCase):
             'TagKeys.member.2': 'SecondKey',
             'Version': '2009-03-31'
         })
+
 
 class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
     connection_class = EmrConnection
@@ -888,6 +914,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
 </DescribeJobFlowsResponse>
         """
 
+
 class TestDescribeJobFlows(DescribeJobFlowsTestBase):
 
     def test_describe_jobflows_response(self):
@@ -910,14 +937,16 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(jf.masterinstanceid, 'i-aaaaaa')
         self.assertEqual(jf.hadoopversion, '1.0.3')
         self.assertEqual(jf.normalizedinstancehours, '12')
-        self.assertEqual(jf.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(
+            jf.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(jf.instancecount, '3')
         self.assertEqual(jf.terminationprotected, 'false')
 
         self.assertTrue(isinstance(jf.steps, list))
         step = jf.steps[0]
         self.assertTrue(isinstance(step, Step))
-        self.assertEqual(step.jar, 's3://us-west-1.elasticmapreduce/libs/script-runner/script-runner.jar')
+        self.assertEqual(
+            step.jar, 's3://us-west-1.elasticmapreduce/libs/script-runner/script-runner.jar')
         self.assertEqual(step.name, 'Setup hive')
         self.assertEqual(step.actiononfailure, 'TERMINATE_JOB_FLOW')
 
@@ -949,7 +978,8 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         now = datetime.now()
         a_bit_before = datetime.fromtimestamp(time() - 1000)
 
-        self.service_connection.describe_jobflows(states=['WAITING', 'RUNNING'], jobflow_ids=['j-aaaaaa', 'j-aaaaab'], created_after=a_bit_before, created_before=now)
+        self.service_connection.describe_jobflows(states=['WAITING', 'RUNNING'], jobflow_ids=[
+                                                  'j-aaaaaa', 'j-aaaaab'], created_after=a_bit_before, created_before=now)
         self.assert_request_parameters({
             'Action': 'DescribeJobFlows',
             'JobFlowIds.member.1': 'j-aaaaaa',
@@ -960,7 +990,9 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
             'CreatedBefore': now.strftime(boto.utils.ISO8601),
         }, ignore_params_values=['Version'])
 
+
 class TestDescribeJobFlow(DescribeJobFlowsTestBase):
+
     def test_describe_jobflow(self):
         self.set_http_response(200)
 
@@ -970,6 +1002,7 @@ class TestDescribeJobFlow(DescribeJobFlowsTestBase):
             'Action': 'DescribeJobFlows',
             'JobFlowIds.member.1': 'j-aaaaaa',
         }, ignore_params_values=['Version'])
+
 
 class TestRunJobFlow(AWSMockServiceTestCase):
     connection_class = EmrConnection
@@ -997,8 +1030,25 @@ class TestRunJobFlow(AWSMockServiceTestCase):
             'Action': 'RunJobFlow',
             'Version': '2009-03-31',
             'ServiceRole': 'EMR_DefaultRole',
-            'Name': 'EmrCluster' },
+            'Name': 'EmrCluster'},
             ignore_params_values=['ActionOnFailure', 'Instances.InstanceCount',
                                   'Instances.KeepJobFlowAliveWhenNoSteps',
                                   'Instances.MasterInstanceType',
                                   'Instances.SlaveInstanceType'])
+
+    def test_run_jobflow_enable_debugging(self):
+        self.region = 'ap-northeast-2'
+        self.set_http_response(200)
+        self.service_connection.run_jobflow(
+            'EmrCluster', enable_debugging=True)
+
+        actual_params = set(self.actual_request.params.copy().items())
+
+        expected_params = set([
+            ('Steps.member.1.HadoopJarStep.Jar',
+             's3://ap-northeast-2.elasticmapreduce/libs/script-runner/script-runner.jar'),
+            ('Steps.member.1.HadoopJarStep.Args.member.1',
+                's3://ap-northeast-2.elasticmapreduce/libs/state-pusher/0.1/fetch'),
+        ])
+
+        self.assertTrue(expected_params <= actual_params)


### PR DESCRIPTION
…en enable_debugging is on. Fixes bug where jobs fail in ap-northeast-2 and eu-central-1.