### PR TITLE
Respect is_secure parameter in generate_url_sigv4

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -771,8 +771,8 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         # Add signature to params now that we have it
         req.params['X-Amz-Signature'] = signature
 
-        return 'https://%s%s?%s' % (req.host, req.path,
-                                    urllib.parse.urlencode(req.params))
+        return '%s://%s%s?%s' % (req.protocol, req.host, req.path,
+                                 urllib.parse.urlencode(req.params))
 
 
 class STSAnonHandler(AuthHandler):

--- a/tests/unit/s3/test_connection.py
+++ b/tests/unit/s3/test_connection.py
@@ -141,6 +141,37 @@ class TestSigV4Presigned(MockServiceWithConfigTestCase):
             'a937f5fbc125d98ac8f04c49e0204ea1526a7b8ca058000a54c192457be05b7d',
             url)
 
+    def test_sigv4_presign_respects_is_secure(self):
+        self.config = {
+            's3': {
+                'use-sigv4': True,
+            }
+        }
+
+        conn = self.connection_class(
+            aws_access_key_id='less',
+            aws_secret_access_key='more',
+            host='s3.amazonaws.com',
+            is_secure=True,
+        )
+
+        url = conn.generate_url_sigv4(86400, 'GET', bucket='examplebucket',
+                                      key='test.txt')
+        self.assertTrue(url.startswith(
+            'https://examplebucket.s3.amazonaws.com/test.txt?'))
+
+        conn = self.connection_class(
+            aws_access_key_id='less',
+            aws_secret_access_key='more',
+            host='s3.amazonaws.com',
+            is_secure=False,
+        )
+
+        url = conn.generate_url_sigv4(86400, 'GET', bucket='examplebucket',
+                                      key='test.txt')
+        self.assertTrue(url.startswith(
+            'http://examplebucket.s3.amazonaws.com/test.txt?'))
+
     def test_sigv4_presign_optional_params(self):
         self.config = {
             's3': {


### PR DESCRIPTION
Previously, the protocol was hardcoded to https.