### PR TITLE
Fix asadmin migration to check instance count, use autoscale terminate instead of ec2 terminate

### DIFF
--- a/bin/asadmin
+++ b/bin/asadmin
@@ -164,10 +164,11 @@ def migrate_instances(autoscale, name):
     g = get_group(autoscale, name)
 
     old_instances = g.instances
+    old_instances_count = len(old_instances)
     ec2 = boto.connect_ec2()
     for old_instance in old_instances:
         print "Terminating instance " + old_instance.instance_id
-        ec2.terminate_instances([old_instance.instance_id])
+        autoscale.terminate_instance(old_instance.instance_id, False)
         while True:
             g = get_group(autoscale, name)
             new_instances = g.instances
@@ -182,6 +183,10 @@ def migrate_instances(autoscale, name):
                     instancesReady = False
                     print "Waiting for instances to be ready...."
                     break
+            if len(new_instances) < old_instances_count:
+                instancesReady = False
+                print "Waiting for new instance to be created..."
+
             if(not hasOldInstance and instancesReady):
                 break
             else:


### PR DESCRIPTION
There is a bug in the asadmin migration process which can cause to shut down two instances at once. There is a short period of time when the old instance is destroyed but the autoscaling group did not create a new one yet. This fix checks the instance count too.

Also instead of terminating the ec2 instance we should use autoscale.terminate which is safer and also leaves a more friendly message in the asg history: "instance i-xxx was taken out of service in response to a user request."
