### PR TITLE
sqs region related signature fixed.

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -472,7 +472,10 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
                 if len(parts) == 3:
                     region_name = 'us-east-1'
                 else:
-                    region_name = parts[1]
+                    if parts[1] == 'queue':
+                        region_name = parts[0]
+                    else:
+                        region_name = parts[1]
         else:
             region_name = parts[0]
 


### PR DESCRIPTION
fixed issue for sqs

```xml
HTTP Error: SQSError: 403 Forbidden
<?xml version="1.0"?>
<ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/">
	<Error>
		<Type>Sender</Type>
		<Code>SignatureDoesNotMatch</Code>
		<Message>Credential should be scoped to a valid region, not 'queue'. </Message>
		<Detail/>
	</Error>
	<RequestId>cb61f365-1b6c-5380-b5fd-a24cce4668f6</RequestId>
</ErrorResponse>
```