### PR TITLE
Make client_token optional in modify_reserved_instances

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -3824,9 +3824,9 @@ class EC2Connection(AWSQueryConnection):
         :rtype: string
         :return: The unique ID for the submitted modification request.
         """
-        params = {
-            'ClientToken': client_token,
-        }
+        params = {}
+        if client_token is not None:
+            params['ClientToken'] = client_token
         if reserved_instance_ids is not None:
             self.build_list_params(params, reserved_instance_ids,
                                    'ReservedInstancesId')

--- a/tests/unit/ec2/test_connection.py
+++ b/tests/unit/ec2/test_connection.py
@@ -1161,6 +1161,38 @@ class TestModifyReservedInstances(TestEC2ConnectionBase):
 
         self.assertEqual(response, 'rimod-3aae219d-3d63-47a9-a7e9-e764example')
 
+    def test_none_token(self):
+        """Ensures that if the token is set to None, nothing is serialized."""
+        self.set_http_response(status_code=200)
+        response = self.ec2.modify_reserved_instances(
+            None,
+            reserved_instance_ids=[
+                '2567o137-8a55-48d6-82fb-7258506bb497',
+            ],
+            target_configurations=[
+                ReservedInstancesConfiguration(
+                    availability_zone='us-west-2c',
+                    platform='EC2-VPC',
+                    instance_count=3,
+                    instance_type='c3.large'
+                ),
+            ]
+        )
+        self.assert_request_parameters({
+            'Action': 'ModifyReservedInstances',
+            'ReservedInstancesConfigurationSetItemType.0.AvailabilityZone': 'us-west-2c',
+            'ReservedInstancesConfigurationSetItemType.0.InstanceCount': 3,
+            'ReservedInstancesConfigurationSetItemType.0.Platform': 'EC2-VPC',
+            'ReservedInstancesConfigurationSetItemType.0.InstanceType': 'c3.large',
+            'ReservedInstancesId.1': '2567o137-8a55-48d6-82fb-7258506bb497'
+        }, ignore_params_values=[
+            'AWSAccessKeyId', 'SignatureMethod',
+            'SignatureVersion', 'Timestamp',
+            'Version'
+        ])
+
+        self.assertEqual(response, 'rimod-3aae219d-3d63-47a9-a7e9-e764example')
+
 
 class TestDescribeReservedInstancesModifications(TestEC2ConnectionBase):
     def default_body(self):


### PR DESCRIPTION
Previously, we had been serializing "None" instead of omitting the optional parameter.

cc @kyleknap @jamesls 