### PR TITLE
Make fetch_file script support large files

### DIFF
--- a/bin/fetch_file
+++ b/bin/fetch_file
@@ -1,27 +1,13 @@
-#!/usr/bin/env python
-# Copyright (c) 2009 Chris Moyer http://coredumped.org
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the
-# "Software"), to deal in the Software without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish, dis-
-# tribute, sublicense, and/or sell copies of the Software, and to permit
-# persons to whom the Software is furnished to do so, subject to the fol-
-# lowing conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
-# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE.
-#
 import sys
 
+def read_in_chunks(file_object, chunk_size=1024):
+    """Lazy function (generator) to read a file piece by piece.
+    Default chunk size: 1k."""
+    while True:
+        data = file_object.read(chunk_size)
+        if not data:
+            break
+        yield data
 
 if __name__ == "__main__":
     from optparse import OptionParser
@@ -41,6 +27,9 @@ The URI can be either an HTTP URL, or "s3://bucket_name/key_name"
     from boto.utils import fetch_file
     f = fetch_file(args[0])
     if options.outfile:
-        open(options.outfile, "w").write(f.read())
+        with open(options.outfile, "ab") as outfile:
+            for piece in read_in_chunks(f):
+                outfile.write(piece)
     else:
-        print(f.read())
+        for piece in read_in_chunks(f):
+            print(piece)


### PR DESCRIPTION
This fixes a bug where the fetch_file script naively reads the entire input file into memory to write it or print it.