### PR TITLE
correct v4 query param auth with non-default port

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -631,8 +631,8 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         port = http_request.port
         secure = http_request.protocol == 'https'
         if ((port == 80 and not secure) or (port == 443 and secure)):
-            return http_request.host
-        return '%s:%s' % (http_request.host, port)
+            return host
+        return '%s:%s' % (host, port)
 
     def headers_to_sign(self, http_request):
         """


### PR DESCRIPTION
when boto calculate v4 query param auth, it will use
`<hostname>:<port>:<port>` instead of `<hostname>:<port>`
for host header, which will cause signature mismatch

Signed-off-by: Stuart Hu <hushijie@qiniu.com>