### PR TITLE
Use RegionInfo by default with heuristics

### DIFF
--- a/boto/regioninfo.py
+++ b/boto/regioninfo.py
@@ -205,6 +205,8 @@ def connect(service_name, region_name, region_cls=None,
 
     :returns: A configured connection class.
     """
+    if region_cls is None:
+        region_cls = RegionInfo
     region = _get_region(service_name, region_name, region_cls, connection_cls)
 
     if region is None and _use_endpoint_heuristics():

--- a/tests/unit/test_connect_to_region.py
+++ b/tests/unit/test_connect_to_region.py
@@ -19,6 +19,8 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+import os
+
 from tests.unit import unittest
 
 
@@ -190,6 +192,16 @@ class TestDynamodb2Connection(unittest.TestCase):
                                        aws_secret_access_key='bar')
         self.assertIsInstance(connection, DynamoDBConnection)
         self.assertEqual(connection.host, 'dynamodb.us-east-1.amazonaws.com')
+
+    def test_connect_to_unkown_region(self):
+        from boto.dynamodb2 import connect_to_region
+        from boto.dynamodb2.layer1 import DynamoDBConnection
+        os.environ['BOTO_USE_ENDPOINT_HEURISTICS'] = 'True'
+        connection = connect_to_region(
+            'us-east-45', aws_access_key_id='foo',
+            aws_secret_access_key='bar')
+        self.assertIsInstance(connection, DynamoDBConnection)
+        self.assertEqual(connection.host, 'dynamodb.us-east-45.amazonaws.com')
 
 
 class TestEC2Connection(unittest.TestCase):

--- a/tests/unit/test_regioninfo.py
+++ b/tests/unit/test_regioninfo.py
@@ -200,6 +200,17 @@ class TestConnectToRegion(unittest.TestCase):
         expected_endpoint = 'ec2.us-southeast-43.amazonaws.com'
         self.assertEqual(connection.region.endpoint, expected_endpoint)
 
+    def test_connect_with_hueristics_without_explicit_regioninfo(self):
+        os.environ['BOTO_USE_ENDPOINT_HEURISTICS'] = 'True'
+        self.addCleanup(os.environ.pop, 'BOTO_USE_ENDPOINT_HEURISTICS')
+        connection = connect(
+            'ec2', 'us-southeast-43', connection_cls=FakeConn)
+        self.assertIsNotNone(connection)
+        self.assertIsInstance(connection.region, RegionInfo)
+        self.assertEqual(connection.region.name, 'us-southeast-43')
+        expected_endpoint = 'ec2.us-southeast-43.amazonaws.com'
+        self.assertEqual(connection.region.endpoint, expected_endpoint)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The generic `connect` wasn't using the `RegionInfo` class by default. This had been masked by two things:

1. `get_regions` properly uses this as the default. Most tests only go through `get_regions` so most tests wouldn't encounter this at all.
2. The tests explicitly for the region heuristics all provide a custom region class.

This fixes the issue and adds tests that would fail if the default were not correctly set.

Anybody on an impacted version can unblock themselves by passing `region_cls=RegionInfo` into their connect call.