### PR TITLE
boto: s3: resumable_download_handler: use http.client on python3

### DIFF
--- a/boto/s3/resumable_download_handler.py
+++ b/boto/s3/resumable_download_handler.py
@@ -19,7 +19,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 import errno
-import httplib
+try:
+    import httplib
+except ImportError:
+    # Python 3
+    import http.client as httplib
 import os
 import re
 import socket


### PR DESCRIPTION
When using ResumableDownloadHandler on python 3, such exception occures:

File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/boto/s3/resumable_download_handler.py", line 22, in <module>
    import httplib
ImportError: No module named 'httplib'

This is because on python3 httplib is now known as http.client.

Fixes #3754

Signed-off-by: Ruslan Kuprieiev <kupruser@gmail.com>