### PR TITLE
S3: Fix sorting of HmacAuthV4Handler canonical_headers

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -411,7 +411,8 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
             else:
                 c_value = ' '.join(raw_value.strip().split())
             canonical.append('%s:%s' % (c_name, c_value))
-        return '\n'.join(sorted(canonical))
+        canonical.sort(key=lambda h: h.split(':', 1)[0])
+        return '\n'.join(canonical)
 
     def signed_headers(self, headers_to_sign):
         l = ['%s' % n.lower().strip() for n in headers_to_sign]


### PR DESCRIPTION
PR for fixing the issue detailed in https://github.com/boto/boto/issues/3749. The example below shows that same workflow with the patch and the headers in the correct order.

```
>>> mp = b.initiate_multipart_upload('my-test-key-kms', headers=hdrs)
2017-08-25 06:43:23,481 boto [DEBUG]:path=/my-test-key-kms
2017-08-25 06:43:23,481 boto [DEBUG]:auth_path=/my-test-bucket-kms/my-test-key-kms
2017-08-25 06:43:23,482 boto [DEBUG]:path=/my-test-key-kms?uploads
2017-08-25 06:43:23,482 boto [DEBUG]:auth_path=/my-test-bucket-kms/my-test-key-kms?uploads
2017-08-25 06:43:23,482 boto [DEBUG]:Method: POST
2017-08-25 06:43:23,482 boto [DEBUG]:Path: /my-test-key-kms?uploads
2017-08-25 06:43:23,482 boto [DEBUG]:Data: 
2017-08-25 06:43:23,482 boto [DEBUG]:Headers: {'x-amz-server-side-encryption-aws-kms-key-id': 'arn:aws:kms:us-west-2:111122223333:key/b9c76fe7-735f-461c-9ce0-f8c01e020676', 'x-amz-server-side-encryption': 'aws:kms'}
2017-08-25 06:43:23,482 boto [DEBUG]:Host: my-test-bucket-kms.s3-us-west-2.amazonaws.com
2017-08-25 06:43:23,482 boto [DEBUG]:Port: 443
2017-08-25 06:43:23,482 boto [DEBUG]:Params: {}
2017-08-25 06:43:23,483 boto [DEBUG]:Token: None
2017-08-25 06:43:23,483 boto [DEBUG]:CanonicalRequest:
POST
/my-test-key-kms
uploads=
host:my-test-bucket-kms.s3-us-west-2.amazonaws.com
user-agent:Boto/2.48.0 Python/2.7.6 Linux/4.4.0-87-generic
x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
x-amz-date:20170825T064323Z
x-amz-server-side-encryption:aws:kms
x-amz-server-side-encryption-aws-kms-key-id:arn:aws:kms:us-west-2:111122223333:key/b9c76fe7-735f-461c-9ce0-f8c01e020676

host;user-agent;x-amz-content-sha256;x-amz-date;x-amz-server-side-encryption;x-amz-server-side-encryption-aws-kms-key-id
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
2017-08-25 06:43:23,483 boto [DEBUG]:StringToSign:
AWS4-HMAC-SHA256
20170825T064323Z
20170825/us-west-2/s3/aws4_request
b1fe2bd4e9cfbb240c4fc0eb1305b4ddaf3559b28483002c275fa9ee8ec5728b
2017-08-25 06:43:23,483 boto [DEBUG]:Signature:
66814a31a5bc5cd832704d7fd4a751d9be23ef0f5d861fe30abe60743c1db2ab
2017-08-25 06:43:23,484 boto [DEBUG]:Final headers: {'x-amz-content-sha256': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', 'Content-Length': '0', 'Host': 'my-test-bucket-kms.s3-us-west-2.amazonaws.com', 'User-Agent': 'Boto/2.48.0 Python/2.7.6 Linux/4.4.0-87-generic', 'x-amz-server-side-encryption-aws-kms-key-id': 'arn:aws:kms:us-west-2:111122223333:key/b9c76fe7-735f-461c-9ce0-f8c01e020676', 'X-Amz-Date': '20170825T064323Z', 'x-amz-server-side-encryption': 'aws:kms', 'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIAKIAKIAKIAKIAKIAK/20170825/us-west-2/s3/aws4_request,SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date;x-amz-server-side-encryption;x-amz-server-side-encryption-aws-kms-key-id,Signature=66814a31a5bc5cd832704d7fd4a751d9be23ef0f5d861fe30abe60743c1db2ab'}
```
```
2017-08-25 06:43:23,641 boto [DEBUG]:Response headers: [('x-amz-id-2', '3gxH6+QK1ZckzhHh0cGBMDD2ewsAWQusZiKe3f5MUik81JzTJevxYWS/xILt47ZC1XsMjQPe5hM='), ('server', 'AmazonS3'), ('transfer-encoding', 'chunked'), ('x-amz-server-side-encryption-aws-kms-key-id', 'arn:aws:kms:us-west-2:111122223333:key/b9c76fe7-735f-461c-9ce0-f8c01e020676'), ('x-amz-request-id', '56A86C844742812B'), ('date', 'Fri, 25 Aug 2017 06:43:24 GMT'), ('x-amz-server-side-encryption', 'aws:kms')]
2017-08-25 06:43:23,642 boto [DEBUG]:<?xml version="1.0" encoding="UTF-8"?>
<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Bucket>my-test-bucket-kms</Bucket><Key>my-test-key-kms</Key><UploadId>DwxTmNkx4eMBKud.32h_rIl1g5jamhLRTU5T07f4OPdpRy6p011HvIRhGVrwZhBra1YaaW2YnPPeUw1Txz1qJRV6B.VaDQp_IAhtvvUJIm5eQGn._IoDg5SpjXaxxQET</UploadId></InitiateMultipartUploadResult>
```