### PR TITLE
Send correct Host header when using v4 auth with non-default port

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -82,6 +82,10 @@ class _CallingFormat(object):
         return url_base
 
     def build_host(self, server, bucket):
+        # Make sure the server is really just the host, not including
+        # the port number
+        server = boto.utils.parse_host(server)
+
         if bucket == '':
             return server
         else:

--- a/tests/unit/s3/test_connection.py
+++ b/tests/unit/s3/test_connection.py
@@ -254,6 +254,12 @@ class TestUnicodeCallingFormat(AWSMockServiceTestCase):
         self.set_http_response(status_code=200)
         self.service_connection.get_all_buckets()
 
+    def test_build_host(self):
+        # build_host should only ever return a hostname, no port
+        host = self.service_connection.calling_format.build_host(
+            'testhost:8080', 'bucket')
+        self.assertEqual(host, 'testhost')
+
 
 class TestHeadBucket(AWSMockServiceTestCase):
     connection_class = S3Connection


### PR DESCRIPTION
Previously, when using a non-default port and v4 authentication, we would send a `Host` header like `<hostname>:<port>:<port>` instead of `<hostname>:<port>`. This would happen because `S3Connection` would explicitly set the host from `self.server_name()` (which includes port) during `make_request` ([code](https://github.com/boto/boto/blob/2.39.0/boto/s3/connection.py#L655)) while `S3HmacAuthV4Handler` would always append the non-standard port to the host (even if it already included a port; [code](https://github.com/boto/boto/blob/2.39.0/boto/auth.py#L592-L597)).

Now, `_CallingFormat`'s `build_host` will only ever return hostnames. This is comparable to what was done in `AWSAuthConnection`'s `new_http_connection` ([code](https://github.com/boto/boto/blob/2.39.0/boto/connection.py#L727-L729)) and seemed

 * more in line with what `build_host` should return (i.e., just a hostname, no port) and
 * less likely to have unintended side effects than a similar change to `server_name`.

Addresses #2623.