### PR TITLE
Use pkg_resources to keep the package zip-safe

### DIFF
--- a/boto/__init__.py
+++ b/boto/__init__.py
@@ -26,6 +26,7 @@
 #
 from boto.pyami.config import Config, BotoConfigLocations
 from boto.storage_uri import BucketStorageUri, FileStorageUri
+from pkg_resources import resource_filename
 import boto.plugin
 import datetime
 import os
@@ -59,7 +60,7 @@ TOO_LONG_DNS_NAME_COMP = re.compile(r'[-_a-z0-9]{64}')
 GENERATION_RE = re.compile(r'(?P<versionless_uri_str>.+)'
                            r'#(?P<generation>[0-9]+)$')
 VERSION_RE = re.compile('(?P<versionless_uri_str>.+)#(?P<version_id>.+)$')
-ENDPOINTS_PATH = os.path.join(os.path.dirname(__file__), 'endpoints.json')
+ENDPOINTS_PATH = resource_filename(__name__, 'endpoints.json')
 
 
 def init_logging():


### PR DESCRIPTION
This resolves a bug in the packaging of this package that occurs in some situation :

When `boto` is installed manually from a source distribution, in a `PYTHONDONTWRITEBYTECODE=1` environment, it ends up in the shape of a **zipfile egg** in dist-packages, as it is not marked **zip-unsafe**.
This means that importing it will result in an error, because `regioninfo.py / _load_json_file()` will try to open `endpoints.json` in what it thinks is inside a directory, when it is actually inside a zipfile.

The package could be marked as **zip-unsafe**, but there is an even better way to solve the problem: `pkg_resources` (which is part of setuptools) that will take care (when needed) of unzipping and caching the data file, returning a valid filename which can be consumed.