### PR TITLE
python3 fix: rm reference to basestring

### DIFF
--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -22,6 +22,8 @@ import xml.sax
 import datetime
 import itertools
 
+import six
+
 from boto import handler
 from boto import config
 from boto.mturk.price import Price
@@ -676,7 +678,7 @@ class MTurkConnection(AWSQueryConnection):
             params['TestDurationInSeconds'] = test_duration
 
         if answer_key is not None:
-            if isinstance(answer_key, basestring):
+            if isinstance(answer_key, six.string_types):
                 params['AnswerKey'] = answer_key  # xml
             else:
                 raise TypeError


### PR DESCRIPTION
Another fix to make mturk work under Python 3.