### PR TITLE
Fix skip certificate validate does not work in python >= 2.7.9 and >= 3.4.3 issue.

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -751,6 +751,11 @@ class AWSAuthConnection(object):
                 connection = https_connection.CertValidatingHTTPSConnection(
                     host, ca_certs=self.ca_certificates_file,
                     **http_connection_kwargs)
+            elif HAVE_HTTPS_CONNECTION and \
+                    hasattr(ssl, '_create_unverified_context'):
+                http_connection_kwargs['context'] = ssl._create_unverified_context()
+                connection = http_client.HTTPSConnection(
+                    host, **http_connection_kwargs)
             else:
                 connection = http_client.HTTPSConnection(
                     host, **http_connection_kwargs)


### PR DESCRIPTION
httplib and http.client perform all the necessary certificate and host name checks by default since python 2.7.9 and 3.4.3 respectively.
To revert to the previous, unverified, behavior ssl._create_unverified_context() can be passed to the context parameter.