### PR TITLE
Do not encode query string parameters

### DIFF
--- a/boto/cloudfront/invalidation.py
+++ b/boto/cloudfront/invalidation.py
@@ -14,7 +14,7 @@
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
 # ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
@@ -71,7 +71,7 @@ class InvalidationBatch(object):
         """Escape a path, make sure it begins with a slash and contains no invalid characters. Retain literal wildcard characters."""
         if not p[0] == "/":
             p = "/%s" % p
-        return urllib.parse.quote(p, safe = "/*")
+        return urllib.parse.quote(p, safe = "/*&?=")
 
     def to_xml(self):
         """Get this batch as XML"""

--- a/tests/unit/cloudfront/test_invalidation.py
+++ b/tests/unit/cloudfront/test_invalidation.py
@@ -19,5 +19,13 @@ class CFInvalidationTest(unittest.TestCase):
         self.assertEqual(batch.escape("/nowildcard"), "/nowildcard")
         self.assertEqual(batch.escape("/other special characters"), "/other%20special%20characters")
 
+    def test_argument_escape(self):
+        """
+        Test that query string parameters are retained as literals
+        See: http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/QueryStringParameters.html
+        """
+        batch = cf.invalidation.InvalidationBatch()
+        self.assertEqual(batch.escape("/foo/bar/baz.jpg?filtered=false&size=*"), "/foo/bar/baz.jpg?filtered=false&size=*")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When Cloudfront is configured to forward parameters it is often
useful to be able to invalidation based on these parameters. This
fixes issue #3591.