### PR TITLE
Respect query_auth setting when adding x-amz-security-token for S3 URL generation.

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -401,8 +401,9 @@ class S3Connection(AWSAuthConnection):
         if response_headers:
             for k, v in response_headers.items():
                 extra_qp.append("%s=%s" % (k, urllib.parse.quote(v)))
-        if self.provider.security_token:
-            headers['x-amz-security-token'] = self.provider.security_token
+        if query_auth:
+            if self.provider.security_token:
+                headers['x-amz-security-token'] = self.provider.security_token
         if extra_qp:
             delimiter = '?' if '?' not in auth_path else '&'
             auth_path += delimiter + '&'.join(extra_qp)

--- a/tests/unit/s3/test_connection.py
+++ b/tests/unit/s3/test_connection.py
@@ -213,6 +213,29 @@ class TestSigV4Presigned(MockServiceWithConfigTestCase):
         self.assertIn('Signature=', url_enabled)
         self.assertNotIn('Signature=', url_disabled)
 
+    def test_sigv4_presign_respect_query_auth_security_token(self):
+        self.config = {
+            's3': {
+                'use-sigv4': True,
+            }
+        }
+
+        conn = self.connection_class(
+            aws_access_key_id='less',
+            aws_secret_access_key='more',
+            security_token='token',
+            host='s3.amazonaws.com'
+        )
+
+        url_enabled = conn.generate_url(86400, 'GET', bucket='examplebucket',
+                                        key='test.txt', query_auth=True)
+
+        url_disabled = conn.generate_url(86400, 'GET', bucket='examplebucket',
+                                         key='test.txt', query_auth=False)
+
+        self.assertIn('x-amz-security-token=', url_enabled.lower())
+        self.assertNotIn('x-amz-security-token=', url_disabled.lower())
+
     def test_sigv4_presign_headers(self):
         self.config = {
             's3': {


### PR DESCRIPTION
When the S3 component of Boto was used on an EC2 instance that was granted permissions via an IAM role, it attempted to append `x-amz-security-token` key and value to the URL generated via
the `generate_url` method on the available connection, even though `query_auth=False` was explicitly being set.

Includes a simple test case, and the test passes on all interpreters specified in the current tox configuration.

Ready and willing to amend this pull request in whatever fashion is necessary if it is not deemed suitable at this time.

Fixes #2043
Refs. #2044