### PR TITLE
SQS endpoints sslCommonName fix

### DIFF
--- a/boto/endpoints.json
+++ b/boto/endpoints.json
@@ -791,7 +791,7 @@
               "http", 
               "https"
             ], 
-            "sslCommonName": "{region}.queue.{dnsSuffix}"
+            "sslCommonName": "sqs.{region}.{dnsSuffix}"
           }, 
           "endpoints": {
             "ap-northeast-1": {}, 
@@ -804,9 +804,7 @@
             "eu-west-1": {}, 
             "eu-west-2": {}, 
             "sa-east-1": {}, 
-            "us-east-1": {
-              "sslCommonName": "queue.{dnsSuffix}"
-            }, 
+            "us-east-1": {}, 
             "us-east-2": {}, 
             "us-west-1": {}, 
             "us-west-2": {}
@@ -1075,7 +1073,7 @@
               "http", 
               "https"
             ], 
-            "sslCommonName": "{region}.queue.{dnsSuffix}"
+            "sslCommonName": "sqs.{region}.{dnsSuffix}"
           }, 
           "endpoints": {
             "cn-north-1": {}
@@ -1275,7 +1273,7 @@
                 "http", 
                 "https"
               ], 
-              "sslCommonName": "{region}.queue.{dnsSuffix}"
+              "sslCommonName": "sqs.{region}.{dnsSuffix}"
             }
           }
         }, 


### PR DESCRIPTION
Modified the `sslCommonName` for SQS according to the AWS specification.

The new structure for an SQS URL is:
`http://sqs.{region}.amazonaws.com/123456789012/MyQueue`

See AWS docs:
http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-queue-message-identifiers.html
