### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -204,7 +204,7 @@ Credentials and other boto-related settings can also be stored in a
 boto config file.  See `this`_ for details.
 
 .. _Contributing Guidelines: https://github.com/boto/boto/blob/develop/CONTRIBUTING
-.. _Porting Guide: http://boto.readthedocs.org/en/latest/porting_guide.html
+.. _Porting Guide: https://boto.readthedocs.io/en/latest/porting_guide.html
 .. _pip: http://www.pip-installer.org/
 .. _release notes: https://github.com/boto/boto/wiki
 .. _github.com: http://github.com/boto/boto

--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -9,7 +9,7 @@ stable and recommended for general use.  It can be used side-by-side with
 Boto in the same project, so it is easy to start using Boto3 in your existing
 projects as well as new projects. Going forward, API updates and all new
 feature work will be focused on Boto3.</p>
-<p>For more information, see the <a href="http://boto3.readthedocs.org/">documentation for boto3.</a></p>
+<p>For more information, see the <a href="https://boto3.readthedocs.io/">documentation for boto3.</a></p>
 </div>
 {{ super() }}
 {% endblock %}

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -197,7 +197,7 @@ and uses `restructured text`_ for the markup language.
 
 
 .. _nose: http://readthedocs.org/docs/nose/en/latest/
-.. _tagging: http://nose.readthedocs.org/en/latest/plugins/attrib.html
+.. _tagging: https://nose.readthedocs.io/en/latest/plugins/attrib.html
 .. _tox: http://tox.testrun.org/latest/
 .. _virtualenvwrapper: http://www.doughellmann.com/projects/virtualenvwrapper/
 .. _sphinx: http://sphinx.pocoo.org/

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -73,7 +73,7 @@ When you are done using ``boto``, you can deactivate your virtual environment::
 If you are creating a lot of virtual environments, `virtualenvwrapper`_
 is an excellent tool that lets you easily manage your virtual environments.
 
-.. _`virtualenvwrapper`: http://virtualenvwrapper.readthedocs.org/en/latest/
+.. _`virtualenvwrapper`: https://virtualenvwrapper.readthedocs.io/en/latest/
 
 
 Configuring Boto Credentials

--- a/docs/source/releasenotes/v2.37.0.rst
+++ b/docs/source/releasenotes/v2.37.0.rst
@@ -13,7 +13,7 @@ bugs in several services.
    ``trail`` parameter, which has been marked for removal by the service
    since early 2014. Instead, you pass each trail parameter as a keyword
    argument now. Please see the
-   `reference <http://boto.readthedocs.org/en/latest/ref/cloudtrail.html#boto.cloudtrail.layer1.CloudTrailConnection.create_trail>`__
+   `reference <https://boto.readthedocs.io/en/latest/ref/cloudtrail.html#boto.cloudtrail.layer1.CloudTrailConnection.create_trail>`__
    to help port over existing code.
 
 


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.