### PR TITLE
boto.dynamodb2.table.Table#batch_get() fails to paginate results if provisioned throughput is exceeded

### DIFF
--- a/boto/dynamodb2/table.py
+++ b/boto/dynamodb2/table.py
@@ -669,7 +669,7 @@ class Table(object):
         should be fetched)
 
         Returns an ``Item`` instance containing all the data for that record.
-        
+
         Raises an ``ItemNotFound`` exception if the item is not found.
 
         Example::
@@ -1581,9 +1581,9 @@ class Table(object):
             })
             results.append(item)
 
-        raw_unproccessed = raw_results.get('UnprocessedKeys', {})
+        raw_unprocessed = raw_results.get('UnprocessedKeys', {}).get(self.table_name, {})
 
-        for raw_key in raw_unproccessed.get('Keys', []):
+        for raw_key in raw_unprocessed.get('Keys', []):
             py_key = {}
 
             for key, value in raw_key.items():

--- a/tests/unit/dynamodb2/test_table.py
+++ b/tests/unit/dynamodb2/test_table.py
@@ -1131,7 +1131,7 @@ class BatchGetResultSetTestCase(unittest.TestCase):
         self.assertFalse(self.results._results_left)
 
     def test_fetch_more_empty(self):
-        self.results.to_call(lambda keys: {'results': [], 'last_key': None}) 
+        self.results.to_call(lambda keys: {'results': [], 'last_key': None})
 
         self.results.fetch_more()
         self.assertEqual(self.results._results, [])
@@ -2913,9 +2913,11 @@ class TableTestCase(unittest.TestCase):
         # Now alter the expected.
         del expected['Responses']['users'][2]
         expected['UnprocessedKeys'] = {
-            'Keys': [
-                {'username': {'S': 'jane',}},
-            ],
+            'users': {
+                'Keys': [
+                    {'username': {'S': 'jane',}},
+                ],
+            },
         }
 
         with mock.patch.object(


### PR DESCRIPTION
Fixes https://github.com/boto/boto/issues/3575.

From the [documentation](http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html) (emphasis mine):
> ### UnprocessedKeys
> A ***map of tables*** and their respective keys that were not processed with the current response. The UnprocessedKeys value is in the same form as RequestItems, so the value can be provided directly to a subsequent BatchGetItem operation. For more information, see RequestItems in the Request Parameters section.
>
> ***Each element*** consists of:
>
> - Keys - An array of primary key attribute values that define specific items in the table.
> - AttributesToGet - One or more attributes to be retrieved from the table or index. By default, all attributes are returned. If a requested attribute is not found, it does not appear in the result.
> - ConsistentRead - The consistency of a read operation. If set to true, then a strongly consistent read is used; otherwise, an eventually consistent read is used.
>
> If there are no unprocessed keys remaining, the response contains an empty UnprocessedKeys map.
>
> Type: String to KeysAndAttributes object map