### PR TITLE
Call LazyLoadMetadata._materialize upon iteritems

### DIFF
--- a/boto/utils.py
+++ b/boto/utils.py
@@ -347,6 +347,10 @@ class LazyLoadMetadata(dict):
         self._materialize()
         return super(LazyLoadMetadata, self).items()
 
+    def iteritems(self):
+        self._materialize()
+        return super(LazyLoadMetadata, self).iteritems()
+
     def __str__(self):
         self._materialize()
         return super(LazyLoadMetadata, self).__str__()


### PR DESCRIPTION
Realized `instance_meta_data['iam']['security-credentials'].iteritems().next()` doesn't work.