### PR TITLE
Fixed GS wrongly converting bucket_name

### DIFF
--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -438,7 +438,7 @@ class Bucket(S3Bucket):
             headers['x-goog-if-metageneration-match'] = str(if_metageneration)
 
         response = self.connection.make_request(
-            'PUT', get_utf8_value(self.name), get_utf8_value(key_name),
+            'PUT', self.name, get_utf8_value(key_name),
             data=get_utf8_value(data), headers=headers, query_args=query_args)
         body = response.read()
         if response.status != 200:
@@ -584,7 +584,7 @@ class Bucket(S3Bucket):
         :param dict headers: Additional headers to send with the request.
         """
         response = self.connection.make_request(
-            'PUT', get_utf8_value(self.name), data=get_utf8_value(cors),
+            'PUT', self.name, data=get_utf8_value(cors),
             query_args=CORS_ARG, headers=headers)
         body = response.read()
         if response.status != 200:
@@ -847,7 +847,7 @@ class Bucket(S3Bucket):
 
         body = self.WebsiteBody % (main_page_frag, error_frag)
         response = self.connection.make_request(
-            'PUT', get_utf8_value(self.name), data=get_utf8_value(body),
+            'PUT', self.name, data=get_utf8_value(body),
             query_args='websiteConfig', headers=headers)
         body = response.read()
         if response.status == 200:
@@ -979,7 +979,7 @@ class Bucket(S3Bucket):
         """
         xml = lifecycle_config.to_xml()
         response = self.connection.make_request(
-            'PUT', get_utf8_value(self.name), data=get_utf8_value(xml),
+            'PUT', self.name, data=get_utf8_value(xml),
             query_args=LIFECYCLE_ARG, headers=headers)
         body = response.read()
         if response.status == 200:

--- a/boto/gs/connection.py
+++ b/boto/gs/connection.py
@@ -91,7 +91,7 @@ class GSConnection(S3Connection):
         data = ('<CreateBucketConfiguration>%s%s</CreateBucketConfiguration>'
                  % (location_elem, storage_class_elem))
         response = self.make_request(
-            'PUT', get_utf8_value(bucket_name), headers=headers,
+            'PUT', bucket_name, headers=headers,
             data=get_utf8_value(data))
         body = response.read()
         if response.status == 409:

--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -934,7 +934,7 @@ class Key(S3Key):
         if content_type:
             headers['Content-Type'] = content_type
         resp = self.bucket.connection.make_request(
-            'PUT', get_utf8_value(self.bucket.name), get_utf8_value(self.name),
+            'PUT', self.bucket.name, get_utf8_value(self.name),
             headers=headers, query_args='compose',
             data=get_utf8_value(compose_req_xml))
         if resp.status < 200 or resp.status > 299:


### PR DESCRIPTION
Boto was incorrectly converting bucket_name to bytes. It should be kept
a string. This caused an error down the stacktrace in boto.s3.connection:94 when
trying to build the path.

I messed up that last pull request some how. Let's try this again.