### PR TITLE
Removes documented support for Python 3 with S3 service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ At the moment, boto supports:
 
 * Storage
 
-  * Amazon Simple Storage Service (S3) (Python 3)
+  * Amazon Simple Storage Service (S3)
   * Amazon Glacier (Python 3)
   * Amazon Elastic Block Store (EBS)
   * Google Cloud Storage


### PR DESCRIPTION
The S3 service does not entirely work with Python 3 (as pointed out in issue #3561). This issue issue has been fixed by PR #2718 long before it was even reported, yet that PR has not been merged yet. Until that PR is merged, the boto documentation should not list Python 3 support for the S3 service, as it does not work in Python 3.