### PR TITLE
Fix config parsing on python3.5

### DIFF
--- a/boto/compat.py
+++ b/boto/compat.py
@@ -61,12 +61,13 @@ if six.PY3:
     # StandardError was removed, so use the base exception type instead
     StandardError = Exception
     long_type = int
-    from configparser import ConfigParser
+    from configparser import ConfigParser, NoOptionError, NoSectionError
     unquote_str = unquote_plus
 else:
     StandardError = StandardError
     long_type = long
     from ConfigParser import SafeConfigParser as ConfigParser
+    from ConfigParser import NoOptionError, NoSectionError
 
     def unquote_str(value, encoding='utf-8'):
         # In python2, unquote() gives us a string back that has the urldecoded

--- a/boto/pyami/config.py
+++ b/boto/pyami/config.py
@@ -68,6 +68,15 @@ class Config(object):
                 except IOError:
                     warnings.warn('Unable to load AWS_CREDENTIAL_FILE (%s)' % full_path)
 
+    def __setstate__(self, state):
+        # There's test that verify that (transitively) a Config
+        # object can be pickled.  Now that we're storing a _parser
+        # attribute and relying on __getattr__ to proxy requests,
+        # we need to implement setstate to ensure we don't get
+        # into recursive loops when looking up _parser when
+        # this object is unpickled.
+        self._parser = state['_parser']
+
     def __getattr__(self, name):
         return getattr(self._parser, name)
 

--- a/boto/pyami/config.py
+++ b/boto/pyami/config.py
@@ -52,8 +52,8 @@ elif 'BOTO_PATH' in os.environ:
 class Config(object):
 
     def __init__(self, path=None, fp=None, do_load=True):
-        self._impl = ConfigParser({'working_dir': '/mnt/pyami',
-                                         'debug': '0'})
+        self._parser = ConfigParser({'working_dir': '/mnt/pyami',
+                                     'debug': '0'})
         if do_load:
             if path:
                 self.load_from_path(path)
@@ -69,18 +69,10 @@ class Config(object):
                     warnings.warn('Unable to load AWS_CREDENTIAL_FILE (%s)' % full_path)
 
     def __getattr__(self, name):
-        try:
-            impl = self.__dict__['_impl']
-        except KeyError:
-            raise AttributeError(name)
-        return getattr(impl, name)
+        return getattr(self._parser, name)
 
     def has_option(self, *args, **kwargs):
-        try:
-            impl = self.__dict__['_impl']
-        except KeyError:
-            return False
-        return impl.has_option(*args, **kwargs)
+        return self._parser.has_option(*args, **kwargs)
 
     def load_credential_file(self, path):
         """Load a credential file as is setup like the Java utilities"""
@@ -151,31 +143,19 @@ class Config(object):
 
     def get(self, section, name, default=None):
         try:
-            impl = self.__dict__['_impl']
-        except KeyError:
-            return default
-        try:
-            return impl.get(section, name)
+            return self._parser.get(section, name)
         except (NoOptionError, NoSectionError):
             return default
 
     def getint(self, section, name, default=0):
         try:
-            impl = self.__dict__['_impl']
-        except KeyError:
-            return int(default)
-        try:
-            return impl.getint(section, name)
+            return self._parser.getint(section, name)
         except (NoOptionError, NoSectionError):
             return int(default)
 
     def getfloat(self, section, name, default=0.0):
         try:
-            impl = self.__dict__['_impl']
-        except KeyError:
-            return float(default)
-        try:
-            return impl.getfloat(section, name)
+            return self._parser.getfloat(section, name)
         except (NoOptionError, NoSectionError):
             return float(default)
 

--- a/boto/pyami/config.py
+++ b/boto/pyami/config.py
@@ -26,7 +26,7 @@ import warnings
 
 import boto
 
-from boto.compat import expanduser, ConfigParser, StringIO
+from boto.compat import expanduser, ConfigParser, NoOptionError, NoSectionError, StringIO
 
 
 # By default we use two locations for the boto configurations,
@@ -128,21 +128,21 @@ class Config(object):
     def get_instance(self, name, default=None):
         try:
             val = self.get('Instance', name)
-        except:
+        except (NoOptionError, NoSectionError):
             val = default
         return val
 
     def get_user(self, name, default=None):
         try:
             val = self.get('User', name)
-        except:
+        except (NoOptionError, NoSectionError):
             val = default
         return val
 
     def getint_user(self, name, default=0):
         try:
             val = self.getint('User', name)
-        except:
+        except (NoOptionError, NoSectionError):
             val = default
         return val
 
@@ -156,7 +156,7 @@ class Config(object):
             return default
         try:
             return impl.get(section, name)
-        except:
+        except (NoOptionError, NoSectionError):
             return default
 
     def getint(self, section, name, default=0):
@@ -166,7 +166,7 @@ class Config(object):
             return int(default)
         try:
             return impl.getint(section, name)
-        except:
+        except (NoOptionError, NoSectionError):
             return int(default)
 
     def getfloat(self, section, name, default=0.0):
@@ -176,7 +176,7 @@ class Config(object):
             return float(default)
         try:
             return impl.getfloat(section, name)
-        except:
+        except (NoOptionError, NoSectionError):
             return float(default)
 
     def getbool(self, section, name, default=False):

--- a/tests/unit/pyami/test_config.py
+++ b/tests/unit/pyami/test_config.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2016 Amazon.com, Inc. or its affiliates.  All Rights Reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+from tests.compat import mock, unittest
+
+from boto.pyami import config
+from boto.compat import StringIO
+
+
+class TestCanLoadConfigFile(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.file_contents = StringIO()
+        file_contents = StringIO(
+            '[Boto]\n'
+            'https_validate_certificates = true\n'
+            'other = false\n'
+            'http_socket_timeout = 1\n'
+            '[Credentials]\n'
+            'aws_access_key_id=foo\n'
+            'aws_secret_access_key=bar\n'
+        )
+        self.config = config.Config(fp=file_contents)
+
+    def test_can_get_bool(self):
+        self.assertTrue(
+            self.config.getbool('Boto', 'https_validate_certificates'))
+        self.assertFalse(self.config.getbool('Boto', 'other'))
+        self.assertFalse(self.config.getbool('Boto', 'does-not-exist'))
+
+    def test_can_get_int(self):
+        self.assertEqual(self.config.getint('Boto', 'http_socket_timeout'), 1)
+        self.assertEqual(self.config.getint('Boto', 'does-not-exist'), 0)
+        self.assertEqual(
+            self.config.getint('Boto', 'does-not-exist', default=20), 20)
+
+    def test_can_get_strings(self):
+        self.assertEqual(
+            self.config.get('Credentials', 'aws_access_key_id'), 'foo')
+        self.assertIsNone(
+            self.config.get('Credentials', 'no-exist'))
+        self.assertEqual(
+            self.config.get('Credentials', 'no-exist', 'default-value'),
+            'default-value')


### PR DESCRIPTION
This PR pulls in https://github.com/boto/boto/pull/3498 with a few modifications:

* Remove usage of attr access through `__dict__`.
* Add unit tests for fix.

I verified that the added tests fail on python 3.5.1 without this fix.

Fixes https://github.com/boto/boto/issues/3474

cc @kyleknap @JordonPhillips 