### PR TITLE
gs/key.py - Use BytesIO instead of StringIO

### DIFF
--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -24,7 +24,7 @@ import binascii
 import os
 import re
 
-from boto.compat import StringIO
+from boto.compat import BytesIO
 from boto.exception import BotoClientError
 from boto.s3.key import Key as S3Key
 from boto.s3.keyfile import KeyFile
@@ -707,7 +707,7 @@ class Key(S3Key):
         self.md5 = None
         self.base64md5 = None
 
-        fp = StringIO(get_utf8_value(s))
+        fp = BytesIO(get_utf8_value(s))
         r = self.set_contents_from_file(fp, headers, replace, cb, num_cb,
                                         policy, md5,
                                         if_generation=if_generation)


### PR DESCRIPTION
`get_utf8_value` will return bytes in python3, so we need to use BytesIO and not StringIO.
(This is python2 compatible thank to https://github.com/boto/boto/blob/0a1d90404839829ac661d049ae069f3dea5ecf54/boto/vendored/six.py#L658)