### PR TITLE
Add py35 and py36 to tox config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy"
 env:
   - BOTO_CONFIG=/tmp/nowhere

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,pypy
+envlist = py26,py27,py33,py34,py35,py36,pypy
 
 # Comment to build sdist and install into virtualenv
 # This is helpful to test installation but takes extra time


### PR DESCRIPTION
While it looks like Python 3.5 and 3.6 are not officially supported the unit tests have [already been updated](https://github.com/boto/boto/blob/master/docs/source/releasenotes/v2.39.0.rst) to pass in 3.5 and already pass in 3.6 as well.

A similar PR https://github.com/boto/boto/pull/2458 was merged to support pypy in tox.

(My current use case is running Apache Airflow which runs on Python through 3.6.x but currently uses boto rather than boto3 behind the scenes.)