### PR TITLE
Python 2 / 3 compatibility changes [MOVED: See PR #3856]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,28 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "pypy"
+matrix:
+  include:
+    # Trusty Tests
+    - os: linux
+      dist: trusty
+      python: "pypy"
+    # Xenial Tests
+    - os: linux
+      dist: xenial
+      python: "2.7"
+    - os: linux
+      dist: xenial
+      python: "3.5"
+    - os: linux
+      dist: xenial
+      python: "3.6"
+    - os: linux
+      dist: xenial
+      python: "3.7"
+    - os: linux
+      dist: xenial
+      python: "pypy3.5"
+  allow_failures:
+    - python: "3.7"
 env:
   - BOTO_CONFIG=/tmp/nowhere
 before_install:
@@ -19,6 +36,5 @@ before_install:
 install:
   - pip install -U 'setuptools<40'
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then travis_retry pip install -r requirements-py26.txt; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then travis_retry pip install -r requirements-py33.txt; fi
   - travis_retry pip install -r requirements.txt
 script: python tests/test.py default

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,13 @@
 language: python
-
-# Some versions of python only work on certain platforms. Specifying the distribution
-# to ensure the version of python will run without issue.
-matrix:
-  include:
-    # Trusty Tests
-    - os: linux
-      dist: trusty
-      python: "pypy"
-    - os: linux
-      dist: trusty
-      python: "2.6"
-    - os: linux
-      dist: trusty
-      python: "3.3"
-    - os: linux
-      dist: trusty
-      python: "3.4"
-    # Xenial Tests
-    - os: linux
-      dist: xenial
-      python: "2.7"
-    - os: linux
-      dist: xenial
-      python: "3.5"
-    - os: linux
-      dist: xenial
-      python: "3.6"
-    - os: linux
-      dist: xenial
-      python: "3.7"
-    - os: linux
-      dist: xenial
-      python: "pypy3.5"
-  allow_failures:
-    - python: "3.7"
-
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "pypy"
 env:
   - BOTO_CONFIG=/tmp/nowhere
-
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
       echo "No pull requests can be sent to the master branch" 1>&2;
@@ -47,11 +16,9 @@ before_install:
   - sudo apt-get update
   - sudo apt-get --reinstall install -qq language-pack-en language-pack-de
   - sudo apt-get install swig
-
 install:
   - pip install -U 'setuptools<40'
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then travis_retry pip install -r requirements-py26.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then travis_retry pip install -r requirements-py33.txt; fi
   - travis_retry pip install -r requirements.txt
-
 script: python tests/test.py default

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,15 @@ matrix:
     - os: linux
       dist: trusty
       python: "pypy"
+    - os: linux
+      dist: trusty
+      python: "2.6"
+    - os: linux
+      dist: trusty
+      python: "3.3"
+    - os: linux
+      dist: trusty
+      python: "3.4"
     # Xenial Tests
     - os: linux
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+
+# Some versions of python only work on certain platforms. Specifying the distribution
+# to ensure the version of python will run without issue.
 matrix:
   include:
     # Trusty Tests
@@ -32,8 +35,10 @@ matrix:
       python: "pypy3.5"
   allow_failures:
     - python: "3.7"
+
 env:
   - BOTO_CONFIG=/tmp/nowhere
+
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
       echo "No pull requests can be sent to the master branch" 1>&2;
@@ -42,8 +47,11 @@ before_install:
   - sudo apt-get update
   - sudo apt-get --reinstall install -qq language-pack-en language-pack-de
   - sudo apt-get install swig
+
 install:
   - pip install -U 'setuptools<40'
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then travis_retry pip install -r requirements-py26.txt; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then travis_retry pip install -r requirements-py33.txt; fi
   - travis_retry pip install -r requirements.txt
+
 script: python tests/test.py default

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -384,8 +384,9 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         pairs = []
         for pname in parameter_names:
             pval = boto.utils.get_utf8_value(http_request.params[pname])
-            pairs.append(urllib.parse.quote(pname, safe='') + '=' +
-                         urllib.parse.quote(pval, safe='-_~'))
+            pairs.append(urllib.parse.quote(pname, safe=''.encode('ascii')) +
+                         '='.encode('ascii') +
+                         urllib.parse.quote(pval, safe='-_~'.encode('ascii')))
         return '&'.join(pairs)
 
     def canonical_query_string(self, http_request):

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -920,7 +920,7 @@ class AWSAuthConnection(object):
         while i <= num_retries:
             # Use binary exponential backoff to desynchronize client requests.
             next_sleep = min(random.random() * (2 ** i),
-                             boto.config.get('Boto', 'max_retry_delay', 60))
+                             float(boto.config.get('Boto', 'max_retry_delay', 60)))
             try:
                 # we now re-sign each request before it is retried
                 boto.log.debug('Token: %s' % self.provider.security_token)

--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -24,8 +24,10 @@ from __future__ import division
 from __future__ import print_function
 
 import re
-import urllib
 import xml.sax
+
+from six import PY3
+from six.moves.urllib.parse import quote
 
 import boto
 from boto import handler
@@ -52,7 +54,7 @@ ENCRYPTION_CONFIG_ARG = 'encryptionConfig'
 LIFECYCLE_ARG = 'lifecycle'
 STORAGE_CLASS_ARG='storageClass'
 ERROR_DETAILS_REGEX_STR = r'<Details>(?P<details>.*)</Details>'
-if six.PY3:
+if PY3:
     ERROR_DETAILS_REGEX_STR = ERROR_DETAILS_REGEX_STR.encode('ascii')
 ERROR_DETAILS_REGEX = re.compile(ERROR_DETAILS_REGEX_STR)
 
@@ -125,7 +127,7 @@ class Bucket(S3Bucket):
             query_args_l.append('generation=%s' % generation)
         if response_headers:
             for rk, rv in six.iteritems(response_headers):
-                query_args_l.append('%s=%s' % (rk, urllib.quote(rv)))
+                query_args_l.append('%s=%s' % (rk, quote(rv)))
         try:
             key, resp = self._get_key_internal(key_name, headers,
                                                query_args_l=query_args_l)
@@ -361,7 +363,7 @@ class Bucket(S3Bucket):
                     details = (('<Details>%s. Note that Full Control access'
                                 ' is required to access ACLs.</Details>') %
                                details)
-                    if six.PY3:
+                    if PY3:
                         details = details.encode('utf-8')
                     body = re.sub(ERROR_DETAILS_REGEX, details, body)
             raise self.connection.provider.storage_response_error(

--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -41,9 +41,8 @@ from boto.gs.key import Key as GSKey
 from boto.s3.acl import Policy
 from boto.s3.bucket import Bucket as S3Bucket
 from boto.utils import get_utf8_value
+from boto.compat import quote
 from boto.compat import six
-
-quote = six.moves.urllib.parse.quote
 
 # constants for http query args
 DEF_OBJ_ACL = 'defaultObjectAcl'
@@ -363,6 +362,7 @@ class Bucket(S3Bucket):
                                 ' is required to access ACLs.</Details>') %
                                details)
                     if six.PY3:
+                        # All args to re.sub() must be of same type
                         details = details.encode('utf-8')
                     body = re.sub(ERROR_DETAILS_REGEX, details, body)
             raise self.connection.provider.storage_response_error(

--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -26,9 +26,6 @@ from __future__ import print_function
 import re
 import xml.sax
 
-from six import PY3
-from six.moves.urllib.parse import quote
-
 import boto
 from boto import handler
 from boto.resultset import ResultSet
@@ -46,6 +43,8 @@ from boto.s3.bucket import Bucket as S3Bucket
 from boto.utils import get_utf8_value
 from boto.compat import six
 
+quote = six.moves.urllib.parse.quote
+
 # constants for http query args
 DEF_OBJ_ACL = 'defaultObjectAcl'
 STANDARD_ACL = 'acl'
@@ -54,7 +53,7 @@ ENCRYPTION_CONFIG_ARG = 'encryptionConfig'
 LIFECYCLE_ARG = 'lifecycle'
 STORAGE_CLASS_ARG='storageClass'
 ERROR_DETAILS_REGEX_STR = r'<Details>(?P<details>.*)</Details>'
-if PY3:
+if six.PY3:
     ERROR_DETAILS_REGEX_STR = ERROR_DETAILS_REGEX_STR.encode('ascii')
 ERROR_DETAILS_REGEX = re.compile(ERROR_DETAILS_REGEX_STR)
 
@@ -363,7 +362,7 @@ class Bucket(S3Bucket):
                     details = (('<Details>%s. Note that Full Control access'
                                 ' is required to access ACLs.</Details>') %
                                details)
-                    if PY3:
+                    if six.PY3:
                         details = details.encode('utf-8')
                     body = re.sub(ERROR_DETAILS_REGEX, details, body)
             raise self.connection.provider.storage_response_error(

--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -19,6 +19,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import re
 import urllib
 import xml.sax
@@ -48,10 +52,8 @@ ENCRYPTION_CONFIG_ARG = 'encryptionConfig'
 LIFECYCLE_ARG = 'lifecycle'
 STORAGE_CLASS_ARG='storageClass'
 ERROR_DETAILS_REGEX_STR = r'<Details>(?P<details>.*)</Details>'
-
 if six.PY3:
     ERROR_DETAILS_REGEX_STR = ERROR_DETAILS_REGEX_STR.encode('ascii')
-
 ERROR_DETAILS_REGEX = re.compile(ERROR_DETAILS_REGEX_STR)
 
 
@@ -461,8 +463,8 @@ class Bucket(S3Bucket):
             headers['x-goog-if-metageneration-match'] = str(if_metageneration)
 
         response = self.connection.make_request(
-            'PUT', get_utf8_value(self.name), get_utf8_value(key_name),
-            data=get_utf8_value(data), headers=headers, query_args=query_args)
+            'PUT', self.name, key_name,
+            data=data, headers=headers, query_args=query_args)
         body = response.read()
         if response.status != 200:
             raise self.connection.provider.storage_response_error(
@@ -607,7 +609,7 @@ class Bucket(S3Bucket):
         :param dict headers: Additional headers to send with the request.
         """
         response = self.connection.make_request(
-            'PUT', get_utf8_value(self.name), data=get_utf8_value(cors),
+            'PUT', self.name, data=cors,
             query_args=CORS_ARG, headers=headers)
         body = response.read()
         if response.status != 200:
@@ -1012,7 +1014,7 @@ class Bucket(S3Bucket):
         """
         xml = lifecycle_config.to_xml()
         response = self.connection.make_request(
-            'PUT', get_utf8_value(self.name), data=get_utf8_value(xml),
+            'PUT', self.name, data=xml,
             query_args=LIFECYCLE_ARG, headers=headers)
         body = response.read()
         if response.status == 200:
@@ -1134,7 +1136,7 @@ class Bucket(S3Bucket):
         body = self._construct_encryption_config_xml(
             default_kms_key_name=default_kms_key_name)
         response = self.connection.make_request(
-            'PUT', get_utf8_value(self.name), data=get_utf8_value(body),
+            'PUT', self.name, data=body,
             query_args=ENCRYPTION_CONFIG_ARG, headers=headers)
         body = response.read()
         if response.status != 200:

--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -47,7 +47,13 @@ CORS_ARG = 'cors'
 ENCRYPTION_CONFIG_ARG = 'encryptionConfig'
 LIFECYCLE_ARG = 'lifecycle'
 STORAGE_CLASS_ARG='storageClass'
-ERROR_DETAILS_REGEX = re.compile(r'<Details>(?P<details>.*)</Details>')
+ERROR_DETAILS_REGEX_STR = r'<Details>(?P<details>.*)</Details>'
+
+if six.PY3:
+    ERROR_DETAILS_REGEX_STR = ERROR_DETAILS_REGEX_STR.encode('ascii')
+
+ERROR_DETAILS_REGEX = re.compile(ERROR_DETAILS_REGEX_STR)
+
 
 class Bucket(S3Bucket):
     """Represents a Google Cloud Storage bucket."""
@@ -353,6 +359,8 @@ class Bucket(S3Bucket):
                     details = (('<Details>%s. Note that Full Control access'
                                 ' is required to access ACLs.</Details>') %
                                details)
+                    if six.PY3:
+                        details = details.encode('utf-8')
                     body = re.sub(ERROR_DETAILS_REGEX, details, body)
             raise self.connection.provider.storage_response_error(
                 response.status, response.reason, body)

--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -52,10 +52,10 @@ CORS_ARG = 'cors'
 ENCRYPTION_CONFIG_ARG = 'encryptionConfig'
 LIFECYCLE_ARG = 'lifecycle'
 STORAGE_CLASS_ARG='storageClass'
-ERROR_DETAILS_REGEX_STR = r'<Details>(?P<details>.*)</Details>'
+_ERROR_DETAILS_REGEX_STR = r'<Details>(?P<details>.*)</Details>'
 if six.PY3:
-    ERROR_DETAILS_REGEX_STR = ERROR_DETAILS_REGEX_STR.encode('ascii')
-ERROR_DETAILS_REGEX = re.compile(ERROR_DETAILS_REGEX_STR)
+    _ERROR_DETAILS_REGEX_STR = _ERROR_DETAILS_REGEX_STR.encode('ascii')
+ERROR_DETAILS_REGEX = re.compile(_ERROR_DETAILS_REGEX_STR)
 
 
 class Bucket(S3Bucket):

--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -24,6 +24,7 @@ import binascii
 import os
 import re
 
+from boto.compat import six
 from boto.compat import StringIO
 from boto.exception import BotoClientError
 from boto.s3.key import Key as S3Key
@@ -707,7 +708,13 @@ class Key(S3Key):
         self.md5 = None
         self.base64md5 = None
 
-        fp = StringIO(get_utf8_value(s))
+        if six.PY3:
+            if isinstance(s, str):
+                s = s.encode('utf-8')
+            fp = io.BytesIO(s)
+        else:
+            fp = StringIO(get_utf8_value(s))
+
         r = self.set_contents_from_file(fp, headers, replace, cb, num_cb,
                                         policy, md5,
                                         if_generation=if_generation)

--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -19,9 +19,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import base64
 import binascii
 import os
+import io
 import re
 
 from boto.compat import six
@@ -713,8 +718,7 @@ class Key(S3Key):
                 s = s.encode('utf-8')
             fp = io.BytesIO(s)
         else:
-            fp = StringIO(get_utf8_value(s))
-
+            fp = io.BytesIO(get_utf8_value(s))
         r = self.set_contents_from_file(fp, headers, replace, cb, num_cb,
                                         policy, md5,
                                         if_generation=if_generation)
@@ -943,9 +947,9 @@ class Key(S3Key):
         if content_type:
             headers['Content-Type'] = content_type
         resp = self.bucket.connection.make_request(
-            'PUT', get_utf8_value(self.bucket.name), get_utf8_value(self.name),
+            'PUT', self.bucket.name, self.name,
             headers=headers, query_args='compose',
-            data=get_utf8_value(compose_req_xml))
+            data=compose_req_xml)
         if resp.status < 200 or resp.status > 299:
             raise self.bucket.connection.provider.storage_response_error(
                 resp.status, resp.reason, resp.read())

--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -717,7 +717,7 @@ class Key(S3Key):
             if isinstance(s, str):
                 s = s.encode('utf-8')
             fp = six.BytesIO(s)
-        else:absolute_import
+        else:
             fp = six.BytesIO(get_utf8_value(s))
         r = self.set_contents_from_file(fp, headers, replace, cb, num_cb,
                                         policy, md5,

--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -716,9 +716,9 @@ class Key(S3Key):
         if six.PY3:
             if isinstance(s, str):
                 s = s.encode('utf-8')
-            fp = io.BytesIO(s)
-        else:
-            fp = io.BytesIO(get_utf8_value(s))
+            fp = six.BytesIO(s)
+        else:absolute_import
+            fp = six.BytesIO(get_utf8_value(s))
         r = self.set_contents_from_file(fp, headers, replace, cb, num_cb,
                                         policy, md5,
                                         if_generation=if_generation)

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -22,6 +22,7 @@
 # IN THE SOFTWARE.
 
 from __future__ import division
+
 import boto
 from boto import handler
 from boto.resultset import ResultSet
@@ -847,13 +848,11 @@ class Bucket(object):
         """
         headers = headers or {}
         provider = self.connection.provider
-        
         if six.PY3:
             if isinstance(src_key_name, bytes):
                 src_key_name = src_key_name.decode('utf-8')
         else:
             src_key_name = boto.utils.get_utf8_value(src_key_name)
-
         if preserve_acl:
             if self.name == src_bucket_name:
                 src_bucket = self
@@ -882,8 +881,6 @@ class Bucket(object):
         if response.status == 200:
             key = self.new_key(new_key_name)
             h = handler.XmlHandler(key, self)
-            if not isinstance(body, bytes):
-                body = body.encode('utf-8')
             xml.sax.parseString(body, h)
             if hasattr(key, 'Error'):
                 raise provider.storage_copy_error(key.Code, key.Message, body)

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -21,6 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+from __future__ import division
 import boto
 from boto import handler
 from boto.resultset import ResultSet
@@ -201,7 +202,7 @@ class Bucket(object):
         response.read()
         # Allow any success status (2xx) - for example this lets us
         # support Range gets, which return status 206:
-        if response.status / 100 == 2:
+        if response.status // 100 == 2:
             k = self.key_class(self)
             provider = self.connection.provider
             k.metadata = boto.utils.get_aws_metadata(response.msg, provider)
@@ -846,7 +847,13 @@ class Bucket(object):
         """
         headers = headers or {}
         provider = self.connection.provider
-        src_key_name = boto.utils.get_utf8_value(src_key_name)
+        
+        if six.PY3:
+            if isinstance(src_key_name, bytes):
+                src_key_name = src_key_name.decode('utf-8')
+        else:
+            src_key_name = boto.utils.get_utf8_value(src_key_name)
+
         if preserve_acl:
             if self.name == src_bucket_name:
                 src_bucket = self

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -89,6 +89,8 @@ class _CallingFormat(object):
 
     def build_auth_path(self, bucket, key=''):
         key = boto.utils.get_utf8_value(key)
+        if isinstance(bucket, bytes):
+            bucket = bucket.decode('utf-8')
         path = ''
         if bucket != '':
             path = '/' + bucket

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -24,9 +24,9 @@
 
 import xml.sax
 import base64
-from boto.compat import six, urllib
 import time
 
+from boto.compat import six, urllib
 from boto.auth import detect_potential_s3sigv4
 import boto.utils
 from boto.connection import AWSAuthConnection

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -20,6 +20,9 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+
+from __future__ import print_function
+
 import email.utils
 import errno
 import hashlib
@@ -1549,7 +1552,7 @@ class Key(object):
             cb(data_len, cb_size)
         try:
             for bytes in self:
-                fp.write(bytes)
+                print_function(bytes, file=fp)
                 data_len += len(bytes)
                 for alg in digesters:
                     digesters[alg].update(bytes)

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -20,7 +20,6 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-
 from __future__ import print_function
 
 import email.utils
@@ -43,6 +42,7 @@ from boto.provider import Provider
 from boto.s3.keyfile import KeyFile
 from boto.s3.user import User
 from boto import UserAgent
+import boto.utils
 from boto.utils import compute_md5, compute_hash
 from boto.utils import find_matching_headers
 from boto.utils import merge_headers_by_name
@@ -852,9 +852,10 @@ class Key(object):
                 chunk_len = len(chunk)
                 data_len += chunk_len
                 if chunked_transfer:
-                    http_conn.send('%x;\r\n' % chunk_len)
+                    chunk_len_bytes = ('%x' % chunk_len).encode('utf-8')
+                    http_conn.send(chunk_len_bytes + b';\r\n')
                     http_conn.send(chunk)
-                    http_conn.send('\r\n')
+                    http_conn.send(b'\r\n')
                 else:
                     http_conn.send(chunk)
                 for alg in digesters:
@@ -882,9 +883,9 @@ class Key(object):
                 self.local_hashes[alg] = digesters[alg].digest()
 
             if chunked_transfer:
-                http_conn.send('0\r\n')
+                http_conn.send(b'0\r\n')
                     # http_conn.send("Content-MD5: %s\r\n" % self.base64md5)
-                http_conn.send('\r\n')
+                http_conn.send(b'\r\n')
 
             if cb and (cb_count <= 1 or i > 0) and data_len > 0:
                 cb(data_len, cb_size)
@@ -1552,7 +1553,7 @@ class Key(object):
             cb(data_len, cb_size)
         try:
             for bytes in self:
-                print_function(bytes, file=fp)
+                boto.utils.ttyprint(bytes, file=fp, end='')
                 data_len += len(bytes)
                 for alg in digesters:
                     digesters[alg].update(bytes)

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -866,10 +866,10 @@ def notify(subject, body=None, html_body=None, to_string=None,
 def get_utf8_value(value):
     if six.PY3:
         if isinstance(value, bytes):
-            return value.decode('utf-8')
+            value = value.decode('utf-8')
         return value
     if not isinstance(value, six.string_types):
-        value = six.text_type(value).encode('utf-8')
+        value = six.text_type(value)
 
     if isinstance(value, six.text_type):
         value = value.encode('utf-8')

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -863,6 +863,14 @@ def notify(subject, body=None, html_body=None, to_string=None,
             boto.log.exception('notify failed')
 
 
+def get_binary_str(value):
+    if isinstance(value, six.binary_type):
+        return value
+    if isinstance(value, six.text_type):
+        return six.ensure_binary(value)
+    return six.ensure_binary(str(value))
+
+
 def get_utf8_value(value):
     if six.PY3:
         if isinstance(value, bytes):

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -35,7 +35,6 @@
 #  this software code. (c) 2006 Amazon Digital Services, Inc. or its
 #  affiliates.
 
-from boto.compat import json
 """
 Some handy utility functions used by several classes.
 """
@@ -43,7 +42,6 @@ Some handy utility functions used by several classes.
 import os
 import sys
 import io
-import collections
 import subprocess
 import time
 import logging.handlers
@@ -62,6 +60,7 @@ import email.encoders
 import gzip
 import threading
 import locale
+import collections
 from boto.compat import six, StringIO, urllib, encodebytes
 
 from contextlib import contextmanager
@@ -69,6 +68,7 @@ from contextlib import contextmanager
 from hashlib import md5, sha512
 _hashfn = sha512
 
+from boto.compat import json
 
 try:
     from boto.compat.json import JSONDecodeError
@@ -252,8 +252,7 @@ class LazyLoadMetadata(dict):
         self._leaves = {}
         self._dicts = []
         self._timeout = timeout
-        data = boto.utils.retry_url(
-            self._url, num_retries=self._num_retries, timeout=self._timeout)
+        data = boto.utils.retry_url(self._url, num_retries=self._num_retries, timeout=self._timeout)
         if data:
             fields = data.split('\n')
             for field in fields:
@@ -422,8 +421,7 @@ def get_instance_identity(version='latest', url='http://169.254.169.254',
         data = retry_url(base_url, num_retries=num_retries, timeout=timeout)
         fields = data.split('\n')
         for field in fields:
-            val = retry_url(base_url + '/' + field + '/',
-                            num_retries=num_retries, timeout=timeout)
+            val = retry_url(base_url + '/' + field + '/', num_retries=num_retries, timeout=timeout)
             if val[0] == '{':
                 val = json.loads(val)
             if field:
@@ -436,8 +434,7 @@ def get_instance_identity(version='latest', url='http://169.254.169.254',
 def get_instance_userdata(version='latest', sep=None,
                           url='http://169.254.169.254', timeout=None, num_retries=5):
     ud_url = _build_instance_metadata_url(url, version, 'user-data')
-    user_data = retry_url(ud_url, retry_on_404=False,
-                          num_retries=num_retries, timeout=timeout)
+    user_data = retry_url(ud_url, retry_on_404=False, num_retries=num_retries, timeout=timeout)
     if user_data:
         if sep:
             l = user_data.split(sep)
@@ -446,7 +443,6 @@ def get_instance_userdata(version='latest', sep=None,
                 t = nvpair.split('=')
                 user_data[t[0].strip()] = t[1].strip()
     return user_data
-
 
 ISO8601 = '%Y-%m-%dT%H:%M:%SZ'
 ISO8601_MS = '%Y-%m-%dT%H:%M:%S.%fZ'
@@ -512,8 +508,7 @@ def update_dme(username, password, dme_id, ip_address):
     """
     dme_url = 'https://www.dnsmadeeasy.com/servlet/updateip'
     dme_url += '?username=%s&password=%s&id=%s&ip=%s'
-    s = urllib.request.urlopen(dme_url % (
-        username, password, dme_id, ip_address))
+    s = urllib.request.urlopen(dme_url % (username, password, dme_id, ip_address))
     return s.read()
 
 
@@ -869,13 +864,15 @@ def notify(subject, body=None, html_body=None, to_string=None,
 
 
 def get_utf8_value(value):
+    # if not six.PY2 and isinstance(value, bytes):
+    #     return value
+
     if six.PY3:
         if isinstance(value, bytes):
             return value.decode('utf-8')
         return value
-
     if not isinstance(value, six.string_types):
-        value = six.text_type(value)
+        value = six.text_type(value).encode('utf-8')
 
     if isinstance(value, six.text_type):
         value = value.encode('utf-8')
@@ -1067,7 +1064,6 @@ class RequestHook(object):
     to gain access to request and response object after the request completes.
     One use for this would be to implement some specific request logging.
     """
-
     def handle_request_data(self, request, response, error=False):
         pass
 
@@ -1110,79 +1106,79 @@ def parse_host(hostname):
         return hostname.split(':', 1)[0]
 
 
-# def ttyprint(*objects, **kwargs):
-#     """ A Python 2&3 compatible version of the print function.
+def ttyprint(*objects, **kwargs):
+  """ A Python 2&3 compatible version of the print function.
 
-#     The main purpose of this function is to favor binary output
-#     over text output.
+  The main purpose of this function is to favor binary output
+  over text output.
 
-#     Args are the same as documented for the print function in Python2.
-#     """
-#     kw_params = collections.OrderedDict([('sep', ' '),
-#                                          ('end', os.linesep),
-#                                          ('file', sys.stdout)])
-#     for key, value in kwargs.items():
-#         if key not in kw_params:
-#             raise TypeError(
-#                 "'{}' is an invalid keyword argument for this function".format(key))
-#         kw_params[key] = value
-#     sep, end, file = kw_params.values()
-#     if six.PY2:
-#         if hasattr(file, 'mode') and 'b' not in file.mode and end == os.linesep:
-#             end = b'\n'
-#         pref_enc = 'utf-8'
-#         if isinstance(sep, unicode):
-#             sep = sep.encode(pref_enc)
-#         if isinstance(end, unicode):
-#             end = end.encode(pref_enc)
-#         byte_objects = []
-#         for object in objects:
-#             if isinstance(object, str):
-#                 byte_objects.append(object)
-#             elif isinstance(object, unicode):
-#                 byte_objects.append(object.encode(pref_enc))
-#             else:
-#                 byte_objects.append(str(object).encode(pref_enc))
-#         data = sep.join(byte_objects)
-#         data += end
-#         ttywrite(file, data)
-#     else:  # PY3
-#         pref_enc = locale.getpreferredencoding(False)
-#         if isinstance(sep, str):
-#             sep = sep.encode(pref_enc)
-#         if isinstance(end, str):
-#             end = end.encode(pref_enc)
-#         byte_objects = []
-#         for object in objects:
-#             if isinstance(object, bytes):
-#                 byte_objects.append(object)
-#             elif isinstance(object, str):
-#                 byte_objects.append(object.encode(pref_enc))
-#             else:
-#                 byte_objects.append(str(object).encode(pref_enc))
-#         data = sep.join(byte_objects)
-#         data += end
-#         ttywrite(file, data)
+  Args are the same as documented for the print function in Python2.
+  """
+  kw_params = collections.OrderedDict([('sep', ' '),
+                                       ('end', os.linesep),
+                                       ('file', sys.stdout)])
+  for key, value in kwargs.items():
+    if key not in kw_params:
+      raise TypeError(
+        "'{}' is an invalid keyword argument for this function".format(key))
+    kw_params[key] = value
+  sep, end, file = kw_params.values()
+  if six.PY2:
+    if hasattr(file, 'mode') and 'b' not in file.mode and end == os.linesep:
+      end = b'\n'
+    pref_enc = 'utf-8'
+    if isinstance(sep, unicode):
+      sep = sep.encode(pref_enc)
+    if isinstance(end, unicode):
+      end = end.encode(pref_enc)
+    byte_objects = []
+    for object in objects:
+      if isinstance(object, str):
+        byte_objects.append(object)
+      elif isinstance(object, unicode):
+        byte_objects.append(object.encode(pref_enc))
+      else:
+        byte_objects.append(str(object).encode(pref_enc))
+    data = sep.join(byte_objects)
+    data += end
+    ttywrite(file, data)
+  else:  # PY3
+    pref_enc = locale.getpreferredencoding(False)
+    if isinstance(sep, str):
+      sep = sep.encode(pref_enc)
+    if isinstance(end, str):
+      end = end.encode(pref_enc)
+    byte_objects = []
+    for object in objects:
+      if isinstance(object, bytes):
+        byte_objects.append(object)
+      elif isinstance(object, str):
+        byte_objects.append(object.encode(pref_enc))
+      else:
+        byte_objects.append(str(object).encode(pref_enc))
+    data = sep.join(byte_objects)
+    data += end
+    ttywrite(file, data)
 
 
-# def ttywrite(fp, data):
-#     if six.PY2:
-#         fp.write(data)
-#     else:  # PY3
-#         if isinstance(data, bytes):
-#             if (hasattr(fp, 'mode') and 'b' in fp.mode) or isinstance(fp, io.BytesIO):
-#                 # data is bytes, and fp is binary
-#                 fp.write(data)
-#             elif hasattr(fp, 'buffer'):
-#                 # data is bytes, but fp is text - try the underlying buffer
-#                 fp.buffer.write(data)
-#             else:
-#                 # data is bytes, but fp is text - try to decode bytes
-#                 fp.write(
-#                     data.decode(locale.getpreferredencoding(False)))
-#         elif 'b' in fp.mode:
-#             # data is not bytes, but fp is binary
-#             fp.write(data.encode(locale.getpreferredencoding(False)))
-#         else:
-#             # data is not bytes, and fp is text
-#             fp.write(data)
+def ttywrite(fp, data):
+  if six.PY2:
+    fp.write(data)
+  else:  # PY3
+    if isinstance(data, bytes):
+      if (hasattr(fp, 'mode') and 'b' in fp.mode) or isinstance(fp, io.BytesIO):
+        # data is bytes, and fp is binary
+        fp.write(data)
+      elif hasattr(fp, 'buffer'):
+        # data is bytes, but fp is text - try the underlying buffer
+        fp.buffer.write(data)
+      else:
+        # data is bytes, but fp is text - try to decode bytes
+        fp.write(
+          data.decode(locale.getpreferredencoding(False)))
+    elif 'b' in fp.mode:
+      # data is not bytes, but fp is binary
+      fp.write(data.encode(locale.getpreferredencoding(False)))
+    else:
+      # data is not bytes, and fp is text
+      fp.write(data)

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -864,9 +864,6 @@ def notify(subject, body=None, html_body=None, to_string=None,
 
 
 def get_utf8_value(value):
-    # if not six.PY2 and isinstance(value, bytes):
-    #     return value
-
     if six.PY3:
         if isinstance(value, bytes):
             return value.decode('utf-8')

--- a/boto/vendored/six.py
+++ b/boto/vendored/six.py
@@ -1,6 +1,6 @@
 """Utilities for writing code that runs on Python 2 and 3"""
 
-# Copyright (c) 2010-2015 Benjamin Peterson
+# Copyright (c) 2010-2018 Benjamin Peterson
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ import sys
 import types
 
 __author__ = "Benjamin Peterson <benjamin@python.org>"
-__version__ = "1.9.0"
+__version__ = "1.12.0"
 
 
 # Useful for very coarse version differentiation.
@@ -165,7 +165,6 @@ class _SixMetaPathImporter(object):
 
     """
     A meta path importer to import six.moves and its submodules.
-
     This class implements a PEP302 finder and loader. It should be compatible
     with Python 2.5 and all existing versions of Python3
     """
@@ -209,7 +208,6 @@ class _SixMetaPathImporter(object):
     def is_package(self, fullname):
         """
         Return true, if the named module is a package.
-
         We need this method to get correct spec objects with
         Python 3.4 (see PEP451)
         """
@@ -217,7 +215,6 @@ class _SixMetaPathImporter(object):
 
     def get_code(self, fullname):
         """Return None
-
         Required, if is_package is implemented"""
         self.__get_module(fullname)  # eventually raises ImportError
         return None
@@ -241,6 +238,7 @@ _moved_attributes = [
     MovedAttribute("map", "itertools", "builtins", "imap", "map"),
     MovedAttribute("getcwd", "os", "os", "getcwdu", "getcwd"),
     MovedAttribute("getcwdb", "os", "os", "getcwd", "getcwdb"),
+    MovedAttribute("getoutput", "commands", "subprocess"),
     MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
     MovedAttribute("reload_module", "__builtin__", "importlib" if PY34 else "imp", "reload"),
     MovedAttribute("reduce", "__builtin__", "functools"),
@@ -262,10 +260,11 @@ _moved_attributes = [
     MovedModule("html_entities", "htmlentitydefs", "html.entities"),
     MovedModule("html_parser", "HTMLParser", "html.parser"),
     MovedModule("http_client", "httplib", "http.client"),
+    MovedModule("email_mime_base", "email.MIMEBase", "email.mime.base"),
+    MovedModule("email_mime_image", "email.MIMEImage", "email.mime.image"),
     MovedModule("email_mime_multipart", "email.MIMEMultipart", "email.mime.multipart"),
     MovedModule("email_mime_nonmultipart", "email.MIMENonMultipart", "email.mime.nonmultipart"),
     MovedModule("email_mime_text", "email.MIMEText", "email.mime.text"),
-    MovedModule("email_mime_base", "email.MIMEBase", "email.mime.base"),
     MovedModule("BaseHTTPServer", "BaseHTTPServer", "http.server"),
     MovedModule("CGIHTTPServer", "CGIHTTPServer", "http.server"),
     MovedModule("SimpleHTTPServer", "SimpleHTTPServer", "http.server"),
@@ -337,10 +336,12 @@ _urllib_parse_moved_attributes = [
     MovedAttribute("quote_plus", "urllib", "urllib.parse"),
     MovedAttribute("unquote", "urllib", "urllib.parse"),
     MovedAttribute("unquote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_to_bytes", "urllib", "urllib.parse", "unquote", "unquote_to_bytes"),
     MovedAttribute("urlencode", "urllib", "urllib.parse"),
     MovedAttribute("splitquery", "urllib", "urllib.parse"),
     MovedAttribute("splittag", "urllib", "urllib.parse"),
     MovedAttribute("splituser", "urllib", "urllib.parse"),
+    MovedAttribute("splitvalue", "urllib", "urllib.parse"),
     MovedAttribute("uses_fragment", "urlparse", "urllib.parse"),
     MovedAttribute("uses_netloc", "urlparse", "urllib.parse"),
     MovedAttribute("uses_params", "urlparse", "urllib.parse"),
@@ -416,6 +417,8 @@ _urllib_request_moved_attributes = [
     MovedAttribute("URLopener", "urllib", "urllib.request"),
     MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
     MovedAttribute("proxy_bypass", "urllib", "urllib.request"),
+    MovedAttribute("parse_http_list", "urllib2", "urllib.request"),
+    MovedAttribute("parse_keqv_list", "urllib2", "urllib.request"),
 ]
 for attr in _urllib_request_moved_attributes:
     setattr(Module_six_moves_urllib_request, attr.name, attr)
@@ -679,11 +682,15 @@ if PY3:
     exec_ = getattr(moves.builtins, "exec")
 
     def reraise(tp, value, tb=None):
-        if value is None:
-            value = tp()
-        if value.__traceback__ is not tb:
-            raise value.with_traceback(tb)
-        raise value
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
 
 else:
     def exec_(_code_, _globs_=None, _locs_=None):
@@ -699,19 +706,28 @@ else:
         exec("""exec _code_ in _globs_, _locs_""")
 
     exec_("""def reraise(tp, value, tb=None):
-    raise tp, value, tb
+    try:
+        raise tp, value, tb
+    finally:
+        tb = None
 """)
 
 
 if sys.version_info[:2] == (3, 2):
     exec_("""def raise_from(value, from_value):
-    if from_value is None:
-        raise value
-    raise value from from_value
+    try:
+        if from_value is None:
+            raise value
+        raise value from from_value
+    finally:
+        value = None
 """)
 elif sys.version_info[:2] > (3, 2):
     exec_("""def raise_from(value, from_value):
-    raise value from from_value
+    try:
+        raise value from from_value
+    finally:
+        value = None
 """)
 else:
     def raise_from(value, from_value):
@@ -802,10 +818,14 @@ def with_metaclass(meta, *bases):
     # This requires a bit of explanation: the basic idea is to make a dummy
     # metaclass for one level of class instantiation that replaces itself with
     # the actual metaclass.
-    class metaclass(meta):
+    class metaclass(type):
 
         def __new__(cls, name, this_bases, d):
             return meta(name, bases, d)
+
+        @classmethod
+        def __prepare__(cls, name, this_bases):
+            return meta.__prepare__(name, bases)
     return type.__new__(metaclass, 'temporary_class', (), {})
 
 
@@ -821,15 +841,69 @@ def add_metaclass(metaclass):
                 orig_vars.pop(slots_var)
         orig_vars.pop('__dict__', None)
         orig_vars.pop('__weakref__', None)
+        if hasattr(cls, '__qualname__'):
+            orig_vars['__qualname__'] = cls.__qualname__
         return metaclass(cls.__name__, cls.__bases__, orig_vars)
     return wrapper
+
+
+def ensure_binary(s, encoding='utf-8', errors='strict'):
+    """Coerce **s** to six.binary_type.
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+    For Python 3:
+      - `str` -> encoded to `bytes`
+      - `bytes` -> `bytes`
+    """
+    if isinstance(s, text_type):
+        return s.encode(encoding, errors)
+    elif isinstance(s, binary_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
+
+
+def ensure_str(s, encoding='utf-8', errors='strict'):
+    """Coerce *s* to `str`.
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if not isinstance(s, (text_type, binary_type)):
+        raise TypeError("not expecting type '%s'" % type(s))
+    if PY2 and isinstance(s, text_type):
+        s = s.encode(encoding, errors)
+    elif PY3 and isinstance(s, binary_type):
+        s = s.decode(encoding, errors)
+    return s
+
+
+def ensure_text(s, encoding='utf-8', errors='strict'):
+    """Coerce *s* to six.text_type.
+    For Python 2:
+      - `unicode` -> `unicode`
+      - `str` -> `unicode`
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if isinstance(s, binary_type):
+        return s.decode(encoding, errors)
+    elif isinstance(s, text_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
+
 
 
 def python_2_unicode_compatible(klass):
     """
     A decorator that defines __unicode__ and __str__ methods under Python 2.
     Under Python 3 it does nothing.
-
     To support Python 2 and 3 with a single code base, define a __str__ method
     returning text and apply this decorator to the class.
     """

--- a/tests/integration/s3/mock_storage_service.py
+++ b/tests/integration/s3/mock_storage_service.py
@@ -30,7 +30,10 @@ import copy
 import boto
 import base64
 import re
+import locale
 from hashlib import md5
+
+import six
 
 from boto.utils import compute_md5
 from boto.utils import find_matching_headers
@@ -88,7 +91,26 @@ class MockKey(object):
                              torrent=NOT_IMPL,
                              version_id=NOT_IMPL,
                              res_download_handler=NOT_IMPL):
-        fp.write(self.data)
+        if six.PY2:
+            fp.write(self.data)
+        else:
+            if isinstance(self.data, bytes):
+                if 'b' in fp.mode:
+                    # data is bytes, and fp is binary
+                    fp.write(self.data)
+                elif hasattr(fp, 'buffer'):
+                    # data is bytes, but fp is text - try the underlying buffer
+                    fp.buffer.write(self.data)
+                else:
+                    # data is bytes, but fp is text - try to decode bytes
+                    fp.write(
+                        self.data.decode(locale.getpreferredencoding(False)))
+            elif 'b' in fp.mode:
+                # data is not bytes, but fp is binary
+                fp.write(self.data.encode(locale.getpreferredencoding(False)))
+            else:
+                # data is not bytes, and fp is text
+                fp.write(self.data)
 
     def get_file(self, fp, headers=NOT_IMPL, cb=NOT_IMPL, num_cb=NOT_IMPL,
                  torrent=NOT_IMPL, version_id=NOT_IMPL,
@@ -147,7 +169,7 @@ class MockKey(object):
                                cb=NOT_IMPL, num_cb=NOT_IMPL, policy=NOT_IMPL,
                                reduced_redundancy=NOT_IMPL, query_args=NOT_IMPL,
                                size=NOT_IMPL):
-        self.data = ''
+        self.data = b''
         chunk = fp.read(self.BufferSize)
         while chunk:
           self.data += chunk
@@ -188,7 +210,7 @@ class MockKey(object):
 
     def set_etag(self):
         """
-        Set etag attribute by generating hex MD5 checksum on current 
+        Set etag attribute by generating hex MD5 checksum on current
         contents of mock key.
         """
         m = md5()
@@ -213,11 +235,11 @@ class MockKey(object):
         """
         tup = compute_md5(fp)
         # Returned values are MD5 hash, base64 encoded MD5 hash, and file size.
-        # The internal implementation of compute_md5() needs to return the 
+        # The internal implementation of compute_md5() needs to return the
         # file size but we don't want to return that value to the external
         # caller because it changes the class interface (i.e. it might
-        # break some code) so we consume the third tuple value here and 
-        # return the remainder of the tuple to the caller, thereby preserving 
+        # break some code) so we consume the third tuple value here and
+        # return the remainder of the tuple to the caller, thereby preserving
         # the existing interface.
         self.size = tup[2]
         return tup[0:2]
@@ -268,7 +290,7 @@ class MockBucket(object):
             # Return ACL for the bucket.
             return self.acls[self.name]
 
-    def get_def_acl(self, key_name=NOT_IMPL, headers=NOT_IMPL, 
+    def get_def_acl(self, key_name=NOT_IMPL, headers=NOT_IMPL,
                     version_id=NOT_IMPL):
         # Return default ACL for the bucket.
         return self.def_acl

--- a/tests/integration/s3/mock_storage_service.py
+++ b/tests/integration/s3/mock_storage_service.py
@@ -39,8 +39,6 @@ from boto.utils import merge_headers_by_name
 from boto.s3.prefix import Prefix
 from boto.compat import six
 
-import six
-
 NOT_IMPL = None
 
 

--- a/tests/integration/s3/mock_storage_service.py
+++ b/tests/integration/s3/mock_storage_service.py
@@ -91,29 +91,23 @@ class MockKey(object):
                              torrent=NOT_IMPL,
                              version_id=NOT_IMPL,
                              res_download_handler=NOT_IMPL):
-        if six.PY2:
-            if hasattr(fp, "mode") and 'b' in fp.mode:
-                fp.write(six.ensure_binary(self.data))
-            else:
-                fp.write(six.ensure_text(self.data))
-        else:
-            if isinstance(self.data, bytes):
-                if 'b' in fp.mode:
-                    # data is bytes, and fp is binary
-                    fp.write(self.data)
-                elif hasattr(fp, 'buffer'):
-                    # data is bytes, but fp is text - try the underlying buffer
-                    fp.buffer.write(self.data)
-                else:
-                    # data is bytes, but fp is text - try to decode bytes
-                    fp.write(
-                        self.data.decode(locale.getpreferredencoding(False)))
-            elif 'b' in fp.mode:
-                # data is not bytes, but fp is binary
-                fp.write(self.data.encode(locale.getpreferredencoding(False)))
-            else:
-                # data is not bytes, and fp is text
+        if isinstance(self.data, six.binary_type):
+            if 'b' in fp.mode:
+                # data is bytes, and fp is binary
                 fp.write(self.data)
+            elif hasattr(fp, 'buffer'):
+                # data is bytes, but fp is text - try the underlying buffer
+                fp.buffer.write(self.data)
+            else:
+                # data is bytes, but fp is text - try to decode bytes
+                fp.write(
+                    self.data.decode(locale.getpreferredencoding(False)))
+        elif 'b' in fp.mode:
+            # data is not bytes, but fp is binary
+            fp.write(self.data.encode(locale.getpreferredencoding(False)))
+        else:
+            # data is not bytes, and fp is text
+            fp.write(self.data)
 
     def get_file(self, fp, headers=NOT_IMPL, cb=NOT_IMPL, num_cb=NOT_IMPL,
                  torrent=NOT_IMPL, version_id=NOT_IMPL,

--- a/tests/integration/s3/mock_storage_service.py
+++ b/tests/integration/s3/mock_storage_service.py
@@ -33,13 +33,13 @@ import re
 import locale
 from hashlib import md5
 
-import six
-
 from boto.utils import compute_md5
 from boto.utils import find_matching_headers
 from boto.utils import merge_headers_by_name
 from boto.s3.prefix import Prefix
 from boto.compat import six
+
+import six
 
 NOT_IMPL = None
 
@@ -92,7 +92,10 @@ class MockKey(object):
                              version_id=NOT_IMPL,
                              res_download_handler=NOT_IMPL):
         if six.PY2:
-            fp.write(self.data)
+            if hasattr(fp, "mode") and 'b' in fp.mode:
+                fp.write(six.ensure_binary(self.data))
+            else:
+                fp.write(six.ensure_text(self.data))
         else:
             if isinstance(self.data, bytes):
                 if 'b' in fp.mode:


### PR DESCRIPTION
@walkerjoe Ed (todo: find Ed's github alias) and I made several fixes to help boto be cross-compatible with Python 2 and 3. These issues were identified while working on making [gsutil's py-six-current branch](https://github.com/GoogleCloudPlatform/gsutil/tree/py-six-current) compatible with Python 2.7 and 3.5+. This was done under the guidance of @houglum

Notably, we're using the [six](https://github.com/benjaminp/six) library to help ensure byte strings vs unicode strings work together nicely. Many of the changes we made revolve around making Python 2 and Python 3's byte vs unicode strings play together nicely, along with changes in division. The ttyprint and ttywrite methods were added to allow type agnostic string printing.

Let us know if you have any questions about these changes! :slightly_smiling_face: