### PR TITLE
Set self.etag to lowercase for md5 comparison

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -977,7 +977,7 @@ class Key(object):
             server_side_encryption_customer_algorithm = response.getheader(
                 'x-amz-server-side-encryption-customer-algorithm', None)
             if server_side_encryption_customer_algorithm is None:
-                if self.etag != '"%s"' % md5:
+                if str(self.etag).lower() != '"%s"' % md5:
                     raise provider.storage_data_error(
                         'ETag from S3 did not match computed MD5. '
                         '%s vs. %s' % (self.etag, self.md5))


### PR DESCRIPTION
I was working on using boto against an S3-compatible service, but the service returns etags as uppercase, so it fails to match md5 comparison. I wrapped self.etag in `str()` in the event it is `None`, so `lower()` doesn't fail -- that seems like the the right thing to do. I could also do `if self.etag and self.etag.lower()`. I'm not sure if you'd have a preference. :)