### PR TITLE
ETag header check handling with SSE-KMS S3 encryption

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -988,7 +988,10 @@ class Key(object):
             # object.
             server_side_encryption_customer_algorithm = response.getheader(
                 'x-amz-server-side-encryption-customer-algorithm', None)
-            if server_side_encryption_customer_algorithm is None:
+            server_side_encryption = response.getheader(
+                'x-amz-server-side-encryption', None)
+            if (server_side_encryption_customer_algorithm is None and
+                    server_side_encryption is None):
                 if self.etag != '"%s"' % md5:
                     raise provider.storage_data_error(
                         'ETag from S3 did not match computed MD5. '

--- a/tests/integration/s3/test_key.py
+++ b/tests/integration/s3/test_key.py
@@ -467,6 +467,17 @@ class S3KeyTest(unittest.TestCase):
         ks = kn.get_contents_as_string(headers=header)
         self.assertEqual(ks, content.encode('utf-8'))
 
+    def test_set_contents_with_sse_kms(self):
+        content="01234567890123456789"
+        # use default aws/s3 KMS key
+        header = {'x-amz-server-side-encryption': 'aws:kms'}
+        # upload and download content with AWS specified headers
+        k = self.bucket.new_key("testkey_for_sse_kms")
+        k.set_contents_from_string(content, headers=header)
+        kn = self.bucket.new_key("testkey_for_sse_kms")
+        ks = kn.get_contents_as_string()
+        self.assertEqual(ks, content)
+        self.assertEqual(kn.encrypted, 'aws:kms')
 
 class S3KeySigV4Test(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
PR for fixing the issue detailed in #3750. The example below shows that same workflow with the patch.

```
hdrs = { 'x-amz-server-side-encryption': 'aws:kms'}
b = s3c.create_bucket('my-test-bucket-kms', location='us-west-2')
mp = b.initiate_multipart_upload('my-test-key-kms', headers=hdrs)
with open('/tmp/datafile', 'rb') as f:
    mp.upload_part_from_file(fp=f, part_num=1)
mp.complete_upload()
```

```
>>>    mp.upload_part_from_file(fp=f, part_num=1)
2017-08-25 07:01:22,764 boto [DEBUG]:path=/my-test-key-kms
2017-08-25 07:01:22,765 boto [DEBUG]:auth_path=/my-test-bucket-kms/my-test-key-kms
2017-08-25 07:01:22,765 boto [DEBUG]:path=/my-test-key-kms?uploadId=DwxTmNkx4eMBKud.32h_rIl1g5jamhLRTU5T07f4OPdpRy6p011HvIRhGVrwZhBra1YaaW2YnPPeUw1Txz1qJRV6B.VaDQp_IAhtvvUJIm5eQGn._IoDg5SpjXaxxQET&partNumber=1
2017-08-25 07:01:22,765 boto [DEBUG]:auth_path=/my-test-bucket-kms/my-test-key-kms?uploadId=DwxTmNkx4eMBKud.32h_rIl1g5jamhLRTU5T07f4OPdpRy6p011HvIRhGVrwZhBra1YaaW2YnPPeUw1Txz1qJRV6B.VaDQp_IAhtvvUJIm5eQGn._IoDg5SpjXaxxQET&partNumber=1
2017-08-25 07:01:22,765 boto [DEBUG]:Method: PUT
2017-08-25 07:01:22,765 boto [DEBUG]:Path: /my-test-key-kms?uploadId=DwxTmNkx4eMBKud.32h_rIl1g5jamhLRTU5T07f4OPdpRy6p011HvIRhGVrwZhBra1YaaW2YnPPeUw1Txz1qJRV6B.VaDQp_IAhtvvUJIm5eQGn._IoDg5SpjXaxxQET&partNumber=1
2017-08-25 07:01:22,765 boto [DEBUG]:Data: 
2017-08-25 07:01:22,765 boto [DEBUG]:Headers: {'_sha256': '47c51d8f3dcaaf36e0a60e8481b05da8d941c352bb7a728bb7f702d35360da30', 'Content-Length': '345992', 'Expect': '100-Continue', 'Content-MD5': u'KrKJE9IMDORzk3K8YjMB1Q==', 'Content-Type': 'application/octet-stream', 'User-Agent': 'Boto/2.48.0 Python/2.7.6 Linux/4.4.0-87-generic'}
2017-08-25 07:01:22,765 boto [DEBUG]:Host: my-test-bucket-kms.s3-us-west-2.amazonaws.com
2017-08-25 07:01:22,765 boto [DEBUG]:Port: 443
2017-08-25 07:01:22,766 boto [DEBUG]:Params: {}
2017-08-25 07:01:22,766 boto [DEBUG]:establishing HTTPS connection: host=my-test-bucket-kms.s3-us-west-2.amazonaws.com, kwargs={'port': 443, 'timeout': 70}
2017-08-25 07:01:22,766 boto [DEBUG]:Token: None
2017-08-25 07:01:22,767 boto [DEBUG]:CanonicalRequest:
PUT
/my-test-key-kms
partNumber=1&uploadId=DwxTmNkx4eMBKud.32h_rIl1g5jamhLRTU5T07f4OPdpRy6p011HvIRhGVrwZhBra1YaaW2YnPPeUw1Txz1qJRV6B.VaDQp_IAhtvvUJIm5eQGn._IoDg5SpjXaxxQET
content-length:345992
content-md5:KrKJE9IMDORzk3K8YjMB1Q==
content-type:application/octet-stream
expect:100-Continue
host:my-test-bucket-kms.s3-us-west-2.amazonaws.com
user-agent:Boto/2.48.0 Python/2.7.6 Linux/4.4.0-87-generic
x-amz-content-sha256:47c51d8f3dcaaf36e0a60e8481b05da8d941c352bb7a728bb7f702d35360da30
x-amz-date:20170825T070122Z

content-length;content-md5;content-type;expect;host;user-agent;x-amz-content-sha256;x-amz-date
47c51d8f3dcaaf36e0a60e8481b05da8d941c352bb7a728bb7f702d35360da30
2017-08-25 07:01:22,767 boto [DEBUG]:StringToSign:
AWS4-HMAC-SHA256
20170825T070122Z
20170825/us-west-2/s3/aws4_request
5571edc80b1b514259d6afc727e842adbcec518bb8fc7af6e3e340401bdfae70
2017-08-25 07:01:22,767 boto [DEBUG]:Signature:
6b6da547d93be0a6dfb6428a4099318629b606c6af2b050b5a89c54a4d1d9d02
2017-08-25 07:01:22,767 boto [DEBUG]:Final headers: {'x-amz-content-sha256': '47c51d8f3dcaaf36e0a60e8481b05da8d941c352bb7a728bb7f702d35360da30', 'Content-Length': '345992', 'Expect': '100-Continue', 'X-Amz-Date': '20170825T070122Z', 'Content-MD5': 'KrKJE9IMDORzk3K8YjMB1Q==', 'Content-Type': 'application/octet-stream', 'Host': 'my-test-bucket-kms.s3-us-west-2.amazonaws.com', 'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIAKIAKIAKIAKIAKIAK/20170825/us-west-2/s3/aws4_request,SignedHeaders=content-length;content-md5;content-type;expect;host;user-agent;x-amz-content-sha256;x-amz-date,Signature=6b6da547d93be0a6dfb6428a4099318629b606c6af2b050b5a89c54a4d1d9d02', 'User-Agent': 'Boto/2.48.0 Python/2.7.6 Linux/4.4.0-87-generic'}
2017-08-25 07:01:23,244 boto [DEBUG]:Response headers: [('content-length', '0'), ('x-amz-id-2', 'COG7Tji3QLb+i85EYZ8T2d6S0t8HXF1BUd+9HQ6HhbLez+DTaZGosmp5UboMqPfiyo5OHwJ4EGc='), ('server', 'AmazonS3'), ('x-amz-server-side-encryption-aws-kms-key-id', 'arn:aws:kms:us-west-2:111122223333:key/b9c76fe7-735f-461c-9ce0-f8c01e020676'), ('x-amz-request-id', 'A81BDD8B53391FCD'), ('etag', '"6b51393f661dddbc70c862e06b8fffc9"'), ('date', 'Fri, 25 Aug 2017 07:01:23 GMT'), ('x-amz-server-side-encryption', 'aws:kms')]
<Key: my-test-bucket-kms,my-test-key-kms>
```