### PR TITLE
Add ap-south-1 endpoint for autoscaling service

### DIFF
--- a/boto/endpoints.json
+++ b/boto/endpoints.json
@@ -2,6 +2,7 @@
     "autoscaling": {
         "ap-northeast-1": "autoscaling.ap-northeast-1.amazonaws.com",
         "ap-northeast-2": "autoscaling.ap-northeast-2.amazonaws.com",
+        "ap-south-1": "autoscaling.ap-south-1.amazonaws.com",
         "ap-southeast-1": "autoscaling.ap-southeast-1.amazonaws.com",
         "ap-southeast-2": "autoscaling.ap-southeast-2.amazonaws.com",
         "cn-north-1": "autoscaling.cn-north-1.amazonaws.com.cn",


### PR DESCRIPTION
boto 2.42 is missing the endpoint of the autoscaling service for the ap-south-1 Mumbai (India) region.
