### PR TITLE
fixed issue for sqs invalid signature

### DIFF
--- a/boto/endpoints.json
+++ b/boto/endpoints.json
@@ -791,7 +791,7 @@
               "http", 
               "https"
             ], 
-            "sslCommonName": "{region}.queue.{dnsSuffix}"
+            "sslCommonName": "sqs.{region}.{dnsSuffix}"
           }, 
           "endpoints": {
             "ap-northeast-1": {}, 
@@ -804,9 +804,7 @@
             "eu-west-1": {}, 
             "eu-west-2": {}, 
             "sa-east-1": {}, 
-            "us-east-1": {
-              "sslCommonName": "queue.{dnsSuffix}"
-            }, 
+            "us-east-1": {}, 
             "us-east-2": {}, 
             "us-west-1": {}, 
             "us-west-2": {}
@@ -1275,7 +1273,7 @@
                 "http", 
                 "https"
               ], 
-              "sslCommonName": "{region}.queue.{dnsSuffix}"
+              "sslCommonName": "sqs.{region}.{dnsSuffix}"
             }
           }
         }, 


### PR DESCRIPTION
```xml
HTTP Error: SQSError: 403 Forbidden
<?xml version="1.0"?>
<ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/">
	<Error>
		<Type>Sender</Type>
		<Code>SignatureDoesNotMatch</Code>
		<Message>Credential should be scoped to a valid region, not 'queue'. </Message>
		<Detail/>
	</Error>
	<RequestId>cb61f365-1b6c-5380-b5fd-a24cce4668f6</RequestId>
</ErrorResponse>
```

i will drop this pull request https://github.com/boto/boto/pull/3688 and replace to this one because it's better to use the current sqs endpoint than fixing by using the legacy endpoint.

current sqs endpoint reference is  here > http://docs.aws.amazon.com/general/latest/gr/rande.html#sqs_region

Cheers 👍 

