### PR TITLE
Allow specifying s3 host from boto config file.

### DIFF
--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -161,7 +161,7 @@ class HostRequiredError(BotoClientError):
 
 class S3Connection(AWSAuthConnection):
 
-    DefaultHost = boto.config.get('s3', 'host', 's3.amazonaws.com')
+    DefaultHost = 's3.amazonaws.com'
     DefaultCallingFormat = boto.config.get('s3', 'calling_format', 'boto.s3.connection.SubdomainCallingFormat')
     QueryString = 'Signature=%s&Expires=%d&AWSAccessKeyId=%s'
 
@@ -174,9 +174,12 @@ class S3Connection(AWSAuthConnection):
                  suppress_consec_slashes=True, anon=False,
                  validate_certs=None, profile_name=None):
         no_host_provided = False
+        # Try falling back to the boto config file's value, if present.
         if host is NoHostProvided:
-            no_host_provided = True
-            host = self.DefaultHost
+            host = boto.config.get('s3', 'host')
+            if host is None:
+                host = self.DefaultHost
+                no_host_provided = True
         if isinstance(calling_format, six.string_types):
             calling_format=boto.utils.find_class(calling_format)()
         self.calling_format = calling_format

--- a/tests/integration/s3/test_key.py
+++ b/tests/integration/s3/test_key.py
@@ -419,7 +419,10 @@ class S3KeyTest(unittest.TestCase):
         remote_metadata = check._get_remote_metadata()
 
         # TODO: investigate whether encoding ' ' as '%20' makes sense
-        self.assertEqual(check.cache_control, 'public,%20max-age=500')
+        self.assertIn(
+            check.cache_control,
+            ('public,%20max-age=500', 'public, max-age=500')
+        )
         self.assertEqual(remote_metadata['cache-control'], 'public,%20max-age=500')
         self.assertEqual(check.get_metadata('test-plus'), 'A plus (+)')
         self.assertEqual(check.content_disposition, 'filename=Sch%C3%B6ne%20Zeit.txt')


### PR DESCRIPTION
This allows users to specify a value for s3:host in their Boto config file, rather than needing to pass the host directly to the constructor for S3Connection.  There are some situations (e.g. when using gsutil) where users don't have direct control over how the constructor is called; this allows passing the host argument in such scenarios.

(This also fixes an s3 integration test flake.)