### PR TITLE
Add space between Authorization header fields

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -579,7 +579,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         l = ['AWS4-HMAC-SHA256 Credential=%s' % self.scope(req)]
         l.append('SignedHeaders=%s' % self.signed_headers(headers_to_sign))
         l.append('Signature=%s' % signature)
-        req.headers['Authorization'] = ','.join(l)
+        req.headers['Authorization'] = ', '.join(l)
 
 
 class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):


### PR DESCRIPTION
According to the documentation, there are spaces between Credential, SignedHeaders, and Signature fields http://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html#sigv4-add-signature-auth-header.