### PR TITLE
Fixes upload parts for glacier

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -368,7 +368,7 @@ class HTTPRequest(object):
             for key in self.headers:
                 val = self.headers[key]
                 if isinstance(val, six.text_type):
-                    safe = '!"#$%&\'()*+,/:;<=>?@[\\]^`{|}~'
+                    safe = '!"#$%&\'()*+,/:;<=>?@[\\]^`{|}~ '
                     self.headers[key] = quote(val.encode('utf-8'), safe)
             setattr(self, '_headers_quoted', True)
 

--- a/boto/glacier/layer1.py
+++ b/boto/glacier/layer1.py
@@ -1273,7 +1273,7 @@ class Layer1(AWSAuthConnection):
                    'x-amz-sha256-tree-hash': tree_hash,
                    'Content-Range': 'bytes %d-%d/*' % byte_range}
         response_headers = [('x-amz-sha256-tree-hash', u'TreeHash')]
-        uri = 'vaults/%s/multipart-uploads/%s' % (vault_name, upload_id)
+        uri = 'vaults/%s/multipart-uploads/%s' % (str(vault_name), upload_id)
         return self.make_request('PUT', uri, headers=headers,
                                  data=part_data, ok_responses=(204,),
                                  response_headers=response_headers)

--- a/tests/unit/glacier/test_layer1.py
+++ b/tests/unit/glacier/test_layer1.py
@@ -2,8 +2,10 @@ import json
 import copy
 import tempfile
 
+from tests.unit import unittest
 from tests.unit import AWSMockServiceTestCase
 from boto.glacier.layer1 import Layer1
+from boto.compat import six
 
 
 class GlacierLayer1ConnectionBase(AWSMockServiceTestCase):
@@ -78,6 +80,24 @@ class GlacierJobOperations(GlacierLayer1ConnectionBase):
         response = self.service_connection.get_job_output(self.vault_name,
                                                           'example-job-id')
         self.assertEqual(self.job_content, response.read())
+
+
+class TestGlacierUploadPart(GlacierLayer1ConnectionBase):
+    def test_upload_part_with_unicode_name(self):
+        fake_data = b'\xe2'
+        self.set_http_response(status_code=204)
+        self.service_connection.upload_part(
+            u'unicode_vault_name', 'upload_id', 'linear_hash', 'tree_hash',
+            (1,2), fake_data)
+        self.assertEqual(
+            self.actual_request.path,
+            '/-/vaults/unicode_vault_name/multipart-uploads/upload_id')
+        # If the path is unicode in python2, it triggers the following bug
+        # noted in this PR: https://github.com/boto/boto/pull/2697
+        # httplib notices that if the path is unicode, it will try to encode
+        # body which may be impossible if there is the data is binary.
+        self.assertIsInstance(self.actual_request.body, six.binary_type)
+        self.assertEqual(self.actual_request.body, fake_data)
 
 
 class GlacierUploadArchiveResets(GlacierLayer1ConnectionBase):

--- a/tests/unit/glacier/test_layer1.py
+++ b/tests/unit/glacier/test_layer1.py
@@ -83,6 +83,15 @@ class GlacierJobOperations(GlacierLayer1ConnectionBase):
 
 
 class TestGlacierUploadPart(GlacierLayer1ConnectionBase):
+    def test_upload_part_content_range_header(self):
+        fake_data = b'\xe2'
+        self.set_http_response(status_code=204)
+        self.service_connection.upload_part(
+            u'unicode_vault_name', 'upload_id', 'linear_hash', 'tree_hash',
+            (1,2), fake_data)
+        self.assertEqual(
+            self.actual_request.headers['Content-Range'], 'bytes 1-2/*')
+
     def test_upload_part_with_unicode_name(self):
         fake_data = b'\xe2'
         self.set_http_response(status_code=204)

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -522,7 +522,7 @@ class TestAWSQueryStatus(TestAWSQueryConnection):
 
 class TestHTTPRequest(unittest.TestCase):
     def test_user_agent_not_url_encoded(self):
-        headers = {'Some-Header': u'should be url encoded',
+        headers = {'Some-Header': u'should be encoded \u2713',
                    'User-Agent': UserAgent}
         request = HTTPRequest('PUT', 'https', 'amazon.com', 443, None,
                               None, {}, headers, 'Body')
@@ -539,7 +539,7 @@ class TestHTTPRequest(unittest.TestCase):
         # Ensure the headers at authorization are as expected i.e.
         # the user agent header was not url encoded but the other header was.
         self.assertEqual(mock_connection.headers_at_auth,
-                         {'Some-Header': 'should%20be%20url%20encoded',
+                         {'Some-Header': 'should be encoded %E2%9C%93',
                           'User-Agent': UserAgent})
 
     def test_content_length_str(self):


### PR DESCRIPTION
This fixes any method related to upload parts of an archive to glacier for both python 2 and python 3. I partially built this PR off of https://github.com/boto/boto/pull/2697 which had the fix for python 2.

Fixes https://github.com/boto/boto/issues/3318
Fixes https://github.com/boto/boto/issues/3304
Closes https://github.com/boto/boto/pull/2697
Closes https://github.com/boto/boto/pull/2557
Fixes https://github.com/boto/boto/issues/2524
Fixes https://github.com/boto/boto/issues/2209

cc @jamesls @JordonPhillips 