### PR TITLE
Fixed GS connection converting bucket_name

### DIFF
--- a/boto/gs/connection.py
+++ b/boto/gs/connection.py
@@ -91,7 +91,7 @@ class GSConnection(S3Connection):
         data = ('<CreateBucketConfiguration>%s%s</CreateBucketConfiguration>'
                  % (location_elem, storage_class_elem))
         response = self.make_request(
-            'PUT', get_utf8_value(bucket_name), headers=headers,
+            'PUT', bucket_name, headers=headers,
             data=get_utf8_value(data))
         body = response.read()
         if response.status == 409:


### PR DESCRIPTION
Boto was incorrectly converting bucket_name to bytes. It should be kept
a string. This caused an error down the stacktrace in boto.s3.connection:94 when
trying to build the path.