### PR TITLE
IAMRegionInfo  - fix calling connect when a custom host is supplied

### DIFF
--- a/boto/iam/__init__.py
+++ b/boto/iam/__init__.py
@@ -40,8 +40,10 @@ class IAMRegionInfo(RegionInfo):
         :rtype: Connection object
         :return: The connection to this regions endpoint
         """
-        if self.connection_cls:
+        if self.connection_cls and 'host' not in kw_params:
             return self.connection_cls(host=self.endpoint, **kw_params)
+        elif self.connection_cls:
+            return self.connection_cls(**kw_params)
 
 
 def regions():

--- a/tests/unit/iam/test_region.py
+++ b/tests/unit/iam/test_region.py
@@ -1,0 +1,21 @@
+from __future__ import unicode_literals
+
+import unittest
+
+import mock
+
+from boto.iam import IAMRegionInfo
+
+
+class IAMRegionInfoTest(unittest.TestCase):
+    def setUp(self):
+        self.connection_cls = mock.Mock()
+        self.region_info = IAMRegionInfo(
+            name='test-region',
+            endpoint='default.region.endpoint',
+            connection_cls=self.connection_cls
+        )
+
+    def test_does_not_attempt_to_overwrite_host_kwarg(self):
+        self.region_info.connect(host='custom.host')
+        self.connection_cls.assert_called_once_with(host='custom.host')


### PR DESCRIPTION
IAMRegionInfo always set the `host` kwarg even if one was supplied. That
led to interpreter errors from two kwargs with the same name.