### PR TITLE
Account for metadata update propagation delay

### DIFF
--- a/tests/integration/gs/testcase.py
+++ b/tests/integration/gs/testcase.py
@@ -113,6 +113,7 @@ class GSTestCase(unittest.TestCase):
         deleted."""
         b = self._MakeBucket()
         b.configure_versioning(True)
+        time.sleep(30)  # Ensure versioning config propagates.
         return b
 
     def _MakeTempDir(self):


### PR DESCRIPTION
Wait 30s as described at
https://cloud.google.com/storage/docs/access-control/lists#defaultobjects, which has the same behavior.

Reviewed in https://codereview.appspot.com/304650043