### PR TITLE
Fix host header in S3Connection

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -655,7 +655,7 @@ class S3Connection(AWSAuthConnection):
         boto.log.debug('path=%s' % path)
         auth_path = self.calling_format.build_auth_path(bucket, key)
         boto.log.debug('auth_path=%s' % auth_path)
-        host = self.calling_format.build_host(self.server_name(), bucket)
+        host = self.calling_format.build_host(self.host, bucket)
         if query_args:
             path += '?' + query_args
             boto.log.debug('path=%s' % path)


### PR DESCRIPTION
Fixing a bug in s3.connection.S3Connection.make_request. Host header is being malformed since port is appended to the hostname twice. First, the call self.server_name() in s3.connection.S3Connection.make_request returns hostname with the port already appended, and then this string is passed as a 'host' parameter to the constructor of HTTPRequest in connection.AWSAuthConnection.build_base_http_request.