### PR TITLE
check for Sid key before accessing it

### DIFF
--- a/boto/sns/connection.py
+++ b/boto/sns/connection.py
@@ -358,7 +358,7 @@ class SNSConnection(AWSQueryConnection):
             policy['Statement'] = []
         # See if a Statement with the Sid exists already.
         for s in policy['Statement']:
-            if s['Sid'] == sid:
+            if 'Sid' in s and s['Sid'] == sid:
                 sid_exists = True
         if not sid_exists:
             statement = {'Action': 'SQS:SendMessage',


### PR DESCRIPTION
If a policy document on an SNS topic doesnt have a Sid, then the `subscribe_sqs_queue` helper function will throw a `KeyError` exception. This patch checks for the field in the policy document before it tries to access it.