### PR TITLE
Fixes incorrect HmacAuthV4 header ordering

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -413,7 +413,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
             canonical[c_name] = c_value
 
         canonical_strings = []
-        for name, value in sorted(canonical.iteritems()):
+        for name, value in sorted(canonical.items()):
             canonical_strings.append('%s:%s' % (name, value))
 
         return '\n'.join(canonical_strings)

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -401,7 +401,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         case, sorting them in alphabetical order and then joining
         them into a string, separated by newlines.
         """
-        canonical = []
+        canonical = {}
 
         for header in headers_to_sign:
             c_name = header.lower().strip()
@@ -410,8 +410,13 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
                 c_value = raw_value.strip()
             else:
                 c_value = ' '.join(raw_value.strip().split())
-            canonical.append('%s:%s' % (c_name, c_value))
-        return '\n'.join(sorted(canonical))
+            canonical[c_name] = c_value
+
+        canonical_strings = []
+        for name, value in sorted(canonical.iteritems()):
+            canonical_strings.append('%s:%s' % (name, value))
+
+        return '\n'.join(canonical_strings)
 
     def signed_headers(self, headers_to_sign):
         l = ['%s' % n.lower().strip() for n in headers_to_sign]


### PR DESCRIPTION
* Fixes incorrect header ordering in HmacAuthV4
* added test

The header ordering was incorrect. The headers should be sorted based on the header name instead of the whole header strings. 

More details about why the old sorting was incorrect and the expected behavior can be found in issue #3749. 

Fixes #3822, #3749