### PR TITLE
Fix "ValueError: too many values to unpack" for allowed_values includes minus value

### DIFF
--- a/boto/rds/parametergroup.py
+++ b/boto/rds/parametergroup.py
@@ -146,7 +146,7 @@ class Parameter(object):
             value = int(value)
         if isinstance(value, int) or isinstance(value, long):
             if self.allowed_values:
-                min, max = self.allowed_values.split('-')
+                min, max = self.allowed_values.rsplit('-', 1)
                 if value < int(min) or value > int(max):
                     raise ValueError('range is %s' % self.allowed_values)
             self._value = value


### PR DESCRIPTION
For postgres instance, `allowed_values` may have minus range like "-1-2147483647".
With such parameters (ex `log_min_duration_statement`), exception above raised at `min, max = allowed_value.split('-')` line.