### PR TITLE
Fix python3 compability

### DIFF
--- a/boto/mws/connection.py
+++ b/boto/mws/connection.py
@@ -323,7 +323,10 @@ class MWSConnection(AWSQueryConnection):
                                                response.reason, body)
         digest = response.getheader('Content-MD5')
         if digest is not None:
-            assert content_md5(body) == digest
+            if type(content_md5(body)) is bytes:
+                assert content_md5(body).decode() == digest
+            else:
+                assert content_md5(body) == digest
         contenttype = response.getheader('Content-Type')
         return self._parse_response(parser, contenttype, body)
 


### PR DESCRIPTION
response.read() returns a byte-string
in python3. This breaks the assert on
line 326