### PR TITLE
Fix tests/unit/glacier/test_writer.py to make work with pypy.

### DIFF
--- a/tests/unit/glacier/test_writer.py
+++ b/tests/unit/glacier/test_writer.py
@@ -67,7 +67,7 @@ def calculate_mock_vault_calls(data, part_size, chunk_size):
         data_part_tree_hash = bytes_to_hex(data_part_tree_hash_blob)
         data_part_linear_hash = sha256(data_part).hexdigest()
         upload_part_calls.append(
-            call.layer1.upload_part(
+            call(
                 sentinel.vault_name, sentinel.upload_id,
                 data_part_linear_hash, data_part_tree_hash,
                 (start, end - 1), data_part))


### PR DESCRIPTION
Also see https://github.com/boto/boto/issues/3761 for discussion.

Remove explicit name from expected _Call.

A recent unrelated boto commit exposed a new failure mode in this test when running against pypy (only). The breakage appears to be due to an underlying change in the behavior of pypy, expressed when using assert_has_calls() from mock.py. Investigation revealed that __eq__ in _Call from mock.py is not symmetric (intentionally, related to wildcard tests), and pypy (now?) passes the arguments to __eq__ in the remove method for the built-in list type in a different order than other Python implementations. Including ".layer1.upload_part" in the name of a _Call triggers the problem when mock.py compares it with the unnamed _Call instance it captures internally. Removing the extended name enables the test to perform correctly when run with both pypy and Python 2.7.6 (and presumably others).

See https://bitbucket.org/pypy/pypy/issues/2352/list__contains__-compares-objects-in-wrong and https://bitbucket.org/pypy/pypy/commits/4bd027dc94a24293c504f60f1cea9070a79af0e0 for possibly related pypy changes (although I didn't fully trace the timeline).