### PR TITLE
Mock https connection in ecs test

### DIFF
--- a/tests/unit/ec2containerservice/test_connection.py
+++ b/tests/unit/ec2containerservice/test_connection.py
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
+import httplib
+from mock import Mock
 from tests.unit import unittest
 
 import boto.ec2containerservice
@@ -28,6 +30,15 @@ from boto.ec2containerservice.layer1 import EC2ContainerServiceConnection
 
 class TestConnectToRegion(unittest.TestCase):
 
+    def setUp(self):
+        self.https_connection = Mock(spec=httplib.HTTPSConnection)
+        self.https_connection_factory = (
+            Mock(return_value=self.https_connection), ())
+
     def test_aws_region(self):
-        ecs = boto.ec2containerservice.connect_to_region('us-east-1')
+        ecs = boto.ec2containerservice.connect_to_region('us-east-1',
+            https_connection_factory=self.https_connection_factory,
+            aws_access_key_id='aws_access_key_id',
+            aws_secret_access_key='aws_secret_access_key'
+        )
         self.assertIsInstance(ecs, EC2ContainerServiceConnection)


### PR DESCRIPTION
Makes this consistent with the EC2 unit tests.

cc @kyleknap @JordonPhillips 