### PR TITLE
Support Python 3.4

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -793,18 +793,18 @@ class AWSAuthConnection(object):
         else:
             sock = socket.create_connection((self.proxy, int(self.proxy_port)))
         boto.log.debug("Proxy connection: CONNECT %s HTTP/1.0\r\n", host)
-        sock.sendall("CONNECT %s HTTP/1.0\r\n" % host)
-        sock.sendall("User-Agent: %s\r\n" % UserAgent)
+        sock.sendall(("CONNECT %s HTTP/1.0\r\n" % host).encode('utf-8'))
+        sock.sendall(("User-Agent: %s\r\n" % UserAgent).encode('utf-8'))
         if self.proxy_user and self.proxy_pass:
             for k, v in self.get_proxy_auth_header().items():
-                sock.sendall("%s: %s\r\n" % (k, v))
+                sock.sendall(("%s: %s\r\n" % (k, v)).encode('utf-8'))
             # See discussion about this config option at
             # https://groups.google.com/forum/?fromgroups#!topic/boto-dev/teenFvOq2Cc
             if config.getbool('Boto', 'send_crlf_after_proxy_auth_headers', False):
-                sock.sendall("\r\n")
+                sock.sendall("\r\n".encode('utf-8'))
         else:
-            sock.sendall("\r\n")
-        resp = http_client.HTTPResponse(sock, strict=True, debuglevel=self.debug)
+            sock.sendall("\r\n".encode('utf-8'))
+        resp = http_client.HTTPResponse(sock, debuglevel=self.debug)
         resp.begin()
 
         if resp.status != 200:


### PR DESCRIPTION
Update `socket` and `httplib` calls to support Python 3.4:

* socket connection expects bytes rather than string type data
* httplib no longer accepts strict flag

This is an update to #2893, fixes #2869, and is intended to be backwards compatible.

### socket

Regarding the `socket` change, the expected input datatype was changed from [`string`](https://docs.python.org/2/library/socket.html#socket.socket.sendall) to [`bytes`](https://docs.python.org/3/library/socket.html#socket.socket.sendall).  You can see that `type("foo".encode("utf-8")) == <type 'str'>` in Python2 and `type("foo".encode("utf-8")) == <class 'bytes'>` in Python3.

This can be reproduced in the following code (run in Python 3.4 with Boto 2.46.1):

```
In [1]: from boto.connection import AWSAuthConnection

In [2]: AWSAuthConnection('us-west-2.queue.amazonaws.com').proxy_ssl()
2017-04-11 20:42:52,755 - boto - DEBUG - Using access key found in environment variable.
2017-04-11 20:42:52,757 - boto - DEBUG - Using secret key found in environment variable.
2017-04-11 20:42:52,758 - boto - DEBUG - Proxy connection: CONNECT us-west-2.queue.amazonaws.com:443 HTTP/1.0

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-37-88d29f72f4c2> in <module>()
----> 1 AWSAuthConnection('us-west-2.queue.amazonaws.com').proxy_ssl(host='us-west-2.queue.amazonaws.com')

/opt/env/lib/python3.5/site-packages/boto/connection.py in proxy_ssl(self, host, port)
    794             sock = socket.create_connection((self.proxy, int(self.proxy_port)))
    795         boto.log.debug("Proxy connection: CONNECT %s HTTP/1.0\r\n", host)
--> 796         sock.sendall("CONNECT %s HTTP/1.0\r\n" % host)
    797         sock.sendall("User-Agent: %s\r\n" % UserAgent)
    798         if self.proxy_user and self.proxy_pass:

TypeError: a bytes-like object is required, not 'str'
```

### httplib

Regarding the `httplib` change, the original `strict` flag of the `HTTPResponse` class was documented as:

> When true, the optional parameter _strict_ (which defaults to a false value) causes `BadStatusLine` to be raised if the status line can’t be parsed as a valid HTTP/1.0 or 1.1 status line.

In Python3.4, [this flag was removed](https://docs.python.org/3.4/library/http.client.html#http.client.HTTPConnection):

> _Changed in version 3.4:_ The _strict_ parameter was removed. HTTP 0.9-style “Simple Responses” are not longer supported.

To the best of my knowledge, AWS does not send HTTP 0.9-style "Simple Responses" (based on the fact that no `BadStatusLine` exceptions were handled previously).

To reproduce error:

```
In [1]: import http.client

In [2]: import socket

In [3]: sock = socket.create_connection(('us-west-2.queue.amazonaws.com',443))

In [4]: http.client.HTTPResponse(sock)
Out[4]: <http.client.HTTPResponse at 0x7fca5ebae8d0>

In [5]: http.client.HTTPResponse(sock, strict=True)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-43-5a28fd1ee7c9> in <module>()
----> 1 http.client.HTTPResponse(sock, strict=True)

TypeError: __init__() got an unexpected keyword argument 'strict'
```
