### PR TITLE
Fix SQS connection.py send_message() to check if delay_seconds is None, instead of falsy

### DIFF
--- a/boto/sqs/connection.py
+++ b/boto/sqs/connection.py
@@ -362,7 +362,7 @@ class SQSConnection(AWSQueryConnection):
 
         """
         params = {'MessageBody' : message_content}
-        if delay_seconds:
+        if delay_seconds is not None:
             params['DelaySeconds'] = int(delay_seconds)
 
         if message_attributes is not None:

--- a/tests/integration/sqs/test_connection.py
+++ b/tests/integration/sqs/test_connection.py
@@ -313,3 +313,17 @@ class SQSConnectionTest(unittest.TestCase):
         m1 = Message()
         m1.set_body('This is a test message.')
         queue.write(m1)
+    
+    def test_send_message_postpone(self):
+        conn = SQSConnection()
+        queue_name = 'test_send_message_postpone_%s' % int(time.time())
+        queue = conn.create_queue(queue_name)
+        conn.set_queue_attribute(queue, 'DelaySeconds', 900)
+        conn.send_message(queue, 'test message', delay_seconds=0)
+        attributes = queue.get_attributes()
+
+        mgs_available = int(attributes['ApproximateNumberOfMessages'])
+        mgs_delayed = int(attributes['ApproximateNumberOfMessagesDelayed'])
+
+        self.assertEquals(mgs_available, 1)
+        self.assertEquals(mgs_delayed, 0)


### PR DESCRIPTION
Fix for https://github.com/boto/boto/issues/3807.