### PR TITLE
Fixes file handler for `load_from_path` function

### DIFF
--- a/boto/pyami/config.py
+++ b/boto/pyami/config.py
@@ -93,14 +93,15 @@ class Config(object):
         self.readfp(c_data)
 
     def load_from_path(self, path):
-        file = open(path)
-        for line in file.readlines():
-            match = re.match("^#import[\s\t]*([^\s^\t]*)[\s\t]*$", line)
-            if match:
-                extended_file = match.group(1)
-                (dir, file) = os.path.split(path)
-                self.load_from_path(os.path.join(dir, extended_file))
-        self.read(path)
+        with open(path) as file:
+            for line in file.readlines():
+                match = re.match("^#import[\s\t]*([^\s^\t]*)[\s\t]*$", line)
+                if match:
+                    extended_file = match.group(1)
+                    (dir, file) = os.path.split(path)
+                    self.load_from_path(os.path.join(dir, extended_file))
+            self.read(path)
+
 
     def save_option(self, path, section, option, value):
         """


### PR DESCRIPTION
This is a small fix. Uses `with` to close the file correctly after usage. 

Tested with Python 3.5.1 on Fedora 23.