### PR TITLE
Fix generate_url() AttributeError when using anonymous connections

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -406,12 +406,12 @@ class S3Connection(AWSAuthConnection):
         if extra_qp:
             delimiter = '?' if '?' not in auth_path else '&'
             auth_path += delimiter + '&'.join(extra_qp)
-        c_string = boto.utils.canonical_string(method, auth_path, headers,
-                                               expires, self.provider)
-        b64_hmac = self._auth_handler.sign_string(c_string)
-        encoded_canonical = urllib.parse.quote(b64_hmac, safe='')
         self.calling_format.build_path_base(bucket, key)
-        if query_auth:
+        if query_auth and not self.anon:
+            c_string = boto.utils.canonical_string(method, auth_path, headers,
+                                                   expires, self.provider)
+            b64_hmac = self._auth_handler.sign_string(c_string)
+            encoded_canonical = urllib.parse.quote(b64_hmac, safe='')
             query_part = '?' + self.QueryString % (encoded_canonical, expires,
                                                    self.aws_access_key_id)
         else:

--- a/tests/unit/s3/test_connection.py
+++ b/tests/unit/s3/test_connection.py
@@ -48,6 +48,18 @@ class TestSignatureAlteration(AWSMockServiceTestCase):
         )
 
 
+class TestAnon(MockServiceWithConfigTestCase):
+    connection_class = S3Connection
+
+    def test_generate_url(self):
+        conn = self.connection_class(
+            anon=True,
+            host='s3.amazonaws.com'
+        )
+        url = conn.generate_url(0, 'GET', bucket='examplebucket', key='test.txt')
+        self.assertNotIn('Signature=', url)
+
+
 class TestPresigned(MockServiceWithConfigTestCase):
     connection_class = S3Connection
 


### PR DESCRIPTION
Previously generating a URL would fail for anonymous connections (even when using `query_auth=False`), with:
`AttributeError: 'AnonAuthHandler' object has no attribute '_hmac_256'`

That now works, and in addition the `query_auth=False` parameter is now optional for anonymous connections.

Fixes #1540.