### PR TITLE
Fix get_contents_to_filename OSError when filename is a directory

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1723,8 +1723,16 @@ class Key(object):
                                           res_download_handler=res_download_handler,
                                           response_headers=response_headers)
         except Exception:
-            os.remove(filename)
-            raise
+            try:
+                os.remove(filename)
+            except OSError:
+                try:
+                    os.rmdir(filename)
+                except:
+                    print(filename)
+                    raise
+
+
         # if last_modified date was sent from s3, try to set file's timestamp
         if self.last_modified is not None:
             try:


### PR DESCRIPTION
## Changes

In `boto/s3/key.py`, `get_contents_to_filename`,  when `os.remove(filename)` fails, this tries again with os.rmdir(filename) in the off chance that a directory is being attempted to be removed.

## Why

`os.remove(filename)` raises an OSError when the filename to be removed is that of a directory. 

I think this is also what https://github.com/boto/boto/issues/1791 was attempting to fix.

For testing, here's the code that was calling s3.get_contents_to_filename: https://github.com/INN/power-players/blob/7efb569/fabfile/assets.py#L219-L230 was called by https://github.com/INN/power-players/blob/7efb569/fabfile/assets.py#L110 as a [Fabric](http://www.fabfile.org/) command.