### PR TITLE
SWF Layer1 client: Fix argument position error for security token.

### DIFF
--- a/boto/swf/layer1.py
+++ b/boto/swf/layer1.py
@@ -69,7 +69,7 @@ class Layer1(AWSAuthConnection):
 
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,
-                 debug=0, session_token=None, region=None, profile_name=None):
+                 debug=0, security_token=None, region=None, profile_name=None):
         if not region:
             region_name = boto.config.get('SWF', 'region',
                                           self.DefaultRegionName)
@@ -82,7 +82,8 @@ class Layer1(AWSAuthConnection):
         super(Layer1, self).__init__(self.region.endpoint,
                                    aws_access_key_id, aws_secret_access_key,
                                    is_secure, port, proxy, proxy_port,
-                                   debug, session_token, profile_name=profile_name)
+                                   debug, security_token=security_token,
+                                   profile_name=profile_name)
 
     def _required_auth_capability(self):
         return ['hmac-v4']
@@ -660,9 +661,9 @@ class Layer1(AWSAuthConnection):
 
     def deprecate_activity_type(self, domain, activity_name, activity_version):
         """
-        Deprecates the specified activity type. After an activity 
-        type has been deprecated, you cannot create new tasks of 
-        that activity type. Tasks of this type that were scheduled 
+        Deprecates the specified activity type. After an activity
+        type has been deprecated, you cannot create new tasks of
+        that activity type. Tasks of this type that were scheduled
         before the type was deprecated will continue to run.
 
         :type domain: string

--- a/tests/unit/swf/test_layer1_base.py
+++ b/tests/unit/swf/test_layer1_base.py
@@ -1,0 +1,25 @@
+from boto.swf.layer1 import Layer1
+from tests.unit import unittest
+
+MOCK_ACCESS_KEY = 'inheritable access key'
+MOCK_SECRET_KEY = 'inheritable secret key'
+MOCK_SECURITY_TOKEN = 'inheritable security_token'
+
+
+class TestBase(unittest.TestCase):
+    """
+    Test for Layer1.
+    """
+
+    def setUp(self):
+        self.swf_base = Layer1(
+            aws_access_key_id=MOCK_ACCESS_KEY,
+            aws_secret_access_key=MOCK_SECRET_KEY,
+            security_token=MOCK_SECURITY_TOKEN,
+        )
+
+    def test_instantiation(self):
+        self.assertEquals(self.swf_base.aws_access_key_id, MOCK_ACCESS_KEY)
+        self.assertEquals(self.swf_base.aws_secret_access_key, MOCK_SECRET_KEY)
+        self.assertEquals(self.swf_base.provider.security_token,
+                          MOCK_SECURITY_TOKEN)


### PR DESCRIPTION
- Fixes issue where the SWF client has an argument type error that
  prevents the swf.Layer1 object from being used with token-based
  authentication (i.e,. anything passing AWS_SECURITY_TOKEN). This
  explicitly passes the security_token argument to AWSAuthConnection
  as a keyword, instead of a positional argument.
- swf.Layer1 constructor API change: session_token => security_token,
  as session_token is not an actual attribute of AWSAuthConnection.