### PR TITLE
dynamodb2.items: enable saving of empty dicts

### DIFF
--- a/boto/dynamodb2/items.py
+++ b/boto/dynamodb2/items.py
@@ -306,7 +306,7 @@ class Item(object):
         # We need to prevent ``None``, empty string & empty set from
         # heading to DDB, but allow false-y values like 0 & False make it.
         if not value:
-            if not value in (0, 0.0, False):
+            if not value in (0, 0.0, False, dict()):
                 return False
 
         return True


### PR DESCRIPTION
empty dicts, unlike empty sets, are saveable, so fix the _is_storable
check to reflect that.

I wan't sure how to test it, and would be happy to add a test. The tests I see mock `Table._put_item`, but the data-to-be-stored isn't available from the public API to be inspected.
Another change would also check empty lists (I think that they are also valid inside DynamoDB).

Signed-off-by: Amit Beka <amit.beka>