### PR TITLE
Do not inject linebreaks into proxy auth header

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -39,7 +39,7 @@ import hmac
 import os
 import posixpath
 
-from boto.compat import urllib, encodebytes, parse_qs_safe, urlparse
+from boto.compat import urllib, b64encode, parse_qs_safe, urlparse
 from boto.auth_handler import AuthHandler
 from boto.exception import BotoClientError
 
@@ -131,7 +131,7 @@ class HmacKeys(object):
     def sign_string(self, string_to_sign):
         new_hmac = self._get_hmac()
         new_hmac.update(string_to_sign.encode('utf-8'))
-        return encodebytes(new_hmac.digest()).decode('utf-8').strip()
+        return b64encode(new_hmac.digest()).decode('utf-8').strip()
 
     def __getstate__(self):
         pickled_dict = copy.copy(self.__dict__)

--- a/boto/compat.py
+++ b/boto/compat.py
@@ -31,7 +31,7 @@ except ImportError:
 
 # Switch to use b64encode, which doesn't insert newlines that break proxy
 # auth
-from base64 import b64encode as encodebytes
+from base64 import b64encode
 
 # If running in Google App Engine there is no "user" and
 # os.path.expanduser() will fail. Attempt to detect this case and use a

--- a/boto/compat.py
+++ b/boto/compat.py
@@ -29,12 +29,9 @@ except ImportError:
     import json
 
 
-# Switch to use encodebytes, which deprecates encodestring in Python 3
-try:
-    from base64 import encodebytes
-except ImportError:
-    from base64 import encodestring as encodebytes
-
+# Switch to use b64encode, which doesn't insert newlines that break proxy
+# auth
+from base64 import b64encode as encodebytes
 
 # If running in Google App Engine there is no "user" and
 # os.path.expanduser() will fail. Attempt to detect this case and use a

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -61,7 +61,7 @@ import boto.handler
 import boto.cacerts
 
 from boto import config, UserAgent
-from boto.compat import six, http_client, urlparse, quote, encodebytes
+from boto.compat import six, http_client, urlparse, quote, b64encode
 from boto.exception import AWSConnectionError
 from boto.exception import BotoClientError
 from boto.exception import BotoServerError
@@ -855,7 +855,7 @@ class AWSAuthConnection(object):
         return path
 
     def get_proxy_auth_header(self):
-        auth = encodebytes(self.proxy_user + ':' + self.proxy_pass)
+        auth = b64encode(self.proxy_user + ':' + self.proxy_pass)
         return {'Proxy-Authorization': 'Basic %s' % auth}
 
     # For passing proxy information to other connection libraries, e.g. cloudsearch2

--- a/boto/mws/connection.py
+++ b/boto/mws/connection.py
@@ -27,7 +27,7 @@ from boto.exception import BotoServerError
 import boto.mws.exception
 import boto.mws.response
 from boto.handler import XmlHandler
-from boto.compat import filter, map, six, encodebytes
+from boto.compat import filter, map, six, b64encode
 
 __all__ = ['MWSConnection']
 
@@ -54,7 +54,7 @@ api_version_path = {
     'OffAmazonPayments': ('2013-01-01', 'SellerId',
                           '/OffAmazonPayments/2013-01-01'),
 }
-content_md5 = lambda c: encodebytes(hashlib.md5(c).digest()).strip()
+content_md5 = lambda c: b64encode(hashlib.md5(c).digest()).strip()
 decorated_attrs = ('action', 'response', 'section',
                    'quota', 'restore', 'version')
 api_call_map = {}

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -31,7 +31,7 @@ import binascii
 import math
 from hashlib import md5
 import boto.utils
-from boto.compat import BytesIO, six, urllib, encodebytes
+from boto.compat import BytesIO, six, urllib, b64encode
 
 from boto.exception import BotoClientError
 from boto.exception import StorageDataError
@@ -217,7 +217,7 @@ class Key(object):
         from just having a precalculated md5_hexdigest.
         """
         digest = binascii.unhexlify(md5_hexdigest)
-        base64md5 = encodebytes(digest)
+        base64md5 = b64encode(digest)
         if base64md5[-1] == '\n':
             base64md5 = base64md5[0:-1]
         return (md5_hexdigest, base64md5)

--- a/boto/sdb/db/manager/xmlmanager.py
+++ b/boto/sdb/db/manager/xmlmanager.py
@@ -22,7 +22,7 @@ import boto
 from boto.utils import find_class, Password
 from boto.sdb.db.key import Key
 from boto.sdb.db.model import Model
-from boto.compat import six, encodebytes
+from boto.compat import six, b64encode
 from datetime import datetime
 from xml.dom.minidom import getDOMImplementation, parse, parseString, Node
 
@@ -203,7 +203,7 @@ class XMLManager(object):
         self.enable_ssl = enable_ssl
         self.auth_header = None
         if self.db_user:
-            base64string = encodebytes('%s:%s' % (self.db_user, self.db_passwd))[:-1]
+            base64string = b64encode('%s:%s' % (self.db_user, self.db_passwd))[:-1]
             authheader = "Basic %s" % base64string
             self.auth_header = authheader
 

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -57,7 +57,7 @@ import email.encoders
 import gzip
 import threading
 import locale
-from boto.compat import six, StringIO, urllib, encodebytes
+from boto.compat import six, StringIO, urllib, b64encode
 
 from contextlib import contextmanager
 
@@ -1013,7 +1013,7 @@ def compute_hash(fp, buf_size=8192, size=None, hash_algorithm=md5):
         else:
             s = fp.read(buf_size)
     hex_digest = hash_obj.hexdigest()
-    base64_digest = encodebytes(hash_obj.digest()).decode('utf-8')
+    base64_digest = b64encode(hash_obj.digest()).decode('utf-8')
     if base64_digest[-1] == '\n':
         base64_digest = base64_digest[0:-1]
     # data_size based on bytes read.

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -26,10 +26,11 @@ from tests.compat import mock, unittest
 from httpretty import HTTPretty
 
 from boto import UserAgent
-from boto.compat import json, parse_qs
+from boto.compat import json, parse_qs, encodebytes
 from boto.connection import AWSQueryConnection, AWSAuthConnection, HTTPRequest
 from boto.exception import BotoServerError
 from boto.regioninfo import RegionInfo
+from boto.vendored.six import PY3
 
 
 class TestListParamsSerialization(unittest.TestCase):
@@ -552,6 +553,14 @@ class TestHTTPRequest(unittest.TestCase):
         # relying on other code cast the value later. (Python 2.7.0, for
         # example, assumes headers are of type str.)
         self.assertIsInstance(request.headers['Content-Length'], str)
+
+    def test_b64_linebreaks(self):
+        auth = "username:" + ("alongpassword" * 10)
+        if PY3:
+            encoded = encodebytes(bytes(auth, "ascii")).decode("ascii")
+        else:
+            encoded = encodebytes(auth)
+        self.assertTrue("\n" not in encoded)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -26,7 +26,7 @@ from tests.compat import mock, unittest
 from httpretty import HTTPretty
 
 from boto import UserAgent
-from boto.compat import json, parse_qs, encodebytes
+from boto.compat import json, parse_qs, b64encode
 from boto.connection import AWSQueryConnection, AWSAuthConnection, HTTPRequest
 from boto.exception import BotoServerError
 from boto.regioninfo import RegionInfo
@@ -557,9 +557,9 @@ class TestHTTPRequest(unittest.TestCase):
     def test_b64_linebreaks(self):
         auth = "username:" + ("alongpassword" * 10)
         if PY3:
-            encoded = encodebytes(bytes(auth, "ascii")).decode("ascii")
+            encoded = b64encode(bytes(auth, "ascii")).decode("ascii")
         else:
-            encoded = encodebytes(auth)
+            encoded = b64encode(auth)
         self.assertTrue("\n" not in encoded)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Using `encodebytes`/`encodestring` injects newlines into the base64 string.  When this is used as a proxy auth header, it breaks.  We see this when the supplied proxy username/password combination is sufficiently long.