### PR TITLE
Support ecs container metadata

### DIFF
--- a/boto/provider.py
+++ b/boto/provider.py
@@ -70,6 +70,8 @@ STORAGE_PERMISSIONS_ERROR = 'StoragePermissionsError'
 STORAGE_RESPONSE_ERROR = 'StorageResponseError'
 NO_CREDENTIALS_PROVIDED = object()
 
+CONTAINER_CREDENTIALS_ENV_VAR = 'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'
+
 
 class ProfileNotFoundError(ValueError):
     pass
@@ -381,15 +383,24 @@ class Provider(object):
         # get_instance_metadata is imported here because of a circular
         # dependency.
         boto.log.debug("Retrieving credentials from metadata server.")
-        from boto.utils import get_instance_metadata
+        from boto.utils import get_instance_metadata, get_container_credentials
         timeout = config.getfloat('Boto', 'metadata_service_timeout', 1.0)
         attempts = config.getint('Boto', 'metadata_service_num_attempts', 1)
         # The num_retries arg is actually the total number of attempts made,
         # so the config options is named *_num_attempts to make this more
         # clear to users.
-        metadata = get_instance_metadata(
-            timeout=timeout, num_retries=attempts,
-            data='meta-data/iam/security-credentials/')
+        metadata = None
+        if CONTAINER_CREDENTIALS_ENV_VAR in os.environ:
+            # Try to get the container credentials if the environment variable is set.
+            metadata = get_container_credentials(os.environ[CONTAINER_CREDENTIALS_ENV_VAR],
+                                                 timeout=timeout, num_retries=attempts)
+
+        if not metadata:
+            # Try to get ec2 instance metadata if no container credentials.
+            metadata = get_instance_metadata(
+                timeout=timeout, num_retries=attempts,
+                data='meta-data/iam/security-credentials/')
+
         if metadata:
             creds = self._get_credentials_from_metadata(metadata)
             self._access_key = creds[0]
@@ -402,6 +413,7 @@ class Provider(object):
             boto.log.debug("Retrieved credentials will expire in %s at: %s",
                            self._credential_expiry_time - datetime.now(),
                            expires_at)
+
 
     def _get_credentials_from_metadata(self, metadata):
         # Given metadata, return a tuple of (access, secret, token, expiration)

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -250,7 +250,8 @@ class LazyLoadMetadata(dict):
         self._timeout = timeout
 
         if is_container_metadata:
-            # Container metadata doesn't have path based keys, so we'll just do the get once in materialize()
+            # Container metadata doesn't have path based keys,
+            # so we'll just do the get once in materialize()
             key = url.split('/')[-1]
             self._leaves[key] = ''
             self[key] = None
@@ -413,13 +414,18 @@ def get_instance_metadata(version='latest', url='http://169.254.169.254',
         return None
 
 
-def get_container_credentials(relative_container_uri, url='http://169.254.170.2', timeout=None, num_retries=5):
+def get_container_credentials(relative_container_uri,
+                              url='http://169.254.170.2',
+                              timeout=None,
+                              num_retries=5):
     """
-    Support ECS Task Credentials https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
+    Support ECS Task Credentials
+    https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
     """
     try:
         metadata_url = '%s%s' % (url, relative_container_uri)
-        return _get_instance_metadata(metadata_url, num_retries=num_retries, timeout=timeout,
+        return _get_instance_metadata(metadata_url, num_retries=num_retries,
+                                      timeout=timeout,
                                       is_container_metadata=True)
     except urllib.error.URLError:
         boto.log.exception("Exception caught when trying to retrieve "

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -237,17 +237,25 @@ def retry_url(url, retry_on_404=True, num_retries=10, timeout=None):
     return ''
 
 
-def _get_instance_metadata(url, num_retries, timeout=None):
-    return LazyLoadMetadata(url, num_retries, timeout)
+def _get_instance_metadata(url, num_retries, timeout=None, is_container_metadata=False):
+    return LazyLoadMetadata(url, num_retries, timeout, is_container_metadata)
 
 
 class LazyLoadMetadata(dict):
-    def __init__(self, url, num_retries, timeout=None):
+    def __init__(self, url, num_retries, timeout=None, is_container_metadata=False):
         self._url = url
         self._num_retries = num_retries
         self._leaves = {}
         self._dicts = []
         self._timeout = timeout
+
+        if is_container_metadata:
+            # Container metadata doesn't have path based keys, so we'll just do the get once in materialize()
+            key = url.split('/')[-1]
+            self._leaves[key] = ''
+            self[key] = None
+            return
+
         data = boto.utils.retry_url(self._url, num_retries=self._num_retries, timeout=self._timeout)
         if data:
             fields = data.split('\n')
@@ -402,6 +410,20 @@ def get_instance_metadata(version='latest', url='http://169.254.169.254',
     except urllib.error.URLError:
         boto.log.exception("Exception caught when trying to retrieve "
                            "instance metadata for: %s", data)
+        return None
+
+
+def get_container_credentials(relative_container_uri, url='http://169.254.170.2', timeout=None, num_retries=5):
+    """
+    Support ECS Task Credentials https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
+    """
+    try:
+        metadata_url = '%s%s' % (url, relative_container_uri)
+        return _get_instance_metadata(metadata_url, num_retries=num_retries, timeout=timeout,
+                                      is_container_metadata=True)
+    except urllib.error.URLError:
+        boto.log.exception("Exception caught when trying to retrieve "
+                           "instance metadata for: %s", relative_container_uri)
         return None
 
 


### PR DESCRIPTION
This closes #3579 

Boto doesn't support ECS Task Metadata at all for containers.
I know that new features are being added to boto3 instead of boto, but for codebases that still use boto, this change allows access ECS task metadata.

The Provider will try to get Task credentials only if the AWS_CONTAINER_CREDENTIALS_RELATIVE_URI env var is set. If the endpoint is unavailable, it will fall back to the regular instance metadata.