### PR TITLE
Fix ec2/ecs unit tests

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -2650,7 +2650,7 @@ class EC2Connection(AWSQueryConnection):
         # get all the snapshots, sort them by date and time, and
         # organize them into one array for each volume:
         all_snapshots = self.get_all_snapshots(owner = 'self')
-        all_snapshots.sort(cmp = lambda x, y: cmp(x.start_time, y.start_time))
+        all_snapshots.sort(key=lambda x: x.start_time)
         snaps_for_each_volume = {}
         for snap in all_snapshots:
             # the snapshot name and the volume name are the same.

--- a/tests/unit/ec2/test_connection.py
+++ b/tests/unit/ec2/test_connection.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-import httplib
-
 from datetime import datetime, timedelta
 from mock import MagicMock, Mock
 from tests.unit import unittest
@@ -13,6 +11,7 @@ from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping
 from boto.ec2.connection import EC2Connection
 from boto.ec2.snapshot import Snapshot
 from boto.ec2.reservedinstance import ReservedInstancesConfiguration
+from boto.compat import http_client
 
 
 class TestEC2ConnectionBase(AWSMockServiceTestCase):
@@ -990,12 +989,12 @@ class TestModifyInterfaceAttribute(TestEC2ConnectionBase):
 
 class TestConnectToRegion(unittest.TestCase):
     def setUp(self):
-        self.https_connection = Mock(spec=httplib.HTTPSConnection)
+        self.https_connection = Mock(spec=http_client.HTTPSConnection)
         self.https_connection_factory = (
             Mock(return_value=self.https_connection), ())
 
     def test_aws_region(self):
-        region = boto.ec2.RegionData.keys()[0]
+        region = list(boto.ec2.RegionData.keys())[0]
         self.ec2 = boto.ec2.connect_to_region(
             region,
             https_connection_factory=self.https_connection_factory,

--- a/tests/unit/ec2containerservice/test_connection.py
+++ b/tests/unit/ec2containerservice/test_connection.py
@@ -20,18 +20,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-import httplib
 from mock import Mock
 from tests.unit import unittest
 
 import boto.ec2containerservice
 from boto.ec2containerservice.layer1 import EC2ContainerServiceConnection
+from boto.compat import http_client
 
 
 class TestConnectToRegion(unittest.TestCase):
 
     def setUp(self):
-        self.https_connection = Mock(spec=httplib.HTTPSConnection)
+        self.https_connection = Mock(spec=http_client.HTTPSConnection)
         self.https_connection_factory = (
             Mock(return_value=self.https_connection), ())
 

--- a/tests/unit/ec2containerservice/test_connection.py
+++ b/tests/unit/ec2containerservice/test_connection.py
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
+import httplib
+from mock import Mock
 from tests.unit import unittest
 
 import boto.ec2containerservice
@@ -28,6 +30,15 @@ from boto.ec2containerservice.layer1 import EC2ContainerServiceConnection
 
 class TestConnectToRegion(unittest.TestCase):
 
+    def setUp(self):
+        self.https_connection = Mock(spec=httplib.HTTPSConnection)
+        self.https_connection_factory = (
+            Mock(return_value=self.https_connection), ())
+
     def test_aws_region(self):
-        ecs = boto.ec2containerservice.connect_to_region('us-east-1')
+        ecs = boto.ec2containerservice.connect_to_region('us-east-1',
+            https_connection_factory=self.https_connection_factory,
+            aws_access_key_id='aws_access_key_id',
+            aws_secret_access_key='aws_secret_access_key'
+        )
         self.assertIsInstance(ecs, EC2ContainerServiceConnection)


### PR DESCRIPTION
Run ec2/ecs tests as part of default test run

I noticed that these tests aren't being run because they're
currently marked as executable, and nose skips executable files
by default.

After `-x` the files, I had an ec2 test failure because
`cmp` is now longer valid in python3.

I also noticed we're using `httplib` which fails in python3.

cc @kyleknap @JordonPhillips 

Note: I discovered this while working on #3569, so it pulls in that commit as well.