### PR TITLE
Remove the broken link to PDF's

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,3 +1,0 @@
-{% extends '!layout.html' %}
-
-{% block sidebarsearch %}{{ super() }}<div><a href="boto.pdf">PDF Version</a></div>{% endblock %}


### PR DESCRIPTION
Clicking on the "PDF Version" link currently results in 404: http://boto.readthedocs.io/en/latest/. I still believe that read the docs produces a PDF but when they changed the domain to readthedocs.io that broke that link. I much rather rely on the link to the PDF they provide in their widget instead of fix the link and have it break again.

cc @jamesls @JordonPhillips 