### PR TITLE
Add gs support for object-level storage class features.

### DIFF
--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -131,6 +131,8 @@ class Key(S3Key):
                 self.content_encoding = value
             elif key == 'x-goog-stored-content-length':
                 self.size = int(value)
+            elif key == 'x-goog-storage-class':
+                self.storage_class = value
 
     def open_read(self, headers=None, query_args='',
                   override_num_retries=None, response_headers=None):

--- a/boto/storage_uri.py
+++ b/boto/storage_uri.py
@@ -444,13 +444,24 @@ class BucketStorageUri(StorageUri):
 
     def get_storage_class(self, validate=False, headers=None):
         self._check_bucket_uri('get_storage_class')
-        # StorageClass is defined as a bucket param for GCS, but as a key
-        # param for S3.
+        # StorageClass is defined as a bucket and object param for GCS, but
+        # only as a key param for S3.
         if self.scheme != 'gs':
             raise ValueError('get_storage_class() not supported for %s '
                              'URIs.' % self.scheme)
         bucket = self.get_bucket(validate, headers)
         return bucket.get_storage_class()
+
+    def set_storage_class(self, storage_class, validate=False, headers=None):
+        """Updates a bucket's storage class."""
+        self._check_bucket_uri('set_storage_class')
+        # StorageClass is defined as a bucket and object param for GCS, but
+        # only as a key param for S3.
+        if self.scheme != 'gs':
+            raise ValueError('set_storage_class() not supported for %s '
+                             'URIs.' % self.scheme)
+        bucket = self.get_bucket(validate, headers)
+        bucket.set_storage_class(storage_class, headers)
 
     def get_subresource(self, subresource, validate=False, headers=None,
                         version_id=None):

--- a/tests/integration/gs/test_basic.py
+++ b/tests/integration/gs/test_basic.py
@@ -56,15 +56,22 @@ LIFECYCLE_EMPTY = ('<?xml version="1.0" encoding="UTF-8"?>'
 LIFECYCLE_DOC = ('<?xml version="1.0" encoding="UTF-8"?>'
                  '<LifecycleConfiguration><Rule>'
                  '<Action><Delete/></Action>'
-                 '<Condition><Age>365</Age>'
+                 '<Condition>''<IsLive>true</IsLive>'
+                 '<MatchesStorageClass>STANDARD</MatchesStorageClass>'
+                 '<Age>365</Age>'
                  '<CreatedBefore>2013-01-15</CreatedBefore>'
                  '<NumberOfNewerVersions>3</NumberOfNewerVersions>'
-                 '<IsLive>true</IsLive></Condition>'
-                 '</Rule></LifecycleConfiguration>')
-LIFECYCLE_CONDITIONS = {'Age': '365',
-                        'CreatedBefore': '2013-01-15',
-                        'NumberOfNewerVersions': '3',
-                        'IsLive': 'true'}
+                 '</Condition></Rule><Rule>'
+                 '<Action><SetStorageClass>NEARLINE</SetStorageClass></Action>'
+                 '<Condition><Age>366</Age>'
+                 '</Condition></Rule></LifecycleConfiguration>')
+LIFECYCLE_CONDITIONS_FOR_DELETE_RULE = {
+    'Age': '365',
+    'CreatedBefore': '2013-01-15',
+    'NumberOfNewerVersions': '3',
+    'IsLive': 'true',
+    'MatchesStorageClass': ['STANDARD']}
+LIFECYCLE_CONDITIONS_FOR_SET_STORAGE_CLASS_RULE = {'Age': '366'}
 
 # Regexp for matching project-private default object ACL.
 PROJECT_PRIVATE_RE = ('\s*<AccessControlList>\s*<Entries>\s*<Entry>'
@@ -412,7 +419,11 @@ class GSBasicTest(GSTestCase):
         self.assertEqual(xml, LIFECYCLE_EMPTY)
         # set lifecycle config
         lifecycle_config = LifecycleConfig()
-        lifecycle_config.add_rule('Delete', None, LIFECYCLE_CONDITIONS)
+        lifecycle_config.add_rule(
+            'Delete', None, LIFECYCLE_CONDITIONS_FOR_DELETE_RULE)
+        lifecycle_config.add_rule(
+            'SetStorageClass', 'NEARLINE',
+            LIFECYCLE_CONDITIONS_FOR_SET_STORAGE_CLASS_RULE)
         bucket.configure_lifecycle(lifecycle_config)
         xml = bucket.get_lifecycle_config().to_xml()
         self.assertEqual(xml, LIFECYCLE_DOC)
@@ -428,7 +439,11 @@ class GSBasicTest(GSTestCase):
         self.assertEqual(xml, LIFECYCLE_EMPTY)
         # set lifecycle config
         lifecycle_config = LifecycleConfig()
-        lifecycle_config.add_rule('Delete', None, LIFECYCLE_CONDITIONS)
+        lifecycle_config.add_rule(
+            'Delete', None, LIFECYCLE_CONDITIONS_FOR_DELETE_RULE)
+        lifecycle_config.add_rule(
+            'SetStorageClass', 'NEARLINE',
+            LIFECYCLE_CONDITIONS_FOR_SET_STORAGE_CLASS_RULE)
         uri.configure_lifecycle(lifecycle_config)
         xml = uri.get_lifecycle_config().to_xml()
         self.assertEqual(xml, LIFECYCLE_DOC)


### PR DESCRIPTION
This adds support for per-object storage class functionality to gsutil through the XML API.  Support for this functionality was introduced for the JSON API (and XML API where possible without Boto changes) in gsutil in this commit:
https://github.com/GoogleCloudPlatform/gsutil/commit/2b8959f2bfc4fb9b53aa7297c37c07d38a5befd4

...but these additions to Boto are necessary to make all the new features work with the XML API.