### PR TITLE
Fix for #3476

### DIFF
--- a/boto/rds/parametergroup.py
+++ b/boto/rds/parametergroup.py
@@ -146,7 +146,12 @@ class Parameter(object):
             value = int(value)
         if isinstance(value, int) or isinstance(value, long):
             if self.allowed_values:
-                min, max = self.allowed_values.split('-')
+                if self.allowed_values.startswith('-'):
+                    # range which begins with a negative value
+                    ign, min, max = self.allowed_values.split('-')
+                    min = '-' + min
+                else:
+                    min, max = self.allowed_values.split('-')
                 if value < int(min) or value > int(max):
                     raise ValueError('range is %s' % self.allowed_values)
             self._value = value


### PR DESCRIPTION

Several Postgres9.x engine parameters support a range of values, with a negative integer as the minimum. 

For example, from running `aws rds describe-db-parameters --db-parameter-group-name 'default.postgres9.3'`:

```
...
        {
            "ApplyMethod": "pending-reboot",
            "Description": "(ms) Vacuum cost delay in milliseconds, for autovacuum.",
            "DataType": "integer",
            "AllowedValues": "-1-100",
            "Source": "engine-default",
            "IsModifiable": true,
            "ParameterName": "autovacuum_vacuum_cost_delay",
            "ApplyType": "dynamic"
        },
...
```
(`"AllowedValues": "-1-100",`).

This change will detect if the AllowedValues string value starts with a negative number.
