### PR TITLE
Fix Travis build on Python 2.6 by adding version constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - sudo apt-get install swig
 install:
   - pip install -U 'setuptools<40'
-  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then travis_retry pip install -r requirements-py26.txt; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then travis_retry pip install -r requirements-py26.txt -c constraints-py26.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then travis_retry pip install -r requirements-py33.txt; fi
   - travis_retry pip install -r requirements.txt
 script: python tests/test.py default

--- a/constraints-py26.txt
+++ b/constraints-py26.txt
@@ -1,0 +1,2 @@
+idna<2.8
+pycparser<2.19


### PR DESCRIPTION
As discovered in https://github.com/boto/boto/pull/3843#issuecomment-465367725, some transitive dependencies no longer support Python 2.6.  One way to address this issue is to add a pip constraints file to ensure transitive dependency versions are appropriately limited.  This PR adds the necessary constraints, as described below:

idna-2.8 fails to install due to `setup.py` requirement:

    idna requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*' but the running Python is 2.6.9

Require <2.8.

pycparser-2.19 fails to install on Python 2.6 due to `from subprocess import check_output` in `pycparser/__init__.py` which causes `ImportError: cannot import name check_output`.  Require <2.19.

Cheers,
Kevin

P.S.  I don't see `install_depends` in `setup.py`.  I'd appreciate it if a reviewer could confirm whether the constraints need to be applied during users installs somehow.