### PR TITLE
Unify connection and allow using endpoint heuristics

### DIFF
--- a/boto/awslambda/__init__.py
+++ b/boto/awslambda/__init__.py
@@ -20,6 +20,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -34,7 +35,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.awslambda.layer1 import AWSLambdaConnection
+    return connect('awslambda', region_name,
+                   connection_cls=AWSLambdaConnection, **kw_params)

--- a/boto/beanstalk/__init__.py
+++ b/boto/beanstalk/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -30,15 +31,14 @@ def regions():
     :rtype: list
     :return: A list of :class:`boto.regioninfo.RegionInfo`
     """
-    import boto.beanstalk.layer1
+    from boto.beanstalk.layer1 import Layer1
     return get_regions(
         'elasticbeanstalk',
-        connection_cls=boto.beanstalk.layer1.Layer1
+        connection_cls=Layer1
     )
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.beanstalk.layer1 import Layer1
+    return connect('elasticbeanstalk', region_name, connection_cls=Layer1,
+                   **kw_params)

--- a/boto/cloudformation/__init__.py
+++ b/boto/cloudformation/__init__.py
@@ -22,6 +22,7 @@
 
 from boto.cloudformation.connection import CloudFormationConnection
 from boto.regioninfo import RegionInfo, get_regions, load_regions
+from boto.regioninfo import connect
 
 RegionData = load_regions().get('cloudformation')
 
@@ -50,7 +51,5 @@ def connect_to_region(region_name, **kw_params):
     :return: A connection to the given region, or None if an invalid region
         name is given
     """
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    return connect('cloudformation', region_name,
+                   connection_cls=CloudFormationConnection, **kw_params)

--- a/boto/cloudhsm/__init__.py
+++ b/boto/cloudhsm/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -35,7 +36,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.cloudhsm.layer1 import CloudHSMConnection
+    return connect('cloudhsm', region_name, connection_cls=CloudHSMConnection,
+                   **kw_params)

--- a/boto/cloudsearch/__init__.py
+++ b/boto/cloudsearch/__init__.py
@@ -22,6 +22,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -31,15 +32,11 @@ def regions():
     :rtype: list
     :return: A list of :class:`boto.regioninfo.RegionInfo`
     """
-    import boto.cloudsearch.layer1
-    return get_regions(
-        'cloudsearch',
-        connection_cls=boto.cloudsearch.layer1.Layer1
-    )
+    from boto.cloudsearch.layer1 import Layer1
+    return get_regions('cloudsearch',connection_cls=Layer1)
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.cloudsearch.layer1 import Layer1
+    return connect('cloudsearch', region_name, connection_cls=Layer1,
+                   **kw_params)

--- a/boto/cloudsearch2/__init__.py
+++ b/boto/cloudsearch2/__init__.py
@@ -19,6 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 from boto.regioninfo import get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -28,15 +29,11 @@ def regions():
     :rtype: list
     :return: A list of :class:`boto.regioninfo.RegionInfo`
     """
-    import boto.cloudsearch2.layer1
-    return get_regions(
-        'cloudsearch',
-        connection_cls=boto.cloudsearch2.layer1.CloudSearchConnection
-    )
+    from boto.cloudsearch2.layer1 import CloudSearchConnection
+    return get_regions('cloudsearch', connection_cls=CloudSearchConnection)
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.cloudsearch2.layer1 import CloudSearchConnection
+    return connect('cloudsearch', region_name,
+                   connection_cls=CloudSearchConnection, **kw_params)

--- a/boto/cloudsearchdomain/__init__.py
+++ b/boto/cloudsearchdomain/__init__.py
@@ -20,6 +20,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -35,7 +36,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.cloudsearchdomain.layer1 import CloudSearchDomainConnection
+    return connect('cloudsearchdomain', region_name,
+                   connection_cls=CloudSearchDomainConnection, **kw_params)

--- a/boto/cloudtrail/__init__.py
+++ b/boto/cloudtrail/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -35,7 +36,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.cloudtrail.layer1 import CloudTrailConnection
+    return connect('cloudtrail', region_name,
+                   connection_cls=CloudTrailConnection, **kw_params)

--- a/boto/codedeploy/__init__.py
+++ b/boto/codedeploy/__init__.py
@@ -20,6 +20,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -34,7 +35,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.codedeploy.layer1 import CodeDeployConnection
+    return connect('codedeploy', region_name,
+                   connection_cls=CodeDeployConnection, **kw_params)

--- a/boto/cognito/identity/__init__.py
+++ b/boto/cognito/identity/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -36,7 +37,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.cognito.identity.layer1 import CognitoIdentityConnection
+    return connect('cognito-identity', region_name,
+                   connection_cls=CognitoIdentityConnection, **kw_params)

--- a/boto/cognito/sync/__init__.py
+++ b/boto/cognito/sync/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -35,7 +36,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.cognito.sync.layer1 import CognitoSyncConnection
+    return connect('cognito-sync', region_name,
+                   connection_cls=CognitoSyncConnection, **kw_params)

--- a/boto/configservice/__init__.py
+++ b/boto/configservice/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -35,7 +36,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.configservice.layer1 import ConfigServiceConnection
+    return connect('configservice', region_name,
+                   connection_cls=ConfigServiceConnection, **kw_params)

--- a/boto/datapipeline/__init__.py
+++ b/boto/datapipeline/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -35,7 +36,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.datapipeline.layer1 import DataPipelineConnection
+    return connect('datapipeline', region_name,
+                   connection_cls=DataPipelineConnection, **kw_params)

--- a/boto/directconnect/__init__.py
+++ b/boto/directconnect/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -35,7 +36,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.directconnect.layer1 import DirectConnectConnection
+    return connect('directconnect', region_name,
+                   connection_cls=DirectConnectConnection, **kw_params)

--- a/boto/dynamodb/__init__.py
+++ b/boto/dynamodb/__init__.py
@@ -22,6 +22,7 @@
 #
 
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -31,12 +32,10 @@ def regions():
     :rtype: list
     :return: A list of :class:`boto.regioninfo.RegionInfo`
     """
-    import boto.dynamodb.layer2
-    return get_regions('dynamodb', connection_cls=boto.dynamodb.layer2.Layer2)
+    from boto.dynamodb.layer2 import Layer2
+    return get_regions('dynamodb', connection_cls=Layer2)
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.dynamodb.layer2 import Layer2
+    return connect('dynamodb', region_name, connection_cls=Layer2, **kw_params)

--- a/boto/dynamodb2/__init__.py
+++ b/boto/dynamodb2/__init__.py
@@ -22,6 +22,7 @@
 #
 
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -36,7 +37,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.dynamodb2.layer1 import DynamoDBConnection
+    return connect('dynamodb', region_name, connection_cls=DynamoDBConnection,
+                   **kw_params)

--- a/boto/ec2/__init__.py
+++ b/boto/ec2/__init__.py
@@ -25,6 +25,7 @@ service from AWS.
 """
 from boto.ec2.connection import EC2Connection
 from boto.regioninfo import RegionInfo, get_regions, load_regions
+from boto.regioninfo import connect
 
 
 RegionData = load_regions().get('ec2', {})
@@ -61,11 +62,8 @@ def connect_to_region(region_name, **kw_params):
        and region_name == kw_params['region'].name:
         return EC2Connection(**kw_params)
 
-    for region in regions(**kw_params):
-        if region.name == region_name:
-            return region.connect(**kw_params)
-
-    return None
+    return connect('ec2', region_name,
+                   connection_cls=EC2Connection, **kw_params)
 
 
 def get_region(region_name, **kw_params):

--- a/boto/ec2/autoscale/__init__.py
+++ b/boto/ec2/autoscale/__init__.py
@@ -32,6 +32,7 @@ import base64
 import boto
 from boto.connection import AWSQueryConnection
 from boto.regioninfo import RegionInfo, get_regions, load_regions
+from boto.regioninfo import connect
 from boto.ec2.autoscale.request import Request
 from boto.ec2.autoscale.launchconfig import LaunchConfiguration
 from boto.ec2.autoscale.group import AutoScalingGroup
@@ -71,10 +72,8 @@ def connect_to_region(region_name, **kw_params):
     :return: A connection to the given region, or None if an invalid region
         name is given
     """
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    return connect('autoscaling', region_name,
+                   connection_cls=AutoScaleConnection, **kw_params)
 
 
 class AutoScaleConnection(AWSQueryConnection):

--- a/boto/ec2/cloudwatch/__init__.py
+++ b/boto/ec2/cloudwatch/__init__.py
@@ -29,6 +29,7 @@ from boto.ec2.cloudwatch.metric import Metric
 from boto.ec2.cloudwatch.alarm import MetricAlarm, MetricAlarms, AlarmHistoryItem
 from boto.ec2.cloudwatch.datapoint import Datapoint
 from boto.regioninfo import RegionInfo, get_regions, load_regions
+from boto.regioninfo import connect
 import boto
 
 RegionData = load_regions().get('cloudwatch', {})
@@ -55,10 +56,8 @@ def connect_to_region(region_name, **kw_params):
     :return: A connection to the given region, or None if an invalid region
         name is given
     """
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    return connect('cloudwatch', region_name,
+                   connection_cls=CloudWatchConnection, **kw_params)
 
 
 class CloudWatchConnection(AWSQueryConnection):

--- a/boto/ec2/elb/__init__.py
+++ b/boto/ec2/elb/__init__.py
@@ -31,6 +31,7 @@ from boto.ec2.elb.loadbalancer import LoadBalancer, LoadBalancerZones
 from boto.ec2.elb.instancestate import InstanceState
 from boto.ec2.elb.healthcheck import HealthCheck
 from boto.regioninfo import RegionInfo, get_regions, load_regions
+from boto.regioninfo import connect
 import boto
 from boto.compat import six
 
@@ -58,10 +59,8 @@ def connect_to_region(region_name, **kw_params):
     :return: A connection to the given region, or None if an invalid region
         name is given
     """
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    return connect('elasticloadbalancing', region_name,
+                   connection_cls=ELBConnection, **kw_params)
 
 
 class ELBConnection(AWSQueryConnection):

--- a/boto/ec2containerservice/__init__.py
+++ b/boto/ec2containerservice/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -36,7 +37,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.ec2containerservice.layer1 import EC2ContainerServiceConnection
+    return connect('ec2containerservice', region_name,
+                   connection_cls=EC2ContainerServiceConnection, **kw_params)

--- a/boto/elasticache/__init__.py
+++ b/boto/elasticache/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -35,7 +36,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.elasticache.layer1 import ElastiCacheConnection
+    return connect('elasticache', region_name,
+                   connection_cls=ElastiCacheConnection, **kw_params)

--- a/boto/elastictranscoder/__init__.py
+++ b/boto/elastictranscoder/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -38,8 +39,7 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.elastictranscoder.layer1 import ElasticTranscoderConnection
+    return connect('elastictranscoder', region_name,
+                   connection_cls=ElasticTranscoderConnection, **kw_params)
 

--- a/boto/emr/__init__.py
+++ b/boto/emr/__init__.py
@@ -30,6 +30,7 @@ from boto.emr.connection import EmrConnection
 from boto.emr.step import Step, StreamingStep, JarStep
 from boto.emr.bootstrap_action import BootstrapAction
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -43,7 +44,5 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    return connect('elasticmapreduce', region_name,
+                   connection_cls=EmrConnection, **kw_params)

--- a/boto/glacier/__init__.py
+++ b/boto/glacier/__init__.py
@@ -22,6 +22,7 @@
 #
 
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -36,7 +37,5 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.glacier.layer2 import Layer2
+    return connect('glacier', region_name, connection_cls=Layer2, **kw_params)

--- a/boto/iam/__init__.py
+++ b/boto/iam/__init__.py
@@ -24,6 +24,7 @@
 # originally, the IAMConnection class was defined here
 from boto.iam.connection import IAMConnection
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 class IAMRegionInfo(RegionInfo):
@@ -80,7 +81,13 @@ def connect_to_region(region_name, **kw_params):
     :return: A connection to the given region, or None if an invalid region
              name is given
     """
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    if region_name == 'universal':
+        region = IAMRegionInfo(
+            name='universal',
+            endpoint='iam.amazonaws.com',
+            connection_cls=IAMConnection
+        )
+        return region.connect(**kw_params)
+
+    return connect('iam', region_name, region_cls=IAMRegionInfo,
+                   connection_cls=IAMConnection, **kw_params)

--- a/boto/kinesis/__init__.py
+++ b/boto/kinesis/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -35,7 +36,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.kinesis.layer1 import KinesisConnection
+    return connect('kinesis', region_name,
+                   connection_cls=KinesisConnection, **kw_params)

--- a/boto/kms/__init__.py
+++ b/boto/kms/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -35,7 +36,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.kms.layer1 import KMSConnection
+    return connect('kms', region_name, connection_cls=KMSConnection,
+                   **kw_params)

--- a/boto/logs/__init__.py
+++ b/boto/logs/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -35,7 +36,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.logs.layer1 import CloudWatchLogsConnection
+    return connect('logs', region_name,
+                   connection_cls=CloudWatchLogsConnection, **kw_params)

--- a/boto/machinelearning/__init__.py
+++ b/boto/machinelearning/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -36,7 +37,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.machinelearning.layer1 import MachineLearningConnection
+    return connect('machinelearning', region_name,
+                   connection_cls=MachineLearningConnection, **kw_params)

--- a/boto/opsworks/__init__.py
+++ b/boto/opsworks/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -35,7 +36,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.opsworks.layer1 import OpsWorksConnection
+    return connect('opsworks', region_name,
+                   connection_cls=OpsWorksConnection, **kw_params)

--- a/boto/rds/__init__.py
+++ b/boto/rds/__init__.py
@@ -32,6 +32,7 @@ from boto.rds.regioninfo import RDSRegionInfo
 from boto.rds.dbsubnetgroup import DBSubnetGroup
 from boto.rds.vpcsecuritygroupmembership import VPCSecurityGroupMembership
 from boto.regioninfo import get_regions
+from boto.regioninfo import connect
 from boto.rds.logfile import LogFile, LogFileObject
 
 
@@ -63,10 +64,8 @@ def connect_to_region(region_name, **kw_params):
     :return: A connection to the given region, or None if an invalid region
              name is given
     """
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    return connect('rds', region_name, region_cls=RDSRegionInfo,
+                   connection_cls=RDSConnection, **kw_params)
 
 #boto.set_stream_logger('rds')
 

--- a/boto/rds2/__init__.py
+++ b/boto/rds2/__init__.py
@@ -20,6 +20,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -47,7 +48,6 @@ def connect_to_region(region_name, **kw_params):
     :return: A connection to the given region, or None if an invalid region
              name is given
     """
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.rds2.layer1 import RDSConnection
+    return connect('rds', region_name, connection_cls=RDSConnection,
+                   **kw_params)

--- a/boto/redshift/__init__.py
+++ b/boto/redshift/__init__.py
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -35,7 +36,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.redshift.layer1 import RedshiftConnection
+    return connect('redshift', region_name,
+                   connection_cls=RedshiftConnection, **kw_params)

--- a/boto/route53/__init__.py
+++ b/boto/route53/__init__.py
@@ -25,6 +25,7 @@
 # originally, the Route53Connection class was defined here
 from boto.route53.connection import Route53Connection
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 class Route53RegionInfo(RegionInfo):
@@ -81,7 +82,13 @@ def connect_to_region(region_name, **kw_params):
     :return: A connection to the given region, or None if an invalid region
              name is given
     """
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    if region_name == 'universal':
+        region = Route53RegionInfo(
+            name='universal',
+            endpoint='route53.amazonaws.com',
+            connection_cls=Route53Connection
+        )
+        return region.connect(**kw_params)
+
+    return connect('route53', region_name, region_cls=Route53RegionInfo,
+                   connection_cls=Route53Connection, **kw_params)

--- a/boto/route53/domains/__init__.py
+++ b/boto/route53/domains/__init__.py
@@ -20,6 +20,7 @@
 # IN THE SOFTWARE.
 #
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -34,7 +35,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.route53.domains.layer1 import Route53DomainsConnection
+    return connect('route53domains', region_name,
+                   connection_cls=Route53DomainsConnection, **kw_params)

--- a/boto/sdb/__init__.py
+++ b/boto/sdb/__init__.py
@@ -22,6 +22,7 @@
 
 from boto.sdb.regioninfo import SDBRegionInfo
 from boto.regioninfo import get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -49,7 +50,4 @@ def connect_to_region(region_name, **kw_params):
     :return: A connection to the given region, or None if an invalid region
              name is given
     """
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    return connect('sdb', region_name, region_cls=SDBRegionInfo, **kw_params)

--- a/boto/ses/__init__.py
+++ b/boto/ses/__init__.py
@@ -22,6 +22,7 @@
 
 from boto.ses.connection import SESConnection
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -46,7 +47,5 @@ def connect_to_region(region_name, **kw_params):
     :return: A connection to the given region, or None if an invalid region
              name is given
     """
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    return connect('ses', region_name, connection_cls=SESConnection,
+                   **kw_params)

--- a/boto/sns/__init__.py
+++ b/boto/sns/__init__.py
@@ -24,6 +24,7 @@
 # originally, the SNSConnection class was defined here
 from boto.sns.connection import SNSConnection
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -48,7 +49,5 @@ def connect_to_region(region_name, **kw_params):
     :return: A connection to the given region, or None if an invalid region
              name is given
     """
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    return connect('sns', region_name,
+                   connection_cls=SNSConnection, **kw_params)

--- a/boto/sqs/__init__.py
+++ b/boto/sqs/__init__.py
@@ -22,6 +22,7 @@
 
 from boto.sqs.regioninfo import SQSRegionInfo
 from boto.regioninfo import get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -40,7 +41,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.sqs.connection import SQSConnection
+    return connect('sqs', region_name, region_cls=SQSRegionInfo,
+                   connection_cls=SQSConnection, **kw_params)

--- a/boto/sts/__init__.py
+++ b/boto/sts/__init__.py
@@ -22,6 +22,7 @@
 
 from boto.sts.connection import STSConnection
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -46,7 +47,5 @@ def connect_to_region(region_name, **kw_params):
     :return: A connection to the given region, or None if an invalid region
              name is given
     """
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    return connect('sts', region_name, connection_cls=STSConnection,
+                   **kw_params)

--- a/boto/support/__init__.py
+++ b/boto/support/__init__.py
@@ -21,6 +21,7 @@
 #
 
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions():
@@ -35,7 +36,6 @@ def regions():
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    from boto.support.layer1 import SupportConnection
+    return connect('support', region_name,
+                   connection_cls=SupportConnection, **kw_params)

--- a/boto/swf/__init__.py
+++ b/boto/swf/__init__.py
@@ -24,6 +24,7 @@
 
 from boto.ec2.regioninfo import RegionInfo
 from boto.regioninfo import get_regions, load_regions
+from boto.regioninfo import connect
 import boto.swf.layer1
 
 REGION_ENDPOINTS = load_regions().get('swf', {})
@@ -40,7 +41,5 @@ def regions(**kw_params):
 
 
 def connect_to_region(region_name, **kw_params):
-    for region in regions():
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    return connect('swf', region_name,
+                   connection_cls=boto.swf.layer1.Layer1, **kw_params)

--- a/boto/vpc/__init__.py
+++ b/boto/vpc/__init__.py
@@ -37,6 +37,7 @@ from boto.vpc.vpnconnection import VpnConnection
 from boto.vpc.vpc_peering_connection import VpcPeeringConnection
 from boto.ec2 import RegionData
 from boto.regioninfo import RegionInfo, get_regions
+from boto.regioninfo import connect
 
 
 def regions(**kw_params):
@@ -66,10 +67,8 @@ def connect_to_region(region_name, **kw_params):
     :return: A connection to the given region, or None if an invalid region
              name is given
     """
-    for region in regions(**kw_params):
-        if region.name == region_name:
-            return region.connect(**kw_params)
-    return None
+    return connect('ec2', region_name, connection_cls=VPCConnection,
+                   **kw_params)
 
 
 class VPCConnection(EC2Connection):

--- a/docs/source/boto_config_tut.rst
+++ b/docs/source/boto_config_tut.rst
@@ -188,6 +188,9 @@ For example::
   Provide an absolute path to a custom JSON file, which gets merged into the
   defaults. (This can also be specified with the ``BOTO_ENDPOINTS``
   environment variable instead.)
+:use_endpoint_heuristics: Allows using endpoint heuristics to guess
+  endpoints for regions that aren't built in. This can also be specified with
+  the ``BOTO_USE_ENDPOINT_HEURISTICS`` environment variable.
 
 These settings will default to::
 
@@ -199,6 +202,7 @@ These settings will default to::
     http_socket_timeout = 60
     send_crlf_after_proxy_auth_headers = False
     endpoints_path = /path/to/my/boto/endpoints.json
+    use_endpoint_heuristics = False
 
 You can control the timeouts and number of retries used when retrieving
 information from the Metadata Service (this is used for retrieving credentials

--- a/tests/unit/test_connect_to_region.py
+++ b/tests/unit/test_connect_to_region.py
@@ -1,0 +1,507 @@
+# Copyright (c) 2017 Amazon.com, Inc. or its affiliates.
+# All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+from tests.unit import unittest
+
+
+class TestConnectAwslambda(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.awslambda import connect_to_region
+        from boto.awslambda.layer1 import AWSLambdaConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, AWSLambdaConnection)
+        self.assertEqual(connection.host, 'lambda.us-east-1.amazonaws.com')
+
+
+class TestConnectBeanstalk(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.beanstalk import connect_to_region
+        from boto.beanstalk.layer1 import Layer1
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, Layer1)
+        self.assertEqual(
+            connection.host, 'elasticbeanstalk.us-east-1.amazonaws.com')
+
+
+class TestConnectCloudformation(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.cloudformation import connect_to_region
+        from boto.cloudformation.connection import CloudFormationConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, CloudFormationConnection)
+        self.assertEqual(
+            connection.host, 'cloudformation.us-east-1.amazonaws.com')
+
+
+class TestConnectCloudHsm(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.cloudhsm import connect_to_region
+        from boto.cloudhsm.layer1 import CloudHSMConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, CloudHSMConnection)
+        self.assertEqual(connection.host, 'cloudhsm.us-east-1.amazonaws.com')
+
+
+class TestCloudsearchConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.cloudsearch import connect_to_region
+        from boto.cloudsearch.layer1 import Layer1
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, Layer1)
+        self.assertEqual(
+            connection.host, 'cloudsearch.us-east-1.amazonaws.com')
+
+
+class TestCloudsearch2Connection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.cloudsearch2 import connect_to_region
+        from boto.cloudsearch2.layer1 import CloudSearchConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, CloudSearchConnection)
+        self.assertEqual(
+            connection.host, 'cloudsearch.us-east-1.amazonaws.com')
+
+
+class TestCloudsearchDomainConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.cloudsearchdomain import connect_to_region
+        from boto.cloudsearchdomain.layer1 import CloudSearchDomainConnection
+        host = 'mycustomdomain.us-east-1.amazonaws.com'
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar', host=host)
+        self.assertIsInstance(connection, CloudSearchDomainConnection)
+        self.assertEqual(connection.host, host)
+
+
+class TestCloudTrailConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.cloudtrail import connect_to_region
+        from boto.cloudtrail.layer1 import CloudTrailConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, CloudTrailConnection)
+        self.assertEqual(connection.host, 'cloudtrail.us-east-1.amazonaws.com')
+
+
+class TestCodeDeployConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.codedeploy import connect_to_region
+        from boto.codedeploy.layer1 import CodeDeployConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, CodeDeployConnection)
+        self.assertEqual(connection.host, 'codedeploy.us-east-1.amazonaws.com')
+
+
+class TestCognitoIdentityConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.cognito.identity import connect_to_region
+        from boto.cognito.identity.layer1 import CognitoIdentityConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, CognitoIdentityConnection)
+        self.assertEqual(
+            connection.host, 'cognito-identity.us-east-1.amazonaws.com')
+
+
+class TestCognitoSyncConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.cognito.sync import connect_to_region
+        from boto.cognito.sync.layer1 import CognitoSyncConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, CognitoSyncConnection)
+        self.assertEqual(
+            connection.host, 'cognito-sync.us-east-1.amazonaws.com')
+
+
+class TestConfigserviceConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.configservice import connect_to_region
+        from boto.configservice.layer1 import ConfigServiceConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, ConfigServiceConnection)
+        self.assertEqual(connection.host, 'config.us-east-1.amazonaws.com')
+
+
+class TestDatapipelineConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.datapipeline import connect_to_region
+        from boto.datapipeline.layer1 import DataPipelineConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, DataPipelineConnection)
+        self.assertEqual(
+            connection.host, 'datapipeline.us-east-1.amazonaws.com')
+
+
+class TestDirectconnectConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.directconnect import connect_to_region
+        from boto.directconnect.layer1 import DirectConnectConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, DirectConnectConnection)
+        self.assertEqual(
+            connection.host, 'directconnect.us-east-1.amazonaws.com')
+
+
+class TestDynamodbConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.dynamodb import connect_to_region
+        from boto.dynamodb.layer2 import Layer2
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, Layer2)
+        self.assertEqual(
+            connection.layer1.host, 'dynamodb.us-east-1.amazonaws.com')
+
+
+class TestDynamodb2Connection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.dynamodb2 import connect_to_region
+        from boto.dynamodb2.layer1 import DynamoDBConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, DynamoDBConnection)
+        self.assertEqual(connection.host, 'dynamodb.us-east-1.amazonaws.com')
+
+
+class TestEC2Connection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.ec2 import connect_to_region
+        from boto.ec2.connection import EC2Connection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, EC2Connection)
+        self.assertEqual(connection.host, 'ec2.us-east-1.amazonaws.com')
+
+
+class TestAutoscaleConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.ec2.autoscale import connect_to_region
+        from boto.ec2.autoscale import AutoScaleConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, AutoScaleConnection)
+        self.assertEqual(
+            connection.host, 'autoscaling.us-east-1.amazonaws.com')
+
+
+class TestCloudwatchConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.ec2.cloudwatch import connect_to_region
+        from boto.ec2.cloudwatch import CloudWatchConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, CloudWatchConnection)
+        self.assertEqual(connection.host, 'monitoring.us-east-1.amazonaws.com')
+
+
+class TestElbConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.ec2.elb import connect_to_region
+        from boto.ec2.elb import ELBConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, ELBConnection)
+        self.assertEqual(
+            connection.host, 'elasticloadbalancing.us-east-1.amazonaws.com')
+
+
+class TestEc2ContainerserviceConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.ec2containerservice import connect_to_region
+        import boto.ec2containerservice.layer1 as layer1
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(
+            connection, layer1.EC2ContainerServiceConnection)
+        self.assertEqual(connection.host, 'ecs.us-east-1.amazonaws.com')
+
+
+class TestElasticacheConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.elasticache import connect_to_region
+        from boto.elasticache.layer1 import ElastiCacheConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, ElastiCacheConnection)
+        self.assertEqual(
+            connection.host, 'elasticache.us-east-1.amazonaws.com')
+
+
+class TestElastictranscoderConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.elastictranscoder import connect_to_region
+        from boto.elastictranscoder.layer1 import ElasticTranscoderConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, ElasticTranscoderConnection)
+        self.assertEqual(
+            connection.host, 'elastictranscoder.us-east-1.amazonaws.com')
+
+
+class TestEmrConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.emr import connect_to_region
+        from boto.emr.connection import EmrConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, EmrConnection)
+        self.assertEqual(
+            connection.host, 'elasticmapreduce.us-east-1.amazonaws.com')
+
+
+class TestGlacierConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.glacier import connect_to_region
+        from boto.glacier.layer2 import Layer2
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, Layer2)
+        self.assertEqual(
+            connection.layer1.host, 'glacier.us-east-1.amazonaws.com')
+
+
+class TestIamConnection(unittest.TestCase):
+    def assert_connection(self, region, host):
+        from boto.iam import connect_to_region
+        from boto.iam.connection import IAMConnection
+        connection = connect_to_region(region, aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, IAMConnection)
+        self.assertEqual(connection.host, host)
+
+    def test_connect_to_region(self):
+        self.assert_connection('us-east-1', 'iam.amazonaws.com')
+
+    def test_connect_to_universal_region(self):
+        self.assert_connection('universal', 'iam.amazonaws.com')
+
+
+class TestKinesisConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.kinesis import connect_to_region
+        from boto.kinesis.layer1 import KinesisConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, KinesisConnection)
+        self.assertEqual(connection.host, 'kinesis.us-east-1.amazonaws.com')
+
+
+class TestLogsConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.logs import connect_to_region
+        from boto.logs.layer1 import CloudWatchLogsConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, CloudWatchLogsConnection)
+        self.assertEqual(
+            connection.host, 'logs.us-east-1.amazonaws.com')
+
+
+class TestMachinelearningConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.machinelearning import connect_to_region
+        from boto.machinelearning.layer1 import MachineLearningConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, MachineLearningConnection)
+        self.assertEqual(
+            connection.host, 'machinelearning.us-east-1.amazonaws.com')
+
+
+class TestOpsworksConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.opsworks import connect_to_region
+        from boto.opsworks.layer1 import OpsWorksConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, OpsWorksConnection)
+        self.assertEqual(
+            connection.host, 'opsworks.us-east-1.amazonaws.com')
+
+
+class TestRdsConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.rds import connect_to_region
+        from boto.rds import RDSConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, RDSConnection)
+        self.assertEqual(
+            connection.host, 'rds.amazonaws.com')
+
+
+class TestRds2Connection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.rds2 import connect_to_region
+        from boto.rds2.layer1 import RDSConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, RDSConnection)
+        self.assertEqual(
+            connection.host, 'rds.amazonaws.com')
+
+
+class TestRedshiftConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.redshift import connect_to_region
+        from boto.redshift.layer1 import RedshiftConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, RedshiftConnection)
+        self.assertEqual(
+            connection.host, 'redshift.us-east-1.amazonaws.com')
+
+
+class TestRoute53Connection(unittest.TestCase):
+    def assert_connection(self, region, host):
+        from boto.route53 import connect_to_region
+        from boto.route53.connection import Route53Connection
+        connection = connect_to_region(region, aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, Route53Connection)
+        self.assertEqual(connection.host, host)
+
+    def test_connect_to_region(self):
+        self.assert_connection('us-east-1', 'route53.amazonaws.com')
+
+    def test_connect_to_universal_region(self):
+        self.assert_connection('universal', 'route53.amazonaws.com')
+
+
+class TestRoute53DomainsConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.route53.domains import connect_to_region
+        from boto.route53.domains.layer1 import Route53DomainsConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, Route53DomainsConnection)
+        self.assertEqual(
+            connection.host, 'route53domains.us-east-1.amazonaws.com')
+
+
+class TestS3Connection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.s3 import connect_to_region
+        from boto.s3.connection import S3Connection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, S3Connection)
+        self.assertEqual(connection.host, 's3.amazonaws.com')
+
+    def test_connect_to_custom_host(self):
+        from boto.s3 import connect_to_region
+        from boto.s3.connection import S3Connection
+        host = 'mycustomhost.example.com'
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar', host=host)
+        self.assertIsInstance(connection, S3Connection)
+        self.assertEqual(connection.host, host)
+
+
+class TestSdbConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.sdb import connect_to_region
+        from boto.sdb.connection import SDBConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, SDBConnection)
+        self.assertEqual(connection.host, 'sdb.amazonaws.com')
+
+
+class TestSesConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.ses import connect_to_region
+        from boto.ses.connection import SESConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, SESConnection)
+        self.assertEqual(connection.host, 'email.us-east-1.amazonaws.com')
+
+
+class TestSnsConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.sns import connect_to_region
+        from boto.sns.connection import SNSConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, SNSConnection)
+        self.assertEqual(connection.host, 'sns.us-east-1.amazonaws.com')
+
+
+class TestSqsConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.sqs import connect_to_region
+        from boto.sqs.connection import SQSConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, SQSConnection)
+        self.assertEqual(connection.host, 'queue.amazonaws.com')
+
+
+class TestStsConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.sts import connect_to_region
+        from boto.sts.connection import STSConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, STSConnection)
+        self.assertEqual(connection.host, 'sts.amazonaws.com')
+
+
+class TestSupportConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.support import connect_to_region
+        from boto.support.layer1 import SupportConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, SupportConnection)
+        self.assertEqual(connection.host, 'support.us-east-1.amazonaws.com')
+
+
+class TestSwfConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.swf import connect_to_region
+        from boto.swf.layer1 import Layer1
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, Layer1)
+        self.assertEqual(connection.host, 'swf.us-east-1.amazonaws.com')
+
+
+class TestVpcConnection(unittest.TestCase):
+    def test_connect_to_region(self):
+        from boto.vpc import connect_to_region
+        from boto.vpc import VPCConnection
+        connection = connect_to_region('us-east-1', aws_access_key_id='foo',
+                                       aws_secret_access_key='bar')
+        self.assertIsInstance(connection, VPCConnection)
+        self.assertEqual(connection.host, 'ec2.us-east-1.amazonaws.com')

--- a/tests/unit/test_regioninfo.py
+++ b/tests/unit/test_regioninfo.py
@@ -20,11 +20,14 @@
 # IN THE SOFTWARE.
 #
 import os
-from tests.unit import unittest
+import mock
 
 import boto
+from boto.pyami.config import Config
 from boto.regioninfo import RegionInfo, load_endpoint_json, merge_endpoints
-from boto.regioninfo import load_regions, get_regions
+from boto.regioninfo import load_regions, get_regions, connect
+
+from tests.unit import unittest
 
 
 class TestRegionInfo(object):
@@ -35,9 +38,14 @@ class TestRegionInfo(object):
         self.endpoint = endpoint
         self.connection_cls = connection_cls
 
+    def connect(self, **kwargs):
+        return self.connection_cls(region=self)
+
 
 class FakeConn(object):
-    pass
+    def __init__(self, region, **kwargs):
+        self.region = region
+        self.kwargs = kwargs
 
 
 class TestEndpointLoading(unittest.TestCase):
@@ -134,6 +142,54 @@ class TestEndpointLoading(unittest.TestCase):
         self.assertEqual(west_2.name, 'us-west-2')
         self.assertEqual(west_2.endpoint, 'ec2.us-west-2.amazonaws.com')
         self.assertEqual(west_2.connection_cls, FakeConn)
+
+
+class TestConnectToRegion(unittest.TestCase):
+    def test_connect(self):
+        connection = connect(
+            'ec2', 'us-west-2', connection_cls=FakeConn)
+        self.assertEqual(connection.region.name, 'us-west-2')
+        expected_endpoint = 'ec2.us-west-2.amazonaws.com'
+        self.assertEqual(connection.region.endpoint, expected_endpoint)
+
+    def test_does_not_use_heuristics_by_default(self):
+        connection = connect(
+            'ec2', 'us-southeast-43', connection_cls=FakeConn)
+        self.assertIsNone(connection)
+
+    def test_uses_region_override(self):
+        connection = connect(
+            'ec2', 'us-west-2', connection_cls=FakeConn,
+            region_cls=TestRegionInfo
+        )
+        self.assertIsInstance(connection.region, TestRegionInfo)
+        self.assertEqual(connection.region.name, 'us-west-2')
+        expected_endpoint = 'ec2.us-west-2.amazonaws.com'
+        self.assertEqual(connection.region.endpoint, expected_endpoint)
+
+    def test_use_heuristics_via_env_var(self):
+        # With ENV overrides.
+        os.environ['BOTO_USE_ENDPOINT_HEURISTICS'] = 'True'
+        self.addCleanup(os.environ.pop, 'BOTO_USE_ENDPOINT_HEURISTICS')
+        connection = connect(
+            'ec2', 'us-southeast-43', connection_cls=FakeConn)
+        self.assertIsNotNone(connection)
+        self.assertEqual(connection.region.name, 'us-southeast-43')
+        expected_endpoint = 'ec2.us-southeast-43.amazonaws.com'
+        self.assertEqual(connection.region.endpoint, expected_endpoint)
+
+    def test_use_heuristics_via_config(self):
+        config = mock.Mock(spec=Config)
+        config.getbool.return_value = True
+
+        with mock.patch('boto.config', config):
+            connection = connect(
+                'ec2', 'us-southeast-43', connection_cls=FakeConn)
+
+        self.assertIsNotNone(connection)
+        self.assertEqual(connection.region.name, 'us-southeast-43')
+        expected_endpoint = 'ec2.us-southeast-43.amazonaws.com'
+        self.assertEqual(connection.region.endpoint, expected_endpoint)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is dependent on #3657, that should be looked at first.

This creates a generic connect function to point all the other connect functions at. This generic connect function supports using endpoint heuristics if necessary.

cc @kyleknap @jamesls @stealthycoin @dstufft 