### PR TITLE
Fix kms with custom host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ MANIFEST
 venv
 venv-2.5
 env-2.5
+*.iml
+*.ipr
+*.iws

--- a/boto/kms/layer1.py
+++ b/boto/kms/layer1.py
@@ -798,7 +798,7 @@ class KMSConnection(AWSQueryConnection):
     def make_request(self, action, body):
         headers = {
             'X-Amz-Target': '%s.%s' % (self.TargetPrefix, action),
-            'Host': self.region.endpoint,
+            'Host': self.host,
             'Content-Type': 'application/x-amz-json-1.1',
             'Content-Length': str(len(body)),
         }

--- a/tests/unit/kms/test_kms.py
+++ b/tests/unit/kms/test_kms.py
@@ -61,3 +61,20 @@ class TestKinesis(AWSMockServiceTestCase):
                                body=json.dumps(content).encode('utf-8'))
         response = self.service_connection.decrypt(b'some arbitrary value')
         self.assertEqual(response['Plaintext'], b'\x00\x01\x02\x03\x04\x05')
+
+    def test_uses_custom_host_for_header(self):
+        self.service_connection = self.create_service_connection(
+            https_connection_factory=self.https_connection_factory,
+            host='custom.host',
+            aws_access_key_id='aws_access_key_id',
+            aws_secret_access_key='aws_secret_access_key'
+        )
+        self.initialize_service_connection()
+
+
+
+        content = {'Plaintext': 'AAECAwQF'}
+        self.set_http_response(status_code=200,
+                               body=json.dumps(content).encode('utf-8'))
+        self.service_connection.decrypt(b'some arbitrary value')
+        self.assertEqual('custom.host', self.actual_request.headers['Host'])


### PR DESCRIPTION
This fixes a bug when using a `KmsConnection` with a custom host value -
for example, [FIPS endpoints](https://aws.amazon.com/compliance/fips/).

Previously, kms would set the host header to the region endpoint,
regardless of the actual host that would be used. That resulted in an
`InvalidSignatureException` when making any call.