### PR TITLE
Add ReviewPolicy class

### DIFF
--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -185,7 +185,9 @@ class MTurkConnection(AWSQueryConnection):
                    reward=None, duration=datetime.timedelta(days=7),
                    approval_delay=None, annotation=None,
                    questions=None, qualifications=None,
-                   layout_params=None, response_groups=None):
+                   layout_params=None, response_groups=None,
+                   assignment_review_policy=None,
+                   hit_review_policy=None):
         """
         Creates a new HIT.
         Returns a ResultSet
@@ -260,6 +262,13 @@ class MTurkConnection(AWSQueryConnection):
         # Handle optional response groups argument
         if response_groups:
             self.build_list_params(params, response_groups, 'ResponseGroup')
+
+        # add AssignmentReviewPolicy and HITReviewPolicy if specified
+        if assignment_review_policy is not None:
+            params.update(assignment_review_policy.get_as_params())
+
+        if hit_review_policy is not None:
+            params.update(hit_review_policy.get_as_params())
 
         # Submit
         return self._process_request('CreateHIT', params, [('HIT', HIT)])

--- a/boto/mturk/review_policy.py
+++ b/boto/mturk/review_policy.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2016 Jonas B. Zimmermann
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+"""
+Provides ReviewPolicy, Parameter, and MapEntry classes, implementing
+the AssignmentReviewPolicy and HITReviewPolicy data structures described in
+http://docs.aws.amazon.com/AWSMechTurk/latest/AWSMturkAPI/ApiReference_HITReviewPolicyDataStructureArticle.html.
+To be used as arguments to boto.mturk.connection.create_hit.
+"""
+
+
+class ReviewPolicy(object):
+    """ReviewPolicy. kind can be 'Assignment' or 'HIT'.
+    paramters should be a list of Parameters.
+    See http://docs.aws.amazon.com/AWSMechTurk/latest/AWSMturkAPI/ApiReference_HITReviewPolicyDataStructureArticle.html
+    """
+    def __init__(self, kind='Assignment', policy_name="ScoreMyKnownAnswers/2011-09-01", parameters=None):
+        self.kind = kind
+        self.policy_name = policy_name
+        self.parameters = parameters
+
+    def get_as_params(self):
+        prefix = '%sReviewPolicy' % (self.kind,)
+        params = {
+            '%s.PolicyName'%(prefix,): self.policy_name
+        }
+        if self.parameters is not None:
+            for i, param in enumerate(self.parameters, 1):
+                paramparams = param.get_as_params()
+                for pp in paramparams:
+                    params['%s.Parameter.%s.%s' % (prefix, i, pp) ] = paramparams[pp]
+        return params
+
+class Parameter(object):
+    """Representation of a single Parameter
+    A Parameter consists of a Key element (string) and either a Value (string) or one or several MapEntry structures.
+    The argument map_entries should be a list of MapEntry elements.
+    """
+    def __init__(self, key, value=None, map_entries=None):
+        self.key = key
+        self.value = value
+        self.map_entries = map_entries
+    def get_as_params(self):
+        params =  {
+            "Key": self.key,
+        }
+        if self.map_entries is not None:
+            for i, map_entry in enumerate(self.map_entries, 1):
+                mapparams = map_entry.get_as_params()
+                for mp in mapparams:
+                    params['MapEntry.%s.%s' % (i, mp) ] = mapparams[mp]
+        else:
+            params['Value'] = self.value
+        return params
+
+
+class MapEntry(object):
+    """Representation of a single MapEntry
+    A MapEntry consists of a Key element (string) and one or several Values. The constructor should be called with
+    either the value or the values argument set to a not-None value. The latter should be a list."""
+    def __init__(self, key, value=None, values=None):
+        self.key = key
+        self.value = value
+        self.values = values
+    def get_as_params(self):
+        params =  {
+            "Key": self.key,
+        }
+        if self.values is not None:
+            for i, value in enumerate(self.values, 1):
+                params['Value.%d' % i] = value
+        else:
+            params['Value'] = self.value
+        return params

--- a/boto/mturk/review_policy.py
+++ b/boto/mturk/review_policy.py
@@ -23,7 +23,7 @@
 Provides ReviewPolicy, Parameter, and MapEntry classes, implementing
 the AssignmentReviewPolicy and HITReviewPolicy data structures described in
 http://docs.aws.amazon.com/AWSMechTurk/latest/AWSMturkAPI/ApiReference_HITReviewPolicyDataStructureArticle.html.
-To be used as arguments to boto.mturk.connection.create_hit.
+To be used as arguments to boto.mturk.connection.create_hit().
 """
 
 
@@ -54,9 +54,10 @@ class Parameter(object):
     A Parameter consists of a Key element (string) and either a Value (string) or one or several MapEntry structures.
     The argument map_entries should be a list of MapEntry elements.
     """
-    def __init__(self, key, value=None, map_entries=None):
+    def __init__(self, key, value=None, values=None, map_entries=None):
         self.key = key
         self.value = value
+        self.values = values
         self.map_entries = map_entries
     def get_as_params(self):
         params =  {
@@ -67,10 +68,12 @@ class Parameter(object):
                 mapparams = map_entry.get_as_params()
                 for mp in mapparams:
                     params['MapEntry.%s.%s' % (i, mp) ] = mapparams[mp]
+        elif self.values is not None:
+            for i, value in enumerate(self.values, 1):
+                params['Value.%d' % i] = value
         else:
             params['Value'] = self.value
         return params
-
 
 class MapEntry(object):
     """Representation of a single MapEntry


### PR DESCRIPTION
Implements #1452: Adds `ReviewPolicy` class, which can be used to create AssignmentReviewPolicy and HITReviewPolicy data structures for `mturk.connection.create_hit()`.

Note that no tests have been implemented because currently all mturk tests fail (looks like inappropriate use of `global` for `SetHostMTurkConnection`)