### PR TITLE
Python 2 / 3 compatibility fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ MANIFEST
 .tox
 .coverage
 *flymake.py
-venv
+.vscode/
+venv*
 venv-2.5
 env-2.5

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -39,7 +39,7 @@ import hmac
 import os
 import posixpath
 
-from boto.compat import urllib, encodebytes, parse_qs_safe, urlparse
+from boto.compat import urllib, encodebytes, parse_qs_safe, urlparse, six
 from boto.auth_handler import AuthHandler
 from boto.exception import BotoClientError
 
@@ -384,8 +384,9 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         pairs = []
         for pname in parameter_names:
             pval = boto.utils.get_utf8_value(http_request.params[pname])
-            pairs.append(urllib.parse.quote(pname, safe='') + '=' +
-                         urllib.parse.quote(pval, safe='-_~'))
+            pairs.append(urllib.parse.quote(pname, safe=''.encode('ascii')) +
+                         '='.encode('ascii') +
+                         urllib.parse.quote(pval, safe='-_~'.encode('ascii')))
         return '&'.join(pairs)
 
     def canonical_query_string(self, http_request):
@@ -836,7 +837,7 @@ class STSAnonHandler(AuthHandler):
         pairs = []
         for key in keys:
             val = boto.utils.get_utf8_value(params[key])
-            pairs.append(key + '=' + self._escape_value(val.decode('utf-8')))
+            pairs.append(key + '=' + self._escape_value(six.ensure_str(val)))
         return '&'.join(pairs)
 
     def add_auth(self, http_request, **kwargs):

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -385,7 +385,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         for pname in parameter_names:
             pval = boto.utils.get_utf8_value(http_request.params[pname])
             pairs.append(urllib.parse.quote(pname, safe=''.encode('ascii')) +
-                         '='.encode('ascii') +
+                         '=' +
                          urllib.parse.quote(pval, safe='-_~'.encode('ascii')))
         return '&'.join(pairs)
 

--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -936,9 +936,9 @@ class Key(S3Key):
         if content_type:
             headers['Content-Type'] = content_type
         resp = self.bucket.connection.make_request(
-            'PUT', get_utf8_value(self.bucket.name), get_utf8_value(self.name),
+            'PUT', self.bucket.name, self.name,
             headers=headers, query_args='compose',
-            data=get_utf8_value(compose_req_xml))
+            data=compose_req_xml)
         if resp.status < 200 or resp.status > 299:
             raise self.bucket.connection.provider.storage_response_error(
                 resp.status, resp.reason, resp.read())

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -1,1879 +1,8640 @@
-# Copyright (c) 2006-2010 Mitch Garnaat http://garnaat.org/
-# Copyright (c) 2010, Eucalyptus Systems, Inc.
-# All rights reserved.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the
-# "Software"), to deal in the Software without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish, dis-
-# tribute, sublicense, and/or sell copies of the Software, and to permit
-# persons to whom the Software is furnished to do so, subject to the fol-
-# lowing conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
-# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE.
-
-import boto
-from boto import handler
-from boto.resultset import ResultSet
-from boto.exception import BotoClientError
-from boto.s3.acl import Policy, CannedACLStrings, Grant
-from boto.s3.key import Key
-from boto.s3.prefix import Prefix
-from boto.s3.deletemarker import DeleteMarker
-from boto.s3.multipart import MultiPartUpload
-from boto.s3.multipart import CompleteMultiPartUpload
-from boto.s3.multidelete import MultiDeleteResult
-from boto.s3.multidelete import Error
-from boto.s3.bucketlistresultset import BucketListResultSet
-from boto.s3.bucketlistresultset import VersionedBucketListResultSet
-from boto.s3.bucketlistresultset import MultiPartUploadListResultSet
-from boto.s3.lifecycle import Lifecycle
-from boto.s3.tagging import Tags
-from boto.s3.cors import CORSConfiguration
-from boto.s3.bucketlogging import BucketLogging
-from boto.s3 import website
-import boto.jsonresponse
-import boto.utils
-import xml.sax
-import xml.sax.saxutils
-import re
-import base64
-from collections import defaultdict
-from boto.compat import BytesIO, six, StringIO, urllib
-
-# as per http://goo.gl/BDuud (02/19/2011)
-
-
-class S3WebsiteEndpointTranslate(object):
-
-    trans_region = defaultdict(lambda: 's3-website-us-east-1')
-    trans_region['eu-west-1'] = 's3-website-eu-west-1'
-    trans_region['eu-central-1'] = 's3-website.eu-central-1'
-    trans_region['us-west-1'] = 's3-website-us-west-1'
-    trans_region['us-west-2'] = 's3-website-us-west-2'
-    trans_region['sa-east-1'] = 's3-website-sa-east-1'
-    trans_region['ap-northeast-1'] = 's3-website-ap-northeast-1'
-    trans_region['ap-southeast-1'] = 's3-website-ap-southeast-1'
-    trans_region['ap-southeast-2'] = 's3-website-ap-southeast-2'
-    trans_region['cn-north-1'] = 's3-website.cn-north-1'
-
-    @classmethod
-    def translate_region(self, reg):
-        return self.trans_region[reg]
-
-S3Permissions = ['READ', 'WRITE', 'READ_ACP', 'WRITE_ACP', 'FULL_CONTROL']
-
-
-class Bucket(object):
-
-    LoggingGroup = 'http://acs.amazonaws.com/groups/s3/LogDelivery'
-
-    BucketPaymentBody = """<?xml version="1.0" encoding="UTF-8"?>
-       <RequestPaymentConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-         <Payer>%s</Payer>
-       </RequestPaymentConfiguration>"""
-
-    VersioningBody = """<?xml version="1.0" encoding="UTF-8"?>
-       <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-         <Status>%s</Status>
-         <MfaDelete>%s</MfaDelete>
-       </VersioningConfiguration>"""
-
-    VersionRE = '<Status>([A-Za-z]+)</Status>'
-    MFADeleteRE = '<MfaDelete>([A-Za-z]+)</MfaDelete>'
-
-    def __init__(self, connection=None, name=None, key_class=Key):
-        self.name = name
-        self.connection = connection
-        self.key_class = key_class
-
-    def __repr__(self):
-        return '<Bucket: %s>' % self.name
-
-    def __iter__(self):
-        return iter(BucketListResultSet(self))
-
-    def __contains__(self, key_name):
-        return not (self.get_key(key_name) is None)
-
-    def startElement(self, name, attrs, connection):
-        return None
-
-    def endElement(self, name, value, connection):
-        if name == 'Name':
-            self.name = value
-        elif name == 'CreationDate':
-            self.creation_date = value
-        else:
-            setattr(self, name, value)
-
-    def set_key_class(self, key_class):
-        """
-        Set the Key class associated with this bucket.  By default, this
-        would be the boto.s3.key.Key class but if you want to subclass that
-        for some reason this allows you to associate your new class with a
-        bucket so that when you call bucket.new_key() or when you get a listing
-        of keys in the bucket you will get an instances of your key class
-        rather than the default.
-
-        :type key_class: class
-        :param key_class: A subclass of Key that can be more specific
-        """
-        self.key_class = key_class
-
-    def lookup(self, key_name, headers=None):
-        """
-        Deprecated: Please use get_key method.
-
-        :type key_name: string
-        :param key_name: The name of the key to retrieve
-
-        :rtype: :class:`boto.s3.key.Key`
-        :returns: A Key object from this bucket.
-        """
-        return self.get_key(key_name, headers=headers)
-
-    def get_key(self, key_name, headers=None, version_id=None,
-                response_headers=None, validate=True):
-        """
-        Check to see if a particular key exists within the bucket.  This
-        method uses a HEAD request to check for the existence of the key.
-        Returns: An instance of a Key object or None
-
-        :param key_name: The name of the key to retrieve
-        :type key_name: string
-
-        :param headers: The headers to send when retrieving the key
-        :type headers: dict
-
-        :param version_id:
-        :type version_id: string
-
-        :param response_headers: A dictionary containing HTTP
-            headers/values that will override any headers associated
-            with the stored object in the response.  See
-            http://goo.gl/EWOPb for details.
-        :type response_headers: dict
-
-        :param validate: Verifies whether the key exists. If ``False``, this
-            will not hit the service, constructing an in-memory object.
-            Default is ``True``.
-        :type validate: bool
-
-        :rtype: :class:`boto.s3.key.Key`
-        :returns: A Key object from this bucket.
-        """
-        if validate is False:
-            if headers or version_id or response_headers:
-                raise BotoClientError(
-                    "When providing 'validate=False', no other params " + \
-                    "are allowed."
-                )
-
-            # This leans on the default behavior of ``new_key`` (not hitting
-            # the service). If that changes, that behavior should migrate here.
-            return self.new_key(key_name)
-
-        query_args_l = []
-        if version_id:
-            query_args_l.append('versionId=%s' % version_id)
-        if response_headers:
-            for rk, rv in six.iteritems(response_headers):
-                query_args_l.append('%s=%s' % (rk, urllib.parse.quote(rv)))
-
-        key, resp = self._get_key_internal(key_name, headers, query_args_l)
-        return key
-
-    def _get_key_internal(self, key_name, headers, query_args_l):
-        query_args = '&'.join(query_args_l) or None
-        response = self.connection.make_request('HEAD', self.name, key_name,
-                                                headers=headers,
-                                                query_args=query_args)
-        response.read()
-        # Allow any success status (2xx) - for example this lets us
-        # support Range gets, which return status 206:
-        if response.status / 100 == 2:
-            k = self.key_class(self)
-            provider = self.connection.provider
-            k.metadata = boto.utils.get_aws_metadata(response.msg, provider)
-            for field in Key.base_fields:
-                k.__dict__[field.lower().replace('-', '_')] = \
-                    response.getheader(field)
-            # the following machinations are a workaround to the fact that
-            # apache/fastcgi omits the content-length header on HEAD
-            # requests when the content-length is zero.
-            # See http://goo.gl/0Tdax for more details.
-            clen = response.getheader('content-length')
-            if clen:
-                k.size = int(response.getheader('content-length'))
-            else:
-                k.size = 0
-            k.name = key_name
-            k.handle_version_headers(response)
-            k.handle_encryption_headers(response)
-            k.handle_restore_headers(response)
-            k.handle_storage_class_header(response)
-            k.handle_addl_headers(response.getheaders())
-            return k, response
-        else:
-            if response.status == 404:
-                return None, response
-            else:
-                raise self.connection.provider.storage_response_error(
-                    response.status, response.reason, '')
-
-    def list(self, prefix='', delimiter='', marker='', headers=None,
-             encoding_type=None):
-        """
-        List key objects within a bucket.  This returns an instance of an
-        BucketListResultSet that automatically handles all of the result
-        paging, etc. from S3.  You just need to keep iterating until
-        there are no more results.
-
-        Called with no arguments, this will return an iterator object across
-        all keys within the bucket.
-
-        The Key objects returned by the iterator are obtained by parsing
-        the results of a GET on the bucket, also known as the List Objects
-        request.  The XML returned by this request contains only a subset
-        of the information about each key.  Certain metadata fields such
-        as Content-Type and user metadata are not available in the XML.
-        Therefore, if you want these additional metadata fields you will
-        have to do a HEAD request on the Key in the bucket.
-
-        :type prefix: string
-        :param prefix: allows you to limit the listing to a particular
-            prefix.  For example, if you call the method with
-            prefix='/foo/' then the iterator will only cycle through
-            the keys that begin with the string '/foo/'.
-
-        :type delimiter: string
-        :param delimiter: can be used in conjunction with the prefix
-            to allow you to organize and browse your keys
-            hierarchically. See http://goo.gl/Xx63h for more details.
-
-        :type marker: string
-        :param marker: The "marker" of where you are in the result set
-
-        :param encoding_type: Requests Amazon S3 to encode the response and
-            specifies the encoding method to use.
-
-            An object key can contain any Unicode character; however, XML 1.0
-            parser cannot parse some characters, such as characters with an
-            ASCII value from 0 to 10. For characters that are not supported in
-            XML 1.0, you can add this parameter to request that Amazon S3
-            encode the keys in the response.
-
-            Valid options: ``url``
-        :type encoding_type: string
-
-        :rtype: :class:`boto.s3.bucketlistresultset.BucketListResultSet`
-        :return: an instance of a BucketListResultSet that handles paging, etc
-        """
-        return BucketListResultSet(self, prefix, delimiter, marker, headers,
-                                   encoding_type=encoding_type)
-
-    def list_versions(self, prefix='', delimiter='', key_marker='',
-                      version_id_marker='', headers=None, encoding_type=None):
-        """
-        List version objects within a bucket.  This returns an
-        instance of an VersionedBucketListResultSet that automatically
-        handles all of the result paging, etc. from S3.  You just need
-        to keep iterating until there are no more results.  Called
-        with no arguments, this will return an iterator object across
-        all keys within the bucket.
-
-        :type prefix: string
-        :param prefix: allows you to limit the listing to a particular
-            prefix.  For example, if you call the method with
-            prefix='/foo/' then the iterator will only cycle through
-            the keys that begin with the string '/foo/'.
-
-        :type delimiter: string
-        :param delimiter: can be used in conjunction with the prefix
-            to allow you to organize and browse your keys
-            hierarchically. See:
-
-            http://aws.amazon.com/releasenotes/Amazon-S3/213
-
-            for more details.
-
-        :type key_marker: string
-        :param key_marker: The "marker" of where you are in the result set
-
-        :param encoding_type: Requests Amazon S3 to encode the response and
-            specifies the encoding method to use.
-
-            An object key can contain any Unicode character; however, XML 1.0
-            parser cannot parse some characters, such as characters with an
-            ASCII value from 0 to 10. For characters that are not supported in
-            XML 1.0, you can add this parameter to request that Amazon S3
-            encode the keys in the response.
-
-            Valid options: ``url``
-        :type encoding_type: string
-
-        :rtype: :class:`boto.s3.bucketlistresultset.BucketListResultSet`
-        :return: an instance of a BucketListResultSet that handles paging, etc
-        """
-        return VersionedBucketListResultSet(self, prefix, delimiter,
-                                            key_marker, version_id_marker,
-                                            headers,
-                                            encoding_type=encoding_type)
-
-    def list_multipart_uploads(self, key_marker='',
-                               upload_id_marker='',
-                               headers=None, encoding_type=None):
-        """
-        List multipart upload objects within a bucket.  This returns an
-        instance of an MultiPartUploadListResultSet that automatically
-        handles all of the result paging, etc. from S3.  You just need
-        to keep iterating until there are no more results.
-
-        :type key_marker: string
-        :param key_marker: The "marker" of where you are in the result set
-
-        :type upload_id_marker: string
-        :param upload_id_marker: The upload identifier
-
-        :param encoding_type: Requests Amazon S3 to encode the response and
-            specifies the encoding method to use.
-
-            An object key can contain any Unicode character; however, XML 1.0
-            parser cannot parse some characters, such as characters with an
-            ASCII value from 0 to 10. For characters that are not supported in
-            XML 1.0, you can add this parameter to request that Amazon S3
-            encode the keys in the response.
-
-            Valid options: ``url``
-        :type encoding_type: string
-
-        :rtype: :class:`boto.s3.bucketlistresultset.MultiPartUploadListResultSet`
-        :return: an instance of a BucketListResultSet that handles paging, etc
-        """
-        return MultiPartUploadListResultSet(self, key_marker,
-                                            upload_id_marker,
-                                            headers,
-                                            encoding_type=encoding_type)
-
-    def _get_all_query_args(self, params, initial_query_string=''):
-        pairs = []
-
-        if initial_query_string:
-            pairs.append(initial_query_string)
-
-        for key, value in sorted(params.items(), key=lambda x: x[0]):
-            if value is None:
-                continue
-            key = key.replace('_', '-')
-            if key == 'maxkeys':
-                key = 'max-keys'
-            if not isinstance(value, six.string_types + (six.binary_type,)):
-                value = six.text_type(value)
-            if not isinstance(value, six.binary_type):
-                value = value.encode('utf-8')
-            if value:
-                pairs.append(u'%s=%s' % (
-                    urllib.parse.quote(key),
-                    urllib.parse.quote(value)
-                ))
-
-        return '&'.join(pairs)
-
-    def _get_all(self, element_map, initial_query_string='',
-                 headers=None, **params):
-        query_args = self._get_all_query_args(
-            params,
-            initial_query_string=initial_query_string
-        )
-        response = self.connection.make_request('GET', self.name,
-                                                headers=headers,
-                                                query_args=query_args)
-        body = response.read()
-        boto.log.debug(body)
-        if response.status == 200:
-            rs = ResultSet(element_map)
-            h = handler.XmlHandler(rs, self)
-            if not isinstance(body, bytes):
-                body = body.encode('utf-8')
-            xml.sax.parseString(body, h)
-            return rs
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def validate_kwarg_names(self, kwargs, names):
-        """
-        Checks that all named arguments are in the specified list of names.
-
-        :type kwargs: dict
-        :param kwargs: Dictionary of kwargs to validate.
-
-        :type names: list
-        :param names: List of possible named arguments.
-        """
-        for kwarg in kwargs:
-            if kwarg not in names:
-                raise TypeError('Invalid argument "%s"!' % kwarg)
-
-    def get_all_keys(self, headers=None, **params):
-        """
-        A lower-level method for listing contents of a bucket.  This
-        closely models the actual S3 API and requires you to manually
-        handle the paging of results.  For a higher-level method that
-        handles the details of paging for you, you can use the list
-        method.
-
-        :type max_keys: int
-        :param max_keys: The maximum number of keys to retrieve
-
-        :type prefix: string
-        :param prefix: The prefix of the keys you want to retrieve
-
-        :type marker: string
-        :param marker: The "marker" of where you are in the result set
-
-        :type delimiter: string
-        :param delimiter: If this optional, Unicode string parameter
-            is included with your request, then keys that contain the
-            same string between the prefix and the first occurrence of
-            the delimiter will be rolled up into a single result
-            element in the CommonPrefixes collection. These rolled-up
-            keys are not returned elsewhere in the response.
-
-        :param encoding_type: Requests Amazon S3 to encode the response and
-            specifies the encoding method to use.
-
-            An object key can contain any Unicode character; however, XML 1.0
-            parser cannot parse some characters, such as characters with an
-            ASCII value from 0 to 10. For characters that are not supported in
-            XML 1.0, you can add this parameter to request that Amazon S3
-            encode the keys in the response.
-
-            Valid options: ``url``
-        :type encoding_type: string
-
-        :rtype: ResultSet
-        :return: The result from S3 listing the keys requested
-
-        """
-        self.validate_kwarg_names(params, ['maxkeys', 'max_keys', 'prefix',
-                                           'marker', 'delimiter',
-                                           'encoding_type'])
-        return self._get_all([('Contents', self.key_class),
-                              ('CommonPrefixes', Prefix)],
-                             '', headers, **params)
-
-    def get_all_versions(self, headers=None, **params):
-        """
-        A lower-level, version-aware method for listing contents of a
-        bucket.  This closely models the actual S3 API and requires
-        you to manually handle the paging of results.  For a
-        higher-level method that handles the details of paging for
-        you, you can use the list method.
-
-        :type max_keys: int
-        :param max_keys: The maximum number of keys to retrieve
-
-        :type prefix: string
-        :param prefix: The prefix of the keys you want to retrieve
-
-        :type key_marker: string
-        :param key_marker: The "marker" of where you are in the result set
-            with respect to keys.
-
-        :type version_id_marker: string
-        :param version_id_marker: The "marker" of where you are in the result
-            set with respect to version-id's.
-
-        :type delimiter: string
-        :param delimiter: If this optional, Unicode string parameter
-            is included with your request, then keys that contain the
-            same string between the prefix and the first occurrence of
-            the delimiter will be rolled up into a single result
-            element in the CommonPrefixes collection. These rolled-up
-            keys are not returned elsewhere in the response.
-
-        :param encoding_type: Requests Amazon S3 to encode the response and
-            specifies the encoding method to use.
-
-            An object key can contain any Unicode character; however, XML 1.0
-            parser cannot parse some characters, such as characters with an
-            ASCII value from 0 to 10. For characters that are not supported in
-            XML 1.0, you can add this parameter to request that Amazon S3
-            encode the keys in the response.
-
-            Valid options: ``url``
-        :type encoding_type: string
-
-        :rtype: ResultSet
-        :return: The result from S3 listing the keys requested
-        """
-        self.validate_get_all_versions_params(params)
-        return self._get_all([('Version', self.key_class),
-                              ('CommonPrefixes', Prefix),
-                              ('DeleteMarker', DeleteMarker)],
-                             'versions', headers, **params)
-
-    def validate_get_all_versions_params(self, params):
-        """
-        Validate that the parameters passed to get_all_versions are valid.
-        Overridden by subclasses that allow a different set of parameters.
-
-        :type params: dict
-        :param params: Parameters to validate.
-        """
-        self.validate_kwarg_names(
-                params, ['maxkeys', 'max_keys', 'prefix', 'key_marker',
-                         'version_id_marker', 'delimiter', 'encoding_type'])
-
-    def get_all_multipart_uploads(self, headers=None, **params):
-        """
-        A lower-level, version-aware method for listing active
-        MultiPart uploads for a bucket.  This closely models the
-        actual S3 API and requires you to manually handle the paging
-        of results.  For a higher-level method that handles the
-        details of paging for you, you can use the list method.
-
-        :type max_uploads: int
-        :param max_uploads: The maximum number of uploads to retrieve.
-            Default value is 1000.
-
-        :type key_marker: string
-        :param key_marker: Together with upload_id_marker, this
-            parameter specifies the multipart upload after which
-            listing should begin.  If upload_id_marker is not
-            specified, only the keys lexicographically greater than
-            the specified key_marker will be included in the list.
-
-            If upload_id_marker is specified, any multipart uploads
-            for a key equal to the key_marker might also be included,
-            provided those multipart uploads have upload IDs
-            lexicographically greater than the specified
-            upload_id_marker.
-
-        :type upload_id_marker: string
-        :param upload_id_marker: Together with key-marker, specifies
-            the multipart upload after which listing should begin. If
-            key_marker is not specified, the upload_id_marker
-            parameter is ignored.  Otherwise, any multipart uploads
-            for a key equal to the key_marker might be included in the
-            list only if they have an upload ID lexicographically
-            greater than the specified upload_id_marker.
-
-        :type encoding_type: string
-        :param encoding_type: Requests Amazon S3 to encode the response and
-            specifies the encoding method to use.
-
-            An object key can contain any Unicode character; however, XML 1.0
-            parser cannot parse some characters, such as characters with an
-            ASCII value from 0 to 10. For characters that are not supported in
-            XML 1.0, you can add this parameter to request that Amazon S3
-            encode the keys in the response.
-
-            Valid options: ``url``
-
-        :type delimiter: string
-        :param delimiter: Character you use to group keys.
-            All keys that contain the same string between the prefix, if
-            specified, and the first occurrence of the delimiter after the
-            prefix are grouped under a single result element, CommonPrefixes.
-            If you don't specify the prefix parameter, then the substring
-            starts at the beginning of the key. The keys that are grouped
-            under CommonPrefixes result element are not returned elsewhere
-            in the response.
-
-        :type prefix: string
-        :param prefix: Lists in-progress uploads only for those keys that
-            begin with the specified prefix. You can use prefixes to separate
-            a bucket into different grouping of keys. (You can think of using
-            prefix to make groups in the same way you'd use a folder in a
-            file system.)
-
-        :rtype: ResultSet
-        :return: The result from S3 listing the uploads requested
-
-        """
-        self.validate_kwarg_names(params, ['max_uploads', 'key_marker',
-                                           'upload_id_marker', 'encoding_type',
-                                           'delimiter', 'prefix'])
-        return self._get_all([('Upload', MultiPartUpload),
-                              ('CommonPrefixes', Prefix)],
-                             'uploads', headers, **params)
-
-    def new_key(self, key_name=None):
-        """
-        Creates a new key
-
-        :type key_name: string
-        :param key_name: The name of the key to create
-
-        :rtype: :class:`boto.s3.key.Key` or subclass
-        :returns: An instance of the newly created key object
-        """
-        if not key_name:
-            raise ValueError('Empty key names are not allowed')
-        return self.key_class(self, key_name)
-
-    def generate_url(self, expires_in, method='GET', headers=None,
-                     force_http=False, response_headers=None,
-                     expires_in_absolute=False):
-        return self.connection.generate_url(expires_in, method, self.name,
-                                            headers=headers,
-                                            force_http=force_http,
-                                            response_headers=response_headers,
-                                            expires_in_absolute=expires_in_absolute)
-
-    def delete_keys(self, keys, quiet=False, mfa_token=None, headers=None):
-        """
-        Deletes a set of keys using S3's Multi-object delete API. If a
-        VersionID is specified for that key then that version is removed.
-        Returns a MultiDeleteResult Object, which contains Deleted
-        and Error elements for each key you ask to delete.
-
-        :type keys: list
-        :param keys: A list of either key_names or (key_name, versionid) pairs
-            or a list of Key instances.
-
-        :type quiet: boolean
-        :param quiet: In quiet mode the response includes only keys
-            where the delete operation encountered an error. For a
-            successful deletion, the operation does not return any
-            information about the delete in the response body.
-
-        :type mfa_token: tuple or list of strings
-        :param mfa_token: A tuple or list consisting of the serial
-            number from the MFA device and the current value of the
-            six-digit token associated with the device.  This value is
-            required anytime you are deleting versioned objects from a
-            bucket that has the MFADelete option on the bucket.
-
-        :returns: An instance of MultiDeleteResult
-        """
-        ikeys = iter(keys)
-        result = MultiDeleteResult(self)
-        provider = self.connection.provider
-        query_args = 'delete'
-
-        def delete_keys2(hdrs):
-            hdrs = hdrs or {}
-            data = u"""<?xml version="1.0" encoding="UTF-8"?>"""
-            data += u"<Delete>"
-            if quiet:
-                data += u"<Quiet>true</Quiet>"
-            count = 0
-            while count < 1000:
-                try:
-                    key = next(ikeys)
-                except StopIteration:
-                    break
-                if isinstance(key, six.string_types):
-                    key_name = key
-                    version_id = None
-                elif isinstance(key, tuple) and len(key) == 2:
-                    key_name, version_id = key
-                elif (isinstance(key, Key) or isinstance(key, DeleteMarker)) and key.name:
-                    key_name = key.name
-                    version_id = key.version_id
-                else:
-                    if isinstance(key, Prefix):
-                        key_name = key.name
-                        code = 'PrefixSkipped'   # Don't delete Prefix
-                    else:
-                        key_name = repr(key)   # try get a string
-                        code = 'InvalidArgument'  # other unknown type
-                    message = 'Invalid. No delete action taken for this object.'
-                    error = Error(key_name, code=code, message=message)
-                    result.errors.append(error)
-                    continue
-                count += 1
-                data += u"<Object><Key>%s</Key>" % xml.sax.saxutils.escape(key_name)
-                if version_id:
-                    data += u"<VersionId>%s</VersionId>" % version_id
-                data += u"</Object>"
-            data += u"</Delete>"
-            if count <= 0:
-                return False  # no more
-            data = data.encode('utf-8')
-            fp = BytesIO(data)
-            md5 = boto.utils.compute_md5(fp)
-            hdrs['Content-MD5'] = md5[1]
-            hdrs['Content-Type'] = 'text/xml'
-            if mfa_token:
-                hdrs[provider.mfa_header] = ' '.join(mfa_token)
-            response = self.connection.make_request('POST', self.name,
-                                                    headers=hdrs,
-                                                    query_args=query_args,
-                                                    data=data)
-            body = response.read()
-            if response.status == 200:
-                h = handler.XmlHandler(result, self)
-                if not isinstance(body, bytes):
-                    body = body.encode('utf-8')
-                xml.sax.parseString(body, h)
-                return count >= 1000  # more?
-            else:
-                raise provider.storage_response_error(response.status,
-                                                      response.reason,
-                                                      body)
-        while delete_keys2(headers):
-            pass
-        return result
-
-    def delete_key(self, key_name, headers=None, version_id=None,
-                   mfa_token=None):
-        """
-        Deletes a key from the bucket.  If a version_id is provided,
-        only that version of the key will be deleted.
-
-        :type key_name: string
-        :param key_name: The key name to delete
-
-        :type version_id: string
-        :param version_id: The version ID (optional)
-
-        :type mfa_token: tuple or list of strings
-        :param mfa_token: A tuple or list consisting of the serial
-            number from the MFA device and the current value of the
-            six-digit token associated with the device.  This value is
-            required anytime you are deleting versioned objects from a
-            bucket that has the MFADelete option on the bucket.
-
-        :rtype: :class:`boto.s3.key.Key` or subclass
-        :returns: A key object holding information on what was
-            deleted.  The Caller can see if a delete_marker was
-            created or removed and what version_id the delete created
-            or removed.
-        """
-        if not key_name:
-            raise ValueError('Empty key names are not allowed')
-        return self._delete_key_internal(key_name, headers=headers,
-                                         version_id=version_id,
-                                         mfa_token=mfa_token,
-                                         query_args_l=None)
-
-    def _delete_key_internal(self, key_name, headers=None, version_id=None,
-                             mfa_token=None, query_args_l=None):
-        query_args_l = query_args_l or []
-        provider = self.connection.provider
-        if version_id:
-            query_args_l.append('versionId=%s' % version_id)
-        query_args = '&'.join(query_args_l) or None
-        if mfa_token:
-            if not headers:
-                headers = {}
-            headers[provider.mfa_header] = ' '.join(mfa_token)
-        response = self.connection.make_request('DELETE', self.name, key_name,
-                                                headers=headers,
-                                                query_args=query_args)
-        body = response.read()
-        if response.status != 204:
-            raise provider.storage_response_error(response.status,
-                                                  response.reason, body)
-        else:
-            # return a key object with information on what was deleted.
-            k = self.key_class(self)
-            k.name = key_name
-            k.handle_version_headers(response)
-            k.handle_addl_headers(response.getheaders())
-            return k
-
-    def copy_key(self, new_key_name, src_bucket_name,
-                 src_key_name, metadata=None, src_version_id=None,
-                 storage_class='STANDARD', preserve_acl=False,
-                 encrypt_key=False, headers=None, query_args=None):
-        """
-        Create a new key in the bucket by copying another existing key.
-
-        :type new_key_name: string
-        :param new_key_name: The name of the new key
-
-        :type src_bucket_name: string
-        :param src_bucket_name: The name of the source bucket
-
-        :type src_key_name: string
-        :param src_key_name: The name of the source key
-
-        :type src_version_id: string
-        :param src_version_id: The version id for the key.  This param
-            is optional.  If not specified, the newest version of the
-            key will be copied.
-
-        :type metadata: dict
-        :param metadata: Metadata to be associated with new key.  If
-            metadata is supplied, it will replace the metadata of the
-            source key being copied.  If no metadata is supplied, the
-            source key's metadata will be copied to the new key.
-
-        :type storage_class: string
-        :param storage_class: The storage class of the new key.  By
-            default, the new key will use the standard storage class.
-            Possible values are: STANDARD | REDUCED_REDUNDANCY
-
-        :type preserve_acl: bool
-        :param preserve_acl: If True, the ACL from the source key will
-            be copied to the destination key.  If False, the
-            destination key will have the default ACL.  Note that
-            preserving the ACL in the new key object will require two
-            additional API calls to S3, one to retrieve the current
-            ACL and one to set that ACL on the new object.  If you
-            don't care about the ACL, a value of False will be
-            significantly more efficient.
-
-        :type encrypt_key: bool
-        :param encrypt_key: If True, the new copy of the object will
-            be encrypted on the server-side by S3 and will be stored
-            in an encrypted form while at rest in S3.
-
-        :type headers: dict
-        :param headers: A dictionary of header name/value pairs.
-
-        :type query_args: string
-        :param query_args: A string of additional querystring arguments
-            to append to the request
-
-        :rtype: :class:`boto.s3.key.Key` or subclass
-        :returns: An instance of the newly created key object
-        """
-        headers = headers or {}
-        provider = self.connection.provider
-        src_key_name = boto.utils.get_utf8_value(src_key_name)
-        if preserve_acl:
-            if self.name == src_bucket_name:
-                src_bucket = self
-            else:
-                src_bucket = self.connection.get_bucket(
-                    src_bucket_name, validate=False, headers=headers)
-            acl = src_bucket.get_xml_acl(src_key_name, headers=headers)
-        if encrypt_key:
-            headers[provider.server_side_encryption_header] = 'AES256'
-        src = '%s/%s' % (src_bucket_name, urllib.parse.quote(src_key_name))
-        if src_version_id:
-            src += '?versionId=%s' % src_version_id
-        headers[provider.copy_source_header] = str(src)
-        # make sure storage_class_header key exists before accessing it
-        if provider.storage_class_header and storage_class:
-            headers[provider.storage_class_header] = storage_class
-        if metadata is not None:
-            headers[provider.metadata_directive_header] = 'REPLACE'
-            headers = boto.utils.merge_meta(headers, metadata, provider)
-        elif not query_args:  # Can't use this header with multi-part copy.
-            headers[provider.metadata_directive_header] = 'COPY'
-        response = self.connection.make_request('PUT', self.name, new_key_name,
-                                                headers=headers,
-                                                query_args=query_args)
-        body = response.read()
-        if response.status == 200:
-            key = self.new_key(new_key_name)
-            h = handler.XmlHandler(key, self)
-            if not isinstance(body, bytes):
-                body = body.encode('utf-8')
-            xml.sax.parseString(body, h)
-            if hasattr(key, 'Error'):
-                raise provider.storage_copy_error(key.Code, key.Message, body)
-            key.handle_version_headers(response)
-            key.handle_addl_headers(response.getheaders())
-            if preserve_acl:
-                self.set_xml_acl(acl, new_key_name)
-            return key
-        else:
-            raise provider.storage_response_error(response.status,
-                                                  response.reason, body)
-
-    def set_canned_acl(self, acl_str, key_name='', headers=None,
-                       version_id=None):
-        assert acl_str in CannedACLStrings
-
-        if headers:
-            headers[self.connection.provider.acl_header] = acl_str
-        else:
-            headers = {self.connection.provider.acl_header: acl_str}
-
-        query_args = 'acl'
-        if version_id:
-            query_args += '&versionId=%s' % version_id
-        response = self.connection.make_request('PUT', self.name, key_name,
-                headers=headers, query_args=query_args)
-        body = response.read()
-        if response.status != 200:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def get_xml_acl(self, key_name='', headers=None, version_id=None):
-        query_args = 'acl'
-        if version_id:
-            query_args += '&versionId=%s' % version_id
-        response = self.connection.make_request('GET', self.name, key_name,
-                                                query_args=query_args,
-                                                headers=headers)
-        body = response.read()
-        if response.status != 200:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-        return body
-
-    def set_xml_acl(self, acl_str, key_name='', headers=None, version_id=None,
-                    query_args='acl'):
-        if version_id:
-            query_args += '&versionId=%s' % version_id
-        if not isinstance(acl_str, bytes):
-            acl_str = acl_str.encode('utf-8')
-        response = self.connection.make_request('PUT', self.name, key_name,
-                                                data=acl_str,
-                                                query_args=query_args,
-                                                headers=headers)
-        body = response.read()
-        if response.status != 200:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def set_acl(self, acl_or_str, key_name='', headers=None, version_id=None):
-        if isinstance(acl_or_str, Policy):
-            self.set_xml_acl(acl_or_str.to_xml(), key_name,
-                             headers, version_id)
-        else:
-            self.set_canned_acl(acl_or_str, key_name,
-                                headers, version_id)
-
-    def get_acl(self, key_name='', headers=None, version_id=None):
-        query_args = 'acl'
-        if version_id:
-            query_args += '&versionId=%s' % version_id
-        response = self.connection.make_request('GET', self.name, key_name,
-                                                query_args=query_args,
-                                                headers=headers)
-        body = response.read()
-        if response.status == 200:
-            policy = Policy(self)
-            h = handler.XmlHandler(policy, self)
-            if not isinstance(body, bytes):
-                body = body.encode('utf-8')
-            xml.sax.parseString(body, h)
-            return policy
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def set_subresource(self, subresource, value, key_name='', headers=None,
-                        version_id=None):
-        """
-        Set a subresource for a bucket or key.
-
-        :type subresource: string
-        :param subresource: The subresource to set.
-
-        :type value: string
-        :param value: The value of the subresource.
-
-        :type key_name: string
-        :param key_name: The key to operate on, or None to operate on the
-            bucket.
-
-        :type headers: dict
-        :param headers: Additional HTTP headers to include in the request.
-
-        :type src_version_id: string
-        :param src_version_id: Optional. The version id of the key to
-            operate on. If not specified, operate on the newest
-            version.
-        """
-        if not subresource:
-            raise TypeError('set_subresource called with subresource=None')
-        query_args = subresource
-        if version_id:
-            query_args += '&versionId=%s' % version_id
-        if not isinstance(value, bytes):
-            value = value.encode('utf-8')
-        response = self.connection.make_request('PUT', self.name, key_name,
-                                                data=value,
-                                                query_args=query_args,
-                                                headers=headers)
-        body = response.read()
-        if response.status != 200:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def get_subresource(self, subresource, key_name='', headers=None,
-                        version_id=None):
-        """
-        Get a subresource for a bucket or key.
-
-        :type subresource: string
-        :param subresource: The subresource to get.
-
-        :type key_name: string
-        :param key_name: The key to operate on, or None to operate on the
-            bucket.
-
-        :type headers: dict
-        :param headers: Additional HTTP headers to include in the request.
-
-        :type src_version_id: string
-        :param src_version_id: Optional. The version id of the key to
-            operate on. If not specified, operate on the newest
-            version.
-
-        :rtype: string
-        :returns: The value of the subresource.
-        """
-        if not subresource:
-            raise TypeError('get_subresource called with subresource=None')
-        query_args = subresource
-        if version_id:
-            query_args += '&versionId=%s' % version_id
-        response = self.connection.make_request('GET', self.name, key_name,
-                                                query_args=query_args,
-                                                headers=headers)
-        body = response.read()
-        if response.status != 200:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-        return body
-
-    def make_public(self, recursive=False, headers=None):
-        self.set_canned_acl('public-read', headers=headers)
-        if recursive:
-            for key in self:
-                self.set_canned_acl('public-read', key.name, headers=headers)
-
-    def add_email_grant(self, permission, email_address,
-                        recursive=False, headers=None):
-        """
-        Convenience method that provides a quick way to add an email grant
-        to a bucket. This method retrieves the current ACL, creates a new
-        grant based on the parameters passed in, adds that grant to the ACL
-        and then PUT's the new ACL back to S3.
-
-        :type permission: string
-        :param permission: The permission being granted. Should be one of:
-            (READ, WRITE, READ_ACP, WRITE_ACP, FULL_CONTROL).
-
-        :type email_address: string
-        :param email_address: The email address associated with the AWS
-            account your are granting the permission to.
-
-        :type recursive: boolean
-        :param recursive: A boolean value to controls whether the
-            command will apply the grant to all keys within the bucket
-            or not.  The default value is False.  By passing a True
-            value, the call will iterate through all keys in the
-            bucket and apply the same grant to each key.  CAUTION: If
-            you have a lot of keys, this could take a long time!
-        """
-        if permission not in S3Permissions:
-            raise self.connection.provider.storage_permissions_error(
-                'Unknown Permission: %s' % permission)
-        policy = self.get_acl(headers=headers)
-        policy.acl.add_email_grant(permission, email_address)
-        self.set_acl(policy, headers=headers)
-        if recursive:
-            for key in self:
-                key.add_email_grant(permission, email_address, headers=headers)
-
-    def add_user_grant(self, permission, user_id, recursive=False,
-                       headers=None, display_name=None):
-        """
-        Convenience method that provides a quick way to add a canonical
-        user grant to a bucket.  This method retrieves the current ACL,
-        creates a new grant based on the parameters passed in, adds that
-        grant to the ACL and then PUT's the new ACL back to S3.
-
-        :type permission: string
-        :param permission: The permission being granted. Should be one of:
-            (READ, WRITE, READ_ACP, WRITE_ACP, FULL_CONTROL).
-
-        :type user_id: string
-        :param user_id:     The canonical user id associated with the AWS
-            account your are granting the permission to.
-
-        :type recursive: boolean
-        :param recursive: A boolean value to controls whether the
-            command will apply the grant to all keys within the bucket
-            or not.  The default value is False.  By passing a True
-            value, the call will iterate through all keys in the
-            bucket and apply the same grant to each key.  CAUTION: If
-            you have a lot of keys, this could take a long time!
-
-        :type display_name: string
-        :param display_name: An option string containing the user's
-            Display Name.  Only required on Walrus.
-        """
-        if permission not in S3Permissions:
-            raise self.connection.provider.storage_permissions_error(
-                'Unknown Permission: %s' % permission)
-        policy = self.get_acl(headers=headers)
-        policy.acl.add_user_grant(permission, user_id,
-                                  display_name=display_name)
-        self.set_acl(policy, headers=headers)
-        if recursive:
-            for key in self:
-                key.add_user_grant(permission, user_id, headers=headers,
-                                   display_name=display_name)
-
-    def list_grants(self, headers=None):
-        policy = self.get_acl(headers=headers)
-        return policy.acl.grants
-
-    def get_location(self, headers=None):
-        """
-        Returns the LocationConstraint for the bucket.
-
-        :rtype: str
-        :return: The LocationConstraint for the bucket or the empty
-            string if no constraint was specified when bucket was created.
-        """
-        response = self.connection.make_request('GET', self.name,
-                                                headers=headers,
-                                                query_args='location')
-        body = response.read()
-        if response.status == 200:
-            rs = ResultSet(self)
-            h = handler.XmlHandler(rs, self)
-            if not isinstance(body, bytes):
-                body = body.encode('utf-8')
-            xml.sax.parseString(body, h)
-            return rs.LocationConstraint
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def set_xml_logging(self, logging_str, headers=None):
-        """
-        Set logging on a bucket directly to the given xml string.
-
-        :type logging_str: unicode string
-        :param logging_str: The XML for the bucketloggingstatus which
-            will be set.  The string will be converted to utf-8 before
-            it is sent.  Usually, you will obtain this XML from the
-            BucketLogging object.
-
-        :rtype: bool
-        :return: True if ok or raises an exception.
-        """
-        body = logging_str
-        if not isinstance(body, bytes):
-            body = body.encode('utf-8')
-        response = self.connection.make_request('PUT', self.name, data=body,
-                query_args='logging', headers=headers)
-        body = response.read()
-        if response.status == 200:
-            return True
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def enable_logging(self, target_bucket, target_prefix='',
-                       grants=None, headers=None):
-        """
-        Enable logging on a bucket.
-
-        :type target_bucket: bucket or string
-        :param target_bucket: The bucket to log to.
-
-        :type target_prefix: string
-        :param target_prefix: The prefix which should be prepended to the
-            generated log files written to the target_bucket.
-
-        :type grants: list of Grant objects
-        :param grants: A list of extra permissions which will be granted on
-            the log files which are created.
-
-        :rtype: bool
-        :return: True if ok or raises an exception.
-        """
-        if isinstance(target_bucket, Bucket):
-            target_bucket = target_bucket.name
-        blogging = BucketLogging(target=target_bucket, prefix=target_prefix,
-                                 grants=grants)
-        return self.set_xml_logging(blogging.to_xml(), headers=headers)
-
-    def disable_logging(self, headers=None):
-        """
-        Disable logging on a bucket.
-
-        :rtype: bool
-        :return: True if ok or raises an exception.
-        """
-        blogging = BucketLogging()
-        return self.set_xml_logging(blogging.to_xml(), headers=headers)
-
-    def get_logging_status(self, headers=None):
-        """
-        Get the logging status for this bucket.
-
-        :rtype: :class:`boto.s3.bucketlogging.BucketLogging`
-        :return: A BucketLogging object for this bucket.
-        """
-        response = self.connection.make_request('GET', self.name,
-                query_args='logging', headers=headers)
-        body = response.read()
-        if response.status == 200:
-            blogging = BucketLogging()
-            h = handler.XmlHandler(blogging, self)
-            if not isinstance(body, bytes):
-                body = body.encode('utf-8')
-            xml.sax.parseString(body, h)
-            return blogging
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def set_as_logging_target(self, headers=None):
-        """
-        Setup the current bucket as a logging target by granting the necessary
-        permissions to the LogDelivery group to write log files to this bucket.
-        """
-        policy = self.get_acl(headers=headers)
-        g1 = Grant(permission='WRITE', type='Group', uri=self.LoggingGroup)
-        g2 = Grant(permission='READ_ACP', type='Group', uri=self.LoggingGroup)
-        policy.acl.add_grant(g1)
-        policy.acl.add_grant(g2)
-        self.set_acl(policy, headers=headers)
-
-    def get_request_payment(self, headers=None):
-        response = self.connection.make_request('GET', self.name,
-                query_args='requestPayment', headers=headers)
-        body = response.read()
-        if response.status == 200:
-            return body
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def set_request_payment(self, payer='BucketOwner', headers=None):
-        body = self.BucketPaymentBody % payer
-        response = self.connection.make_request('PUT', self.name, data=body,
-                query_args='requestPayment', headers=headers)
-        body = response.read()
-        if response.status == 200:
-            return True
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def configure_versioning(self, versioning, mfa_delete=False,
-                             mfa_token=None, headers=None):
-        """
-        Configure versioning for this bucket.
-
-        ..note:: This feature is currently in beta.
-
-        :type versioning: bool
-        :param versioning: A boolean indicating whether version is
-            enabled (True) or disabled (False).
-
-        :type mfa_delete: bool
-        :param mfa_delete: A boolean indicating whether the
-            Multi-Factor Authentication Delete feature is enabled
-            (True) or disabled (False).  If mfa_delete is enabled then
-            all Delete operations will require the token from your MFA
-            device to be passed in the request.
-
-        :type mfa_token: tuple or list of strings
-        :param mfa_token: A tuple or list consisting of the serial
-            number from the MFA device and the current value of the
-            six-digit token associated with the device.  This value is
-            required when you are changing the status of the MfaDelete
-            property of the bucket.
-        """
-        if versioning:
-            ver = 'Enabled'
-        else:
-            ver = 'Suspended'
-        if mfa_delete:
-            mfa = 'Enabled'
-        else:
-            mfa = 'Disabled'
-        body = self.VersioningBody % (ver, mfa)
-        if mfa_token:
-            if not headers:
-                headers = {}
-            provider = self.connection.provider
-            headers[provider.mfa_header] = ' '.join(mfa_token)
-        response = self.connection.make_request('PUT', self.name, data=body,
-                query_args='versioning', headers=headers)
-        body = response.read()
-        if response.status == 200:
-            return True
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def get_versioning_status(self, headers=None):
-        """
-        Returns the current status of versioning on the bucket.
-
-        :rtype: dict
-        :returns: A dictionary containing a key named 'Versioning'
-            that can have a value of either Enabled, Disabled, or
-            Suspended. Also, if MFADelete has ever been enabled on the
-            bucket, the dictionary will contain a key named
-            'MFADelete' which will have a value of either Enabled or
-            Suspended.
-        """
-        response = self.connection.make_request('GET', self.name,
-                query_args='versioning', headers=headers)
-        body = response.read()
-        if not isinstance(body, six.string_types):
-            body = body.decode('utf-8')
-        boto.log.debug(body)
-        if response.status == 200:
-            d = {}
-            ver = re.search(self.VersionRE, body)
-            if ver:
-                d['Versioning'] = ver.group(1)
-            mfa = re.search(self.MFADeleteRE, body)
-            if mfa:
-                d['MfaDelete'] = mfa.group(1)
-            return d
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def configure_lifecycle(self, lifecycle_config, headers=None):
-        """
-        Configure lifecycle for this bucket.
-
-        :type lifecycle_config: :class:`boto.s3.lifecycle.Lifecycle`
-        :param lifecycle_config: The lifecycle configuration you want
-            to configure for this bucket.
-        """
-        xml = lifecycle_config.to_xml()
-        #xml = xml.encode('utf-8')
-        fp = StringIO(xml)
-        md5 = boto.utils.compute_md5(fp)
-        if headers is None:
-            headers = {}
-        headers['Content-MD5'] = md5[1]
-        headers['Content-Type'] = 'text/xml'
-        response = self.connection.make_request('PUT', self.name,
-                                                data=fp.getvalue(),
-                                                query_args='lifecycle',
-                                                headers=headers)
-        body = response.read()
-        if response.status == 200:
-            return True
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def get_lifecycle_config(self, headers=None):
-        """
-        Returns the current lifecycle configuration on the bucket.
-
-        :rtype: :class:`boto.s3.lifecycle.Lifecycle`
-        :returns: A LifecycleConfig object that describes all current
-            lifecycle rules in effect for the bucket.
-        """
-        response = self.connection.make_request('GET', self.name,
-                query_args='lifecycle', headers=headers)
-        body = response.read()
-        boto.log.debug(body)
-        if response.status == 200:
-            lifecycle = Lifecycle()
-            h = handler.XmlHandler(lifecycle, self)
-            if not isinstance(body, bytes):
-                body = body.encode('utf-8')
-            xml.sax.parseString(body, h)
-            return lifecycle
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def delete_lifecycle_configuration(self, headers=None):
-        """
-        Removes all lifecycle configuration from the bucket.
-        """
-        response = self.connection.make_request('DELETE', self.name,
-                                                query_args='lifecycle',
-                                                headers=headers)
-        body = response.read()
-        boto.log.debug(body)
-        if response.status == 204:
-            return True
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def configure_website(self, suffix=None, error_key=None,
-                          redirect_all_requests_to=None,
-                          routing_rules=None,
-                          headers=None):
-        """
-        Configure this bucket to act as a website
-
-        :type suffix: str
-        :param suffix: Suffix that is appended to a request that is for a
-            "directory" on the website endpoint (e.g. if the suffix is
-            index.html and you make a request to samplebucket/images/
-            the data that is returned will be for the object with the
-            key name images/index.html).  The suffix must not be empty
-            and must not include a slash character.
-
-        :type error_key: str
-        :param error_key: The object key name to use when a 4XX class
-            error occurs.  This is optional.
-
-        :type redirect_all_requests_to: :class:`boto.s3.website.RedirectLocation`
-        :param redirect_all_requests_to: Describes the redirect behavior for
-            every request to this bucket's website endpoint. If this value is
-            non None, no other values are considered when configuring the
-            website configuration for the bucket. This is an instance of
-            ``RedirectLocation``.
-
-        :type routing_rules: :class:`boto.s3.website.RoutingRules`
-        :param routing_rules: Object which specifies conditions
-            and redirects that apply when the conditions are met.
-
-        """
-        config = website.WebsiteConfiguration(
-                suffix, error_key, redirect_all_requests_to,
-                routing_rules)
-        return self.set_website_configuration(config, headers=headers)
-
-    def set_website_configuration(self, config, headers=None):
-        """
-        :type config: boto.s3.website.WebsiteConfiguration
-        :param config: Configuration data
-        """
-        return self.set_website_configuration_xml(config.to_xml(),
-          headers=headers)
-
-
-    def set_website_configuration_xml(self, xml, headers=None):
-        """Upload xml website configuration"""
-        response = self.connection.make_request('PUT', self.name, data=xml,
-                                                query_args='website',
-                                                headers=headers)
-        body = response.read()
-        if response.status == 200:
-            return True
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def get_website_configuration(self, headers=None):
-        """
-        Returns the current status of website configuration on the bucket.
-
-        :rtype: dict
-        :returns: A dictionary containing a Python representation
-            of the XML response from S3. The overall structure is:
-
-        * WebsiteConfiguration
-
-          * IndexDocument
-
-            * Suffix : suffix that is appended to request that
-              is for a "directory" on the website endpoint
-            * ErrorDocument
-
-              * Key : name of object to serve when an error occurs
-
-        """
-        return self.get_website_configuration_with_xml(headers)[0]
-
-    def get_website_configuration_obj(self, headers=None):
-        """Get the website configuration as a
-        :class:`boto.s3.website.WebsiteConfiguration` object.
-        """
-        config_xml = self.get_website_configuration_xml(headers=headers)
-        config = website.WebsiteConfiguration()
-        h = handler.XmlHandler(config, self)
-        xml.sax.parseString(config_xml, h)
-        return config
-
-    def get_website_configuration_with_xml(self, headers=None):
-        """
-        Returns the current status of website configuration on the bucket as
-        unparsed XML.
-
-        :rtype: 2-Tuple
-        :returns: 2-tuple containing:
-
-            1) A dictionary containing a Python representation \
-                of the XML response. The overall structure is:
-
-              * WebsiteConfiguration
-
-                * IndexDocument
-
-                  * Suffix : suffix that is appended to request that \
-                    is for a "directory" on the website endpoint
-
-                  * ErrorDocument
-
-                    * Key : name of object to serve when an error occurs
-
-
-            2) unparsed XML describing the bucket's website configuration
-
-        """
-
-        body = self.get_website_configuration_xml(headers=headers)
-        e = boto.jsonresponse.Element()
-        h = boto.jsonresponse.XmlHandler(e, None)
-        h.parse(body)
-        return e, body
-
-    def get_website_configuration_xml(self, headers=None):
-        """Get raw website configuration xml"""
-        response = self.connection.make_request('GET', self.name,
-                query_args='website', headers=headers)
-        body = response.read().decode('utf-8')
-        boto.log.debug(body)
-
-        if response.status != 200:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-        return body
-
-    def delete_website_configuration(self, headers=None):
-        """
-        Removes all website configuration from the bucket.
-        """
-        response = self.connection.make_request('DELETE', self.name,
-                query_args='website', headers=headers)
-        body = response.read()
-        boto.log.debug(body)
-        if response.status == 204:
-            return True
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def get_website_endpoint(self):
-        """
-        Returns the fully qualified hostname to use is you want to access this
-        bucket as a website.  This doesn't validate whether the bucket has
-        been correctly configured as a website or not.
-        """
-        l = [self.name]
-        l.append(S3WebsiteEndpointTranslate.translate_region(self.get_location()))
-        l.append('.'.join(self.connection.host.split('.')[-2:]))
-        return '.'.join(l)
-
-    def get_policy(self, headers=None):
-        """
-        Returns the JSON policy associated with the bucket.  The policy
-        is returned as an uninterpreted JSON string.
-        """
-        response = self.connection.make_request('GET', self.name,
-                query_args='policy', headers=headers)
-        body = response.read()
-        if response.status == 200:
-            return body
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def set_policy(self, policy, headers=None):
-        """
-        Add or replace the JSON policy associated with the bucket.
-
-        :type policy: str
-        :param policy: The JSON policy as a string.
-        """
-        response = self.connection.make_request('PUT', self.name,
-                                                data=policy,
-                                                query_args='policy',
-                                                headers=headers)
-        body = response.read()
-        if response.status >= 200 and response.status <= 204:
-            return True
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def delete_policy(self, headers=None):
-        response = self.connection.make_request('DELETE', self.name,
-                                                data='/?policy',
-                                                query_args='policy',
-                                                headers=headers)
-        body = response.read()
-        if response.status >= 200 and response.status <= 204:
-            return True
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def set_cors_xml(self, cors_xml, headers=None):
-        """
-        Set the CORS (Cross-Origin Resource Sharing) for a bucket.
-
-        :type cors_xml: str
-        :param cors_xml: The XML document describing your desired
-            CORS configuration.  See the S3 documentation for details
-            of the exact syntax required.
-        """
-        fp = StringIO(cors_xml)
-        md5 = boto.utils.compute_md5(fp)
-        if headers is None:
-            headers = {}
-        headers['Content-MD5'] = md5[1]
-        headers['Content-Type'] = 'text/xml'
-        response = self.connection.make_request('PUT', self.name,
-                                                data=fp.getvalue(),
-                                                query_args='cors',
-                                                headers=headers)
-        body = response.read()
-        if response.status == 200:
-            return True
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def set_cors(self, cors_config, headers=None):
-        """
-        Set the CORS for this bucket given a boto CORSConfiguration
-        object.
-
-        :type cors_config: :class:`boto.s3.cors.CORSConfiguration`
-        :param cors_config: The CORS configuration you want
-            to configure for this bucket.
-        """
-        return self.set_cors_xml(cors_config.to_xml())
-
-    def get_cors_xml(self, headers=None):
-        """
-        Returns the current CORS configuration on the bucket as an
-        XML document.
-        """
-        response = self.connection.make_request('GET', self.name,
-                query_args='cors', headers=headers)
-        body = response.read()
-        boto.log.debug(body)
-        if response.status == 200:
-            return body
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def get_cors(self, headers=None):
-        """
-        Returns the current CORS configuration on the bucket.
-
-        :rtype: :class:`boto.s3.cors.CORSConfiguration`
-        :returns: A CORSConfiguration object that describes all current
-            CORS rules in effect for the bucket.
-        """
-        body = self.get_cors_xml(headers)
-        cors = CORSConfiguration()
-        h = handler.XmlHandler(cors, self)
-        xml.sax.parseString(body, h)
-        return cors
-
-    def delete_cors(self, headers=None):
-        """
-        Removes all CORS configuration from the bucket.
-        """
-        response = self.connection.make_request('DELETE', self.name,
-                                                query_args='cors',
-                                                headers=headers)
-        body = response.read()
-        boto.log.debug(body)
-        if response.status == 204:
-            return True
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def initiate_multipart_upload(self, key_name, headers=None,
-                                  reduced_redundancy=False,
-                                  metadata=None, encrypt_key=False,
-                                  policy=None):
-        """
-        Start a multipart upload operation.
-
-        .. note::
-
-            Note: After you initiate multipart upload and upload one or more
-            parts, you must either complete or abort multipart upload in order
-            to stop getting charged for storage of the uploaded parts. Only
-            after you either complete or abort multipart upload, Amazon S3
-            frees up the parts storage and stops charging you for the parts
-            storage.
-
-        :type key_name: string
-        :param key_name: The name of the key that will ultimately
-            result from this multipart upload operation.  This will be
-            exactly as the key appears in the bucket after the upload
-            process has been completed.
-
-        :type headers: dict
-        :param headers: Additional HTTP headers to send and store with the
-            resulting key in S3.
-
-        :type reduced_redundancy: boolean
-        :param reduced_redundancy: In multipart uploads, the storage
-            class is specified when initiating the upload, not when
-            uploading individual parts.  So if you want the resulting
-            key to use the reduced redundancy storage class set this
-            flag when you initiate the upload.
-
-        :type metadata: dict
-        :param metadata: Any metadata that you would like to set on the key
-            that results from the multipart upload.
-
-        :type encrypt_key: bool
-        :param encrypt_key: If True, the new copy of the object will
-            be encrypted on the server-side by S3 and will be stored
-            in an encrypted form while at rest in S3.
-
-        :type policy: :class:`boto.s3.acl.CannedACLStrings`
-        :param policy: A canned ACL policy that will be applied to the
-            new key (once completed) in S3.
-        """
-        query_args = 'uploads'
-        provider = self.connection.provider
-        headers = headers or {}
-        if policy:
-            headers[provider.acl_header] = policy
-        if reduced_redundancy:
-            storage_class_header = provider.storage_class_header
-            if storage_class_header:
-                headers[storage_class_header] = 'REDUCED_REDUNDANCY'
-            # TODO: what if the provider doesn't support reduced redundancy?
-            # (see boto.s3.key.Key.set_contents_from_file)
-        if encrypt_key:
-            headers[provider.server_side_encryption_header] = 'AES256'
-        if metadata is None:
-            metadata = {}
-
-        headers = boto.utils.merge_meta(headers, metadata,
-                self.connection.provider)
-        response = self.connection.make_request('POST', self.name, key_name,
-                                                query_args=query_args,
-                                                headers=headers)
-        body = response.read()
-        boto.log.debug(body)
-        if response.status == 200:
-            resp = MultiPartUpload(self)
-            h = handler.XmlHandler(resp, self)
-            if not isinstance(body, bytes):
-                body = body.encode('utf-8')
-            xml.sax.parseString(body, h)
-            return resp
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def complete_multipart_upload(self, key_name, upload_id,
-                                  xml_body, headers=None):
-        """
-        Complete a multipart upload operation.
-        """
-        query_args = 'uploadId=%s' % upload_id
-        if headers is None:
-            headers = {}
-        headers['Content-Type'] = 'text/xml'
-        response = self.connection.make_request('POST', self.name, key_name,
-                                                query_args=query_args,
-                                                headers=headers, data=xml_body)
-        contains_error = False
-        body = response.read().decode('utf-8')
-        # Some errors will be reported in the body of the response
-        # even though the HTTP response code is 200.  This check
-        # does a quick and dirty peek in the body for an error element.
-        if body.find('<Error>') > 0:
-            contains_error = True
-        boto.log.debug(body)
-        if response.status == 200 and not contains_error:
-            resp = CompleteMultiPartUpload(self)
-            h = handler.XmlHandler(resp, self)
-            if not isinstance(body, bytes):
-                body = body.encode('utf-8')
-            xml.sax.parseString(body, h)
-            # Use a dummy key to parse various response headers
-            # for versioning, encryption info and then explicitly
-            # set the completed MPU object values from key.
-            k = self.key_class(self)
-            k.handle_version_headers(response)
-            k.handle_encryption_headers(response)
-            resp.version_id = k.version_id
-            resp.encrypted = k.encrypted
-            return resp
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def cancel_multipart_upload(self, key_name, upload_id, headers=None):
-        """
-        To verify that all parts have been removed, so you don't get charged
-        for the part storage, you should call the List Parts operation and
-        ensure the parts list is empty.
-        """
-        query_args = 'uploadId=%s' % upload_id
-        response = self.connection.make_request('DELETE', self.name, key_name,
-                                                query_args=query_args,
-                                                headers=headers)
-        body = response.read()
-        boto.log.debug(body)
-        if response.status != 204:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def delete(self, headers=None):
-        return self.connection.delete_bucket(self.name, headers=headers)
-
-    def get_tags(self, headers=None):
-        response = self.get_xml_tags(headers)
-        tags = Tags()
-        h = handler.XmlHandler(tags, self)
-        if not isinstance(response, bytes):
-            response = response.encode('utf-8')
-        xml.sax.parseString(response, h)
-        return tags
-
-    def get_xml_tags(self, headers=None):
-        response = self.connection.make_request('GET', self.name,
-                                                query_args='tagging',
-                                                headers=headers)
-        body = response.read()
-        if response.status == 200:
-            return body
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-
-    def set_xml_tags(self, tag_str, headers=None, query_args='tagging'):
-        if headers is None:
-            headers = {}
-        md5 = boto.utils.compute_md5(StringIO(tag_str))
-        headers['Content-MD5'] = md5[1]
-        headers['Content-Type'] = 'text/xml'
-        if not isinstance(tag_str, bytes):
-            tag_str = tag_str.encode('utf-8')
-        response = self.connection.make_request('PUT', self.name,
-                                                data=tag_str,
-                                                query_args=query_args,
-                                                headers=headers)
-        body = response.read()
-        if response.status != 204:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
-        return True
-
-    def set_tags(self, tags, headers=None):
-        return self.set_xml_tags(tags.to_xml(), headers=headers)
-
-    def delete_tags(self, headers=None):
-        response = self.connection.make_request('DELETE', self.name,
-                                                query_args='tagging',
-                                                headers=headers)
-        body = response.read()
-        boto.log.debug(body)
-        if response.status == 204:
-            return True
-        else:
-            raise self.connection.provider.storage_response_error(
-                response.status, response.reason, body)
+
+
+
+
+
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  <link rel="dns-prefetch" href="https://github.githubassets.com">
+  <link rel="dns-prefetch" href="https://avatars0.githubusercontent.com">
+  <link rel="dns-prefetch" href="https://avatars1.githubusercontent.com">
+  <link rel="dns-prefetch" href="https://avatars2.githubusercontent.com">
+  <link rel="dns-prefetch" href="https://avatars3.githubusercontent.com">
+  <link rel="dns-prefetch" href="https://github-cloud.s3.amazonaws.com">
+  <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/">
+
+
+
+  <link crossorigin="anonymous" media="all" integrity="sha512-A9QuENBx7wdV7lzJMZ1WVk18pXDoNo9VPaUEtN5LeRZAScCPV2mZygJnUxGXxcGRBofXTEc3cHqTkCjloOlPMQ==" rel="stylesheet" href="https://github.githubassets.com/assets/frameworks-574e79274f191ff598834554443b5a1c.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-5LDBQ/DhsFq/ry7aepdbc1FV0mW/0lPqH6GlYFfzzd5wo8MBz9Rb67LigKe0uKM8kK5QrA/QsJCpsE1+hOLF6w==" rel="stylesheet" href="https://github.githubassets.com/assets/site-0e25450ff46c1fbf61d504f9ffc4d784.css" />
+    <link crossorigin="anonymous" media="all" integrity="sha512-kPMIIv3a9n5JTf0DJfMtBPuVVHi89vH20wKiIYYZpeOhLIz6d+hq+LzjaqOrBSAJGfMt5vHNmRP5ToA0jp8R+Q==" rel="stylesheet" href="https://github.githubassets.com/assets/github-bc91cc1784c152eec5801a21221639a5.css" />
+    
+    
+    
+    
+
+  <meta name="viewport" content="width=device-width">
+  
+  <title>boto/bucket.py at 603d3ce3f3f3ee9ecf452772814a7231f9ef81e3 · boto/boto · GitHub</title>
+    <meta name="description" content="For the latest version of boto, see https://github.com/boto/boto3 -- Python interface to Amazon Web Services - boto/boto">
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
+  <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
+  <meta property="fb:app_id" content="1401488693436528">
+
+    
+    <meta property="og:image" content="https://avatars2.githubusercontent.com/u/327752?s=400&amp;v=4" /><meta property="og:site_name" content="GitHub" /><meta property="og:type" content="object" /><meta property="og:title" content="boto/boto" /><meta property="og:url" content="https://github.com/boto/boto" /><meta property="og:description" content="For the latest version of boto, see https://github.com/boto/boto3 -- Python interface to Amazon Web Services - boto/boto" />
+
+  <link rel="assets" href="https://github.githubassets.com/">
+  
+  <meta name="pjax-timeout" content="1000">
+  
+  <meta name="request-id" content="B6D0:79EE:8BA70:10FF37:5C92A6B9" data-pjax-transient>
+
+
+  
+
+  <meta name="selected-link" value="repo_source" data-pjax-transient>
+
+      <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+    <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+    <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
+
+  <meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="B6D0:79EE:8BA70:10FF37:5C92A6B9" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
+<meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/blob/show" data-pjax-transient="true" />
+
+
+
+    <meta name="google-analytics" content="UA-3769691-2">
+
+
+<meta class="js-ga-set" name="dimension1" content="Logged Out">
+
+
+
+  
+
+      <meta name="hostname" content="github.com">
+    <meta name="user-login" content="">
+
+      <meta name="expected-hostname" content="github.com">
+    <meta name="js-proxy-site-detection-payload" content="NjIwODY0MDljNTAwMjY1NmUyNWNiOTNmYzc2MTA1OGNiMjUwYTU3ZTE2ZWI5YmJhYjlhYTI1YTg1NTljMTA2MXx7InJlbW90ZV9hZGRyZXNzIjoiMTA0LjEzMi4xNTQuNzkiLCJyZXF1ZXN0X2lkIjoiQjZEMDo3OUVFOjhCQTcwOjEwRkYzNzo1QzkyQTZCOSIsInRpbWVzdGFtcCI6MTU1MzExNDgxMCwiaG9zdCI6ImdpdGh1Yi5jb20ifQ==">
+
+    <meta name="enabled-features" content="UNIVERSE_BANNER,MARKETPLACE_SOCIAL_PROOF,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_PLAN_RESTRICTION_EDITOR">
+
+  <meta name="html-safe-nonce" content="0d3b32bd8fea979e7ff71ca4c7753bdd4cf1ab63">
+
+  <meta http-equiv="x-pjax-version" content="261b4aeef5636e7d9ed3d5697012184b">
+  
+
+      <link href="https://github.com/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3.atom" rel="alternate" title="Recent Commits to boto:603d3ce3f3f3ee9ecf452772814a7231f9ef81e3" type="application/atom+xml">
+
+  <meta name="go-import" content="github.com/boto/boto git https://github.com/boto/boto.git">
+
+  <meta name="octolytics-dimension-user_id" content="327752" /><meta name="octolytics-dimension-user_login" content="boto" /><meta name="octolytics-dimension-repository_id" content="771016" /><meta name="octolytics-dimension-repository_nwo" content="boto/boto" /><meta name="octolytics-dimension-repository_public" content="true" /><meta name="octolytics-dimension-repository_is_fork" content="false" /><meta name="octolytics-dimension-repository_network_root_id" content="771016" /><meta name="octolytics-dimension-repository_network_root_nwo" content="boto/boto" /><meta name="octolytics-dimension-repository_explore_github_marketplace_ci_cta_shown" content="false" />
+
+
+    <link rel="canonical" href="https://github.com/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py" data-pjax-transient>
+
+
+  <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats">
+
+  <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
+
+  <link rel="mask-icon" href="https://github.githubassets.com/pinned-octocat.svg" color="#000000">
+  <link rel="icon" type="image/x-icon" class="js-site-favicon" href="https://github.githubassets.com/favicon.ico">
+
+<meta name="theme-color" content="#1e2327">
+
+
+
+
+  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
+
+  </head>
+
+  <body class="logged-out env-production page-blob">
+    
+
+  <div class="position-relative js-header-wrapper ">
+    <a href="#start-of-content" tabindex="1" class="px-2 py-4 bg-blue text-white show-on-focus js-skip-to-content">Skip to content</a>
+    <div id="js-pjax-loader-bar" class="pjax-loader-bar"><div class="progress"></div></div>
+
+    
+    
+    
+
+
+        
+<header class="Header-old header-logged-out  position-relative f4 py-3" role="banner">
+  <div class="container-lg d-flex px-3">
+    <div class="d-flex flex-justify-between flex-items-center">
+        <a class="mr-4" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark">
+          <svg height="32" class="octicon octicon-mark-github text-white" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+        </a>
+    </div>
+
+    <div class="HeaderMenu HeaderMenu--logged-out d-flex flex-justify-between flex-items-center flex-auto">
+      <div class="d-none">
+        <button class="btn-link js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
+          <svg height="24" class="octicon octicon-x text-gray" viewBox="0 0 12 16" version="1.1" width="18" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+        </button>
+      </div>
+
+        <nav class="mt-0" aria-label="Global">
+          <ul class="d-flex list-style-none">
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
+                    Why GitHub?
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 mt-0  p-4 left-n4 position-absolute">
+                    <a href="/features" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Features <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+                    <ul class="list-style-none f5 pb-3">
+                      <li class="edge-item-fix"><a href="/features/code-review/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code review">Code review</a></li>
+                      <li class="edge-item-fix"><a href="/features/project-management/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Project management">Project management</a></li>
+                      <li class="edge-item-fix"><a href="/features/integrations" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Integrations">Integrations</a></li>
+                      <li class="edge-item-fix"><a href="/features/actions" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Actions">Actions</a>
+                      <li class="edge-item-fix"><a href="/features#team-management" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team management">Team management</a></li>
+                      <li class="edge-item-fix"><a href="/features#social-coding" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Social coding">Social coding</a></li>
+                      <li class="edge-item-fix"><a href="/features#documentation" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Documentation">Documentation</a></li>
+                      <li class="edge-item-fix"><a href="/features#code-hosting" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code hosting">Code hosting</a></li>
+                    </ul>
+
+                    <ul class="list-style-none mb-0 border-lg-top pt-lg-3">
+                      <li class="edge-item-fix"><a href="/case-studies" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Customer stories">Customer stories <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="/security" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Security">Security <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+              <li class=" mr-3 mr-lg-3">
+                <a href="/enterprise" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, click, go to Enterprise">Enterprise</a>
+              </li>
+
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
+                    Explore
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
+
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-0 mt-0  p-4 left-n4 position-absolute">
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/explore" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Explore GitHub <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Learn &amp; contribute</h4>
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/topics" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Topics">Topics</a></li>
+                        <li class="edge-item-fix"><a href="/collections" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Collections">Collections</a></li>
+                      <li class="edge-item-fix"><a href="/trending" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Trending">Trending</a></li>
+                      <li class="edge-item-fix"><a href="https://lab.github.com/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Learning lab">Learning Lab</a></li>
+                      <li class="edge-item-fix"><a href="https://opensource.guide" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Open source guides">Open source guides</a></li>
+                    </ul>
+
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Connect with others</h4>
+                    <ul class="list-style-none mb-0">
+                      <li class="edge-item-fix"><a href="https://github.com/events" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Events">Events</a></li>
+                      <li class="edge-item-fix"><a href="https://github.community" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Community forum">Community forum</a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com" class="py-2 pb-0 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to GitHub Education">GitHub Education</a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+
+              <li class=" mr-3 mr-lg-3">
+                <a href="/marketplace" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Marketplace">Marketplace</a>
+              </li>
+
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
+                    Pricing
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                       <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
+
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-4 mt-0  p-4 left-n4 position-absolute">
+                    <a href="/pricing" class="pb-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Pricing">Plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/pricing#feature-comparison" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Compare features">Compare plans</a></li>
+                      <li class="edge-item-fix"><a href="https://enterprise.github.com/contact" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Compare features">Contact Sales</a></li>
+                    </ul>
+
+                    <ul class="list-style-none mb-0  border-top pt-3">
+                      <li class="edge-item-fix"><a href="/nonprofit" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Nonprofits">Nonprofit <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com" class="py-2 pb-0 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover"  data-ga-click="(Logged out) Header, go to Education">Education <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+          </ul>
+        </nav>
+
+      <div class="d-flex flex-items-center px-0 text-center text-left">
+          <div class="d-lg-flex ">
+            <div class="header-search mr-3 scoped-search site-scoped-search js-site-search position-relative js-jump-to"
+  role="combobox"
+  aria-owns="jump-to-results"
+  aria-label="Search or jump to"
+  aria-haspopup="listbox"
+  aria-expanded="false"
+>
+  <div class="position-relative">
+    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-site-search-form" role="search" aria-label="Site" data-scope-type="Repository" data-scope-id="771016" data-scoped-search-url="/boto/boto/search" data-unscoped-search-url="/search" action="/boto/boto/search" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+      <label class="form-control input-sm header-search-wrapper p-0 header-search-wrapper-jump-to position-relative d-flex flex-justify-between flex-items-center js-chromeless-input-container">
+        <input type="text"
+          class="form-control input-sm header-search-input jump-to-field js-jump-to-field js-site-search-focus js-site-search-field is-clearable"
+          data-hotkey="s,/"
+          name="q"
+          value=""
+          placeholder="Search"
+          data-unscoped-placeholder="Search GitHub"
+          data-scoped-placeholder="Search"
+          autocapitalize="off"
+          aria-autocomplete="list"
+          aria-controls="jump-to-results"
+          aria-label="Search"
+          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=OaRezg0C1tqJZjjFMMLjhetRkLI5vcwf1SuNQ44Twj5Cg/L1Hw/CSU50cz6g+YMbt5ueIiNyzscHxgrbHtVqOA=="
+          spellcheck="false"
+          autocomplete="off"
+          >
+          <input type="hidden" class="js-site-search-type-field" name="type" >
+            <img src="https://github.githubassets.com/images/search-key-slash.svg" alt="" class="mr-2 header-search-key-slash">
+
+            <div class="Box position-absolute overflow-hidden d-none jump-to-suggestions js-jump-to-suggestions-container">
+              
+<ul class="d-none js-jump-to-suggestions-template-container">
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-suggestion" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+</ul>
+
+<ul class="d-none js-jump-to-no-results-template-container">
+  <li class="d-flex flex-justify-center flex-items-center f5 d-none js-jump-to-suggestion p-2">
+    <span class="text-gray">No suggested jump to results</span>
+  </li>
+</ul>
+
+<ul id="jump-to-results" role="listbox" class="p-0 m-0 js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container">
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-scoped-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-global-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+
+</ul>
+
+            </div>
+      </label>
+</form>  </div>
+</div>
+
+          </div>
+
+        <a class="HeaderMenu-link no-underline mr-3" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;B6D0:79EE:8BA70:10FF37:5C92A6B9&quot;,&quot;originating_url&quot;:&quot;https://github.com/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="a57fcf380641741a5fc493468f26d55cd923568fe9746e42d289c57779fac3e0" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in" href="/login?return_to=%2Fboto%2Fboto%2Fblob%2F603d3ce3f3f3ee9ecf452772814a7231f9ef81e3%2Fboto%2Fs3%2Fbucket.py">
+          Sign&nbsp;in
+</a>          <a class="HeaderMenu-link d-inline-block no-underline border border-gray-dark rounded-1 px-2 py-1" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;B6D0:79EE:8BA70:10FF37:5C92A6B9&quot;,&quot;originating_url&quot;:&quot;https://github.com/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="1361130f02b3e4b5a14444b3b165edc18214250c45088e7576f16c1ecc24667e" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up" href="/join">
+            Sign&nbsp;up
+</a>      </div>
+    </div>
+  </div>
+</header>
+
+  </div>
+
+  <div id="start-of-content" class="show-on-focus"></div>
+
+    <div id="js-flash-container">
+
+</div>
+
+
+
+  <div class="application-main " data-commit-hovercards-enabled>
+        <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
+    <main id="js-repo-pjax-container" data-pjax-container >
+      
+
+
+  
+
+
+
+  
+
+
+
+
+  <div class="pagehead repohead instapaper_ignore readability-menu experiment-repo-nav  ">
+    <div class="repohead-details-container clearfix container">
+
+      <ul class="pagehead-actions">
+
+
+
+  <li>
+      <a class="btn btn-sm btn-with-count tooltipped tooltipped-s" aria-label="You must be signed in to watch a repository" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;notification subscription menu watch&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;B6D0:79EE:8BA70:10FF37:5C92A6B9&quot;,&quot;originating_url&quot;:&quot;https://github.com/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="6f4efd2d86b503c38487375bc9de82eab4776b3d7220641f573b10e961e0cc8f" href="/login?return_to=%2Fboto%2Fboto">
+    <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
+    Watch
+</a>  <a class="social-count" href="/boto/boto/watchers"
+     aria-label="311 users are watching this repository">
+    311
+  </a>
+
+  </li>
+
+  <li>
+        <a class="btn btn-sm btn-with-count tooltipped tooltipped-s" aria-label="You must be signed in to star a repository" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;star button&quot;,&quot;repository_id&quot;:771016,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;B6D0:79EE:8BA70:10FF37:5C92A6B9&quot;,&quot;originating_url&quot;:&quot;https://github.com/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="0fadc398996d2b684b5ef96adcfb735d7f94ef05e9457337de7ca3eb498a91f2" href="/login?return_to=%2Fboto%2Fboto">
+      <svg class="octicon octicon-star v-align-text-bottom" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
+      Star
+</a>
+    <a class="social-count js-social-count" href="/boto/boto/stargazers"
+      aria-label="6291 users starred this repository">
+      6,291
+    </a>
+
+  </li>
+
+  <li>
+      <a class="btn btn-sm btn-with-count tooltipped tooltipped-s" aria-label="You must be signed in to fork a repository" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;repo details fork button&quot;,&quot;repository_id&quot;:771016,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;B6D0:79EE:8BA70:10FF37:5C92A6B9&quot;,&quot;originating_url&quot;:&quot;https://github.com/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="cbb74df12f53c4feead762469ebab7d5969d0f1fafd1ce03345af813dbb80386" href="/login?return_to=%2Fboto%2Fboto">
+        <svg class="octicon octicon-repo-forked v-align-text-bottom" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
+        Fork
+</a>
+    <a href="/boto/boto/network/members" class="social-count"
+       aria-label="2279 users forked this repository">
+      2,279
+    </a>
+  </li>
+</ul>
+
+      <h1 class="public ">
+  <svg class="octicon octicon-repo" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+  <span class="author" itemprop="author"><a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/boto/hovercard" href="/boto">boto</a></span><!--
+--><span class="path-divider">/</span><!--
+--><strong itemprop="name"><a data-pjax="#js-repo-pjax-container" href="/boto/boto">boto</a></strong>
+
+</h1>
+
+    </div>
+    
+<nav class="reponav js-repo-nav js-sidenav-container-pjax container"
+     itemscope
+     itemtype="http://schema.org/BreadcrumbList"
+    aria-label="Repository"
+     data-pjax="#js-repo-pjax-container">
+
+  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+    <a class="js-selected-navigation-item selected reponav-item" itemprop="url" data-hotkey="g c" aria-current="page" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /boto/boto" href="/boto/boto">
+      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"/></svg>
+      <span itemprop="name">Code</span>
+      <meta itemprop="position" content="1">
+</a>  </span>
+
+    <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+      <a itemprop="url" data-hotkey="g i" class="js-selected-navigation-item reponav-item" data-selected-links="repo_issues repo_labels repo_milestones /boto/boto/issues" href="/boto/boto/issues">
+        <svg class="octicon octicon-issue-opened" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"/></svg>
+        <span itemprop="name">Issues</span>
+        <span class="Counter">785</span>
+        <meta itemprop="position" content="2">
+</a>    </span>
+
+  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+    <a data-hotkey="g p" itemprop="url" class="js-selected-navigation-item reponav-item" data-selected-links="repo_pulls checks /boto/boto/pulls" href="/boto/boto/pulls">
+      <svg class="octicon octicon-git-pull-request" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
+      <span itemprop="name">Pull requests</span>
+      <span class="Counter">381</span>
+      <meta itemprop="position" content="3">
+</a>  </span>
+
+
+    <a data-hotkey="g b" class="js-selected-navigation-item reponav-item" data-selected-links="repo_projects new_repo_project repo_project /boto/boto/projects" href="/boto/boto/projects">
+      <svg class="octicon octicon-project" viewBox="0 0 15 16" version="1.1" width="15" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      Projects
+      <span class="Counter" >0</span>
+</a>
+
+
+    <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse alerts security people /boto/boto/pulse" href="/boto/boto/pulse">
+      <svg class="octicon octicon-graph" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"/></svg>
+      Insights
+</a>
+
+</nav>
+
+
+  </div>
+<div class="container new-discussion-timeline experiment-repo-nav  ">
+  <div class="repository-content ">
+
+    
+    
+
+
+
+  
+    <a class="d-none js-permalink-shortcut" data-hotkey="y" href="/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py">Permalink</a>
+
+    <!-- blob contrib key: blob_contributors:v21:87ce23e7050062f662206e6cbdf01f0e -->
+
+        <div class="signup-prompt-bg rounded-1">
+      <div class="signup-prompt p-4 text-center mb-4 rounded-1">
+        <div class="position-relative">
+          <!-- '"` --><!-- </textarea></xmp> --></option></form><form action="/site/dismiss_signup_prompt" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="A2DvcViUixkdGT7+sSgg5mP3MqDVb9awMStWKlYj/39cAhPr9wf8xV+lcuskDzUcKtXl1vtilUAfjbnfuzDLew==" />
+            <button type="submit" class="position-absolute top-0 right-0 btn-link link-gray" data-ga-click="(Logged out) Sign up prompt, clicked Dismiss, text:dismiss">
+              Dismiss
+            </button>
+</form>          <h3 class="pt-2">Join GitHub today</h3>
+          <p class="col-6 mx-auto">GitHub is home to over 31 million developers working together to host and review code, manage projects, and build software together.</p>
+          <a class="btn btn-primary" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;files signup prompt&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;B6D0:79EE:8BA70:10FF37:5C92A6B9&quot;,&quot;originating_url&quot;:&quot;https://github.com/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="f62270455eaf0a8f6d376afbad7becaf71d4c78d86aeaf874a3904b4f014aa3a" data-ga-click="(Logged out) Sign up prompt, clicked Sign up, text:sign-up" href="/join?source=prompt-blob-show">Sign up</a>
+        </div>
+      </div>
+    </div>
+
+
+    <div class="d-flex flex-shrink-0 flex-items-center mb-3">
+      
+<details class="details-reset details-overlay select-menu branch-select-menu">
+  <summary class="btn btn-sm select-menu-button css-truncate"
+           data-hotkey="w"
+           
+           title="Switch branches or tags">
+    <i>Tree:</i>
+    <span class="css-truncate-target">603d3ce3f3</span>
+  </summary>
+
+  <details-menu class="select-menu-modal position-absolute" style="z-index: 99;" src="/boto/boto/ref-list/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?source_action=show&amp;source_controller=blob" preload>
+    <include-fragment class="select-menu-loading-overlay anim-pulse">
+      <svg height="32" class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"/></svg>
+    </include-fragment>
+  </details-menu>
+</details>
+
+      <div id="blob-path" class="breadcrumb flex-auto ml-2">
+        <span class="js-repo-root text-bold"><span class="js-path-segment"><a data-pjax="true" rel="nofollow" href="/boto/boto/tree/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3"><span>boto</span></a></span></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" rel="nofollow" href="/boto/boto/tree/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto"><span>boto</span></a></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" rel="nofollow" href="/boto/boto/tree/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3"><span>s3</span></a></span><span class="separator">/</span><strong class="final-path">bucket.py</strong>
+      </div>
+      <div class="BtnGroup">
+        <a href="/boto/boto/find/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3"
+              class="js-pjax-capture-input btn btn-sm BtnGroup-item"
+              data-pjax
+              data-hotkey="t">
+          Find file
+        </a>
+        <clipboard-copy for="blob-path" class="btn btn-sm BtnGroup-item">
+          Copy path
+        </clipboard-copy>
+      </div>
+    </div>
+
+
+
+    
+  <div class="Box Box--condensed d-flex flex-column flex-shrink-0">
+      <div class="Box-body d-flex flex-justify-between bg-blue-light flex-items-center">
+        <span class="pr-md-4 f6">
+          <a rel="contributor" data-skip-pjax="true" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=43632885" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/catleeball"><img class="avatar" src="https://avatars1.githubusercontent.com/u/43632885?s=40&amp;v=4" width="20" height="20" alt="@catleeball" /></a>
+          <a class="text-bold link-gray-dark lh-default v-align-middle" rel="contributor" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=43632885" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/catleeball">catleeball</a>
+            <span class="lh-default v-align-middle">
+              <a data-pjax="true" title="Adding the rest of Ed&#39;s boto changes" class="link-gray" href="/boto/boto/commit/9cb3ef473d08a4b65515e8750ef05e21ca1f3984">Adding the rest of Ed's boto changes</a>
+            </span>
+        </span>
+        <span class="d-inline-block flex-shrink-0 v-align-bottom f6">
+          <a class="pr-2 text-mono link-gray" href="/boto/boto/commit/9cb3ef473d08a4b65515e8750ef05e21ca1f3984" data-pjax>
+            9cb3ef4
+          </a>
+          <relative-time datetime="2019-01-09T23:40:46Z">Jan 9, 2019</relative-time>
+        </span>
+      </div>
+
+    <div class="Box-body d-flex flex-items-center flex-auto f6 border-bottom-0" >
+      
+<details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark float-left mr-2" id="blob_contributors_box">
+  <summary
+      class="btn-link"
+      aria-haspopup="dialog"
+      
+      
+      >
+    
+    <span><strong>49</strong> contributors</span>
+  </summary>
+  <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast " aria-label="Users who have contributed to this file">
+    <div class="Box-header">
+      <button class="Box-btn-octicon btn-octicon float-right" type="button" aria-label="Close dialog" data-close-dialog>
+        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+      </button>
+      <h3 class="Box-title">Users who have contributed to this file</h3>
+    </div>
+    
+        <ul class="list-style-none overflow-auto">
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/garnaat">
+                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/2056?s=40&amp;v=4" width="20" height="20" />
+                garnaat
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/toastdriven">
+                <img class="avatar mr-1" alt="" src="https://avatars0.githubusercontent.com/u/2449?s=40&amp;v=4" width="20" height="20" />
+                toastdriven
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/danielgtaylor">
+                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/106826?s=40&amp;v=4" width="20" height="20" />
+                danielgtaylor
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/mfschwartz">
+                <img class="avatar mr-1" alt="" src="https://avatars3.githubusercontent.com/u/333551?s=40&amp;v=4" width="20" height="20" />
+                mfschwartz
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/jamesls">
+                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/368057?s=40&amp;v=4" width="20" height="20" />
+                jamesls
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/marcacohen">
+                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/658327?s=40&amp;v=4" width="20" height="20" />
+                marcacohen
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/tpodowd">
+                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/235524?s=40&amp;v=4" width="20" height="20" />
+                tpodowd
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/sievlev">
+                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/241111?s=40&amp;v=4" width="20" height="20" />
+                sievlev
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/kouk">
+                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/456007?s=40&amp;v=4" width="20" height="20" />
+                kouk
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/yovadia">
+                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/1914389?s=40&amp;v=4" width="20" height="20" />
+                yovadia
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/fabiant7t">
+                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/81570?s=40&amp;v=4" width="20" height="20" />
+                fabiant7t
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/davbo">
+                <img class="avatar mr-1" alt="" src="https://avatars3.githubusercontent.com/u/330135?s=40&amp;v=4" width="20" height="20" />
+                davbo
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/catleeball">
+                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/43632885?s=40&amp;v=4" width="20" height="20" />
+                catleeball
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/zwilt">
+                <img class="avatar mr-1" alt="" src="https://avatars0.githubusercontent.com/u/3579806?s=40&amp;v=4" width="20" height="20" />
+                zwilt
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/tobiaspal">
+                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/297953?s=40&amp;v=4" width="20" height="20" />
+                tobiaspal
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/tmclane">
+                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/511975?s=40&amp;v=4" width="20" height="20" />
+                tmclane
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/krallin">
+                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/1737686?s=40&amp;v=4" width="20" height="20" />
+                krallin
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/showard">
+                <img class="avatar mr-1" alt="" src="https://avatars0.githubusercontent.com/u/445027?s=40&amp;v=4" width="20" height="20" />
+                showard
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/pasc">
+                <img class="avatar mr-1" alt="" src="https://avatars3.githubusercontent.com/u/56096?s=40&amp;v=4" width="20" height="20" />
+                pasc
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/opottone">
+                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/8319326?s=40&amp;v=4" width="20" height="20" />
+                opottone
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/najeira">
+                <img class="avatar mr-1" alt="" src="https://avatars3.githubusercontent.com/u/1098127?s=40&amp;v=4" width="20" height="20" />
+                najeira
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/markhjelm">
+                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/24922726?s=40&amp;v=4" width="20" height="20" />
+                markhjelm
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/marascio">
+                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/53063?s=40&amp;v=4" width="20" height="20" />
+                marascio
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/kyleknap">
+                <img class="avatar mr-1" alt="" src="https://avatars0.githubusercontent.com/u/4605355?s=40&amp;v=4" width="20" height="20" />
+                kyleknap
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/jtriley">
+                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/46910?s=40&amp;v=4" width="20" height="20" />
+                jtriley
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/jianli">
+                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/1527821?s=40&amp;v=4" width="20" height="20" />
+                jianli
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/houglum">
+                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/14894525?s=40&amp;v=4" width="20" height="20" />
+                houglum
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/gleicon">
+                <img class="avatar mr-1" alt="" src="https://avatars0.githubusercontent.com/u/38321?s=40&amp;v=4" width="20" height="20" />
+                gleicon
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/gholms">
+                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/92943?s=40&amp;v=4" width="20" height="20" />
+                gholms
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/daviddpark">
+                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/383789?s=40&amp;v=4" width="20" height="20" />
+                daviddpark
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/callahad">
+                <img class="avatar mr-1" alt="" src="https://avatars3.githubusercontent.com/u/24193?s=40&amp;v=4" width="20" height="20" />
+                callahad
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/brimcfadden">
+                <img class="avatar mr-1" alt="" src="https://avatars3.githubusercontent.com/u/276142?s=40&amp;v=4" width="20" height="20" />
+                brimcfadden
+</a>            </li>
+            <li class="Box-row">
+              <a class="link-gray-dark no-underline" href="/JJC1138">
+                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/428774?s=40&amp;v=4" width="20" height="20" />
+                JJC1138
+</a>            </li>
+        </ul>
+
+  </details-dialog>
+</details>
+          <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=2056" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=garnaat">
+      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/2056?s=40&amp;v=4" width="20" height="20" alt="@garnaat" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=2449" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=toastdriven">
+      <img class="avatar mr-1" src="https://avatars0.githubusercontent.com/u/2449?s=40&amp;v=4" width="20" height="20" alt="@toastdriven" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=106826" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=danielgtaylor">
+      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/106826?s=40&amp;v=4" width="20" height="20" alt="@danielgtaylor" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=333551" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=mfschwartz">
+      <img class="avatar mr-1" src="https://avatars3.githubusercontent.com/u/333551?s=40&amp;v=4" width="20" height="20" alt="@mfschwartz" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=368057" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=jamesls">
+      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/368057?s=40&amp;v=4" width="20" height="20" alt="@jamesls" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=658327" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=marcacohen">
+      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/658327?s=40&amp;v=4" width="20" height="20" alt="@marcacohen" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=235524" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=tpodowd">
+      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/235524?s=40&amp;v=4" width="20" height="20" alt="@tpodowd" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=241111" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=sievlev">
+      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/241111?s=40&amp;v=4" width="20" height="20" alt="@sievlev" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=456007" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=kouk">
+      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/456007?s=40&amp;v=4" width="20" height="20" alt="@kouk" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1914389" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=yovadia">
+      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/1914389?s=40&amp;v=4" width="20" height="20" alt="@yovadia" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=81570" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=fabiant7t">
+      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/81570?s=40&amp;v=4" width="20" height="20" alt="@fabiant7t" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=330135" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=davbo">
+      <img class="avatar mr-1" src="https://avatars3.githubusercontent.com/u/330135?s=40&amp;v=4" width="20" height="20" alt="@davbo" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=43632885" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=catleeball">
+      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/43632885?s=40&amp;v=4" width="20" height="20" alt="@catleeball" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=3579806" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=zwilt">
+      <img class="avatar mr-1" src="https://avatars0.githubusercontent.com/u/3579806?s=40&amp;v=4" width="20" height="20" alt="@zwilt" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=297953" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=tobiaspal">
+      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/297953?s=40&amp;v=4" width="20" height="20" alt="@tobiaspal" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=511975" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=tmclane">
+      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/511975?s=40&amp;v=4" width="20" height="20" alt="@tmclane" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1737686" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=krallin">
+      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/1737686?s=40&amp;v=4" width="20" height="20" alt="@krallin" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=445027" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=showard">
+      <img class="avatar mr-1" src="https://avatars0.githubusercontent.com/u/445027?s=40&amp;v=4" width="20" height="20" alt="@showard" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=56096" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=pasc">
+      <img class="avatar mr-1" src="https://avatars3.githubusercontent.com/u/56096?s=40&amp;v=4" width="20" height="20" alt="@pasc" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=8319326" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=opottone">
+      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/8319326?s=40&amp;v=4" width="20" height="20" alt="@opottone" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1098127" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=najeira">
+      <img class="avatar mr-1" src="https://avatars3.githubusercontent.com/u/1098127?s=40&amp;v=4" width="20" height="20" alt="@najeira" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=24922726" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=markhjelm">
+      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/24922726?s=40&amp;v=4" width="20" height="20" alt="@markhjelm" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=53063" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=marascio">
+      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/53063?s=40&amp;v=4" width="20" height="20" alt="@marascio" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=4605355" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=kyleknap">
+      <img class="avatar mr-1" src="https://avatars0.githubusercontent.com/u/4605355?s=40&amp;v=4" width="20" height="20" alt="@kyleknap" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=46910" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=jtriley">
+      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/46910?s=40&amp;v=4" width="20" height="20" alt="@jtriley" /> 
+</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1527821" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=jianli">
+      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/1527821?s=40&amp;v=4" width="20" height="20" alt="@jianli" /> 
+</a>
+    <button type="button" class="btn-link lh-default" data-toggle-for="blob_contributors_box">and others</button>
+
+    </div>
+  </div>
+
+
+
+
+
+    <div class="Box mt-3 position-relative">
+      
+<div class="Box-header py-2 d-flex flex-justify-between flex-items-center">
+
+  <div class="text-mono f6">
+      1884 lines (1628 sloc)
+      <span class="file-info-divider"></span>
+    77.9 KB
+  </div>
+
+  <div class="d-flex">
+
+    <div class="BtnGroup">
+      <a id="raw-url" class="btn btn-sm BtnGroup-item" href="/boto/boto/raw/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py">Raw</a>
+        <a class="btn btn-sm js-update-url-with-hash BtnGroup-item" data-hotkey="b" href="/boto/boto/blame/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py">Blame</a>
+      <a rel="nofollow" class="btn btn-sm BtnGroup-item" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py">History</a>
+    </div>
+
+
+    <div>
+
+          <button type="button" class="btn-octicon disabled tooltipped tooltipped-nw"
+            aria-label="You must be signed in to make or propose changes">
+            <svg class="octicon octicon-pencil" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"/></svg>
+          </button>
+          <button type="button" class="btn-octicon btn-octicon-danger disabled tooltipped tooltipped-nw"
+            aria-label="You must be signed in to make or propose changes">
+            <svg class="octicon octicon-trashcan" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"/></svg>
+          </button>
+    </div>
+  </div>
+</div>
+
+      
+
+  <div itemprop="text" class="Box-body px-0 blob-wrapper data type-python ">
+      
+<table class="highlight tab-size js-file-line-container" data-tab-size="8">
+      <tr>
+        <td id="L1" class="blob-num js-line-number" data-line-number="1"></td>
+        <td id="LC1" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> Copyright (c) 2006-2010 Mitch Garnaat http://garnaat.org/</span></td>
+      </tr>
+      <tr>
+        <td id="L2" class="blob-num js-line-number" data-line-number="2"></td>
+        <td id="LC2" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> Copyright (c) 2010, Eucalyptus Systems, Inc.</span></td>
+      </tr>
+      <tr>
+        <td id="L3" class="blob-num js-line-number" data-line-number="3"></td>
+        <td id="LC3" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> All rights reserved.</span></td>
+      </tr>
+      <tr>
+        <td id="L4" class="blob-num js-line-number" data-line-number="4"></td>
+        <td id="LC4" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span></span></td>
+      </tr>
+      <tr>
+        <td id="L5" class="blob-num js-line-number" data-line-number="5"></td>
+        <td id="LC5" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> Permission is hereby granted, free of charge, to any person obtaining a</span></td>
+      </tr>
+      <tr>
+        <td id="L6" class="blob-num js-line-number" data-line-number="6"></td>
+        <td id="LC6" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> copy of this software and associated documentation files (the</span></td>
+      </tr>
+      <tr>
+        <td id="L7" class="blob-num js-line-number" data-line-number="7"></td>
+        <td id="LC7" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> &quot;Software&quot;), to deal in the Software without restriction, including</span></td>
+      </tr>
+      <tr>
+        <td id="L8" class="blob-num js-line-number" data-line-number="8"></td>
+        <td id="LC8" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> without limitation the rights to use, copy, modify, merge, publish, dis-</span></td>
+      </tr>
+      <tr>
+        <td id="L9" class="blob-num js-line-number" data-line-number="9"></td>
+        <td id="LC9" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> tribute, sublicense, and/or sell copies of the Software, and to permit</span></td>
+      </tr>
+      <tr>
+        <td id="L10" class="blob-num js-line-number" data-line-number="10"></td>
+        <td id="LC10" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> persons to whom the Software is furnished to do so, subject to the fol-</span></td>
+      </tr>
+      <tr>
+        <td id="L11" class="blob-num js-line-number" data-line-number="11"></td>
+        <td id="LC11" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> lowing conditions:</span></td>
+      </tr>
+      <tr>
+        <td id="L12" class="blob-num js-line-number" data-line-number="12"></td>
+        <td id="LC12" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span></span></td>
+      </tr>
+      <tr>
+        <td id="L13" class="blob-num js-line-number" data-line-number="13"></td>
+        <td id="LC13" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> The above copyright notice and this permission notice shall be included</span></td>
+      </tr>
+      <tr>
+        <td id="L14" class="blob-num js-line-number" data-line-number="14"></td>
+        <td id="LC14" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> in all copies or substantial portions of the Software.</span></td>
+      </tr>
+      <tr>
+        <td id="L15" class="blob-num js-line-number" data-line-number="15"></td>
+        <td id="LC15" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span></span></td>
+      </tr>
+      <tr>
+        <td id="L16" class="blob-num js-line-number" data-line-number="16"></td>
+        <td id="LC16" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS</span></td>
+      </tr>
+      <tr>
+        <td id="L17" class="blob-num js-line-number" data-line-number="17"></td>
+        <td id="LC17" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-</span></td>
+      </tr>
+      <tr>
+        <td id="L18" class="blob-num js-line-number" data-line-number="18"></td>
+        <td id="LC18" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT</span></td>
+      </tr>
+      <tr>
+        <td id="L19" class="blob-num js-line-number" data-line-number="19"></td>
+        <td id="LC19" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,</span></td>
+      </tr>
+      <tr>
+        <td id="L20" class="blob-num js-line-number" data-line-number="20"></td>
+        <td id="LC20" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,</span></td>
+      </tr>
+      <tr>
+        <td id="L21" class="blob-num js-line-number" data-line-number="21"></td>
+        <td id="LC21" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS</span></td>
+      </tr>
+      <tr>
+        <td id="L22" class="blob-num js-line-number" data-line-number="22"></td>
+        <td id="LC22" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> IN THE SOFTWARE.</span></td>
+      </tr>
+      <tr>
+        <td id="L23" class="blob-num js-line-number" data-line-number="23"></td>
+        <td id="LC23" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L24" class="blob-num js-line-number" data-line-number="24"></td>
+        <td id="LC24" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> <span class="pl-c1">__future__</span> <span class="pl-k">import</span> division</td>
+      </tr>
+      <tr>
+        <td id="L25" class="blob-num js-line-number" data-line-number="25"></td>
+        <td id="LC25" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L26" class="blob-num js-line-number" data-line-number="26"></td>
+        <td id="LC26" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> boto</td>
+      </tr>
+      <tr>
+        <td id="L27" class="blob-num js-line-number" data-line-number="27"></td>
+        <td id="LC27" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto <span class="pl-k">import</span> handler</td>
+      </tr>
+      <tr>
+        <td id="L28" class="blob-num js-line-number" data-line-number="28"></td>
+        <td id="LC28" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.resultset <span class="pl-k">import</span> ResultSet</td>
+      </tr>
+      <tr>
+        <td id="L29" class="blob-num js-line-number" data-line-number="29"></td>
+        <td id="LC29" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.exception <span class="pl-k">import</span> BotoClientError</td>
+      </tr>
+      <tr>
+        <td id="L30" class="blob-num js-line-number" data-line-number="30"></td>
+        <td id="LC30" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.acl <span class="pl-k">import</span> Policy, CannedACLStrings, Grant</td>
+      </tr>
+      <tr>
+        <td id="L31" class="blob-num js-line-number" data-line-number="31"></td>
+        <td id="LC31" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.key <span class="pl-k">import</span> Key</td>
+      </tr>
+      <tr>
+        <td id="L32" class="blob-num js-line-number" data-line-number="32"></td>
+        <td id="LC32" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.prefix <span class="pl-k">import</span> Prefix</td>
+      </tr>
+      <tr>
+        <td id="L33" class="blob-num js-line-number" data-line-number="33"></td>
+        <td id="LC33" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.deletemarker <span class="pl-k">import</span> DeleteMarker</td>
+      </tr>
+      <tr>
+        <td id="L34" class="blob-num js-line-number" data-line-number="34"></td>
+        <td id="LC34" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.multipart <span class="pl-k">import</span> MultiPartUpload</td>
+      </tr>
+      <tr>
+        <td id="L35" class="blob-num js-line-number" data-line-number="35"></td>
+        <td id="LC35" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.multipart <span class="pl-k">import</span> CompleteMultiPartUpload</td>
+      </tr>
+      <tr>
+        <td id="L36" class="blob-num js-line-number" data-line-number="36"></td>
+        <td id="LC36" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.multidelete <span class="pl-k">import</span> MultiDeleteResult</td>
+      </tr>
+      <tr>
+        <td id="L37" class="blob-num js-line-number" data-line-number="37"></td>
+        <td id="LC37" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.multidelete <span class="pl-k">import</span> Error</td>
+      </tr>
+      <tr>
+        <td id="L38" class="blob-num js-line-number" data-line-number="38"></td>
+        <td id="LC38" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.bucketlistresultset <span class="pl-k">import</span> BucketListResultSet</td>
+      </tr>
+      <tr>
+        <td id="L39" class="blob-num js-line-number" data-line-number="39"></td>
+        <td id="LC39" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.bucketlistresultset <span class="pl-k">import</span> VersionedBucketListResultSet</td>
+      </tr>
+      <tr>
+        <td id="L40" class="blob-num js-line-number" data-line-number="40"></td>
+        <td id="LC40" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.bucketlistresultset <span class="pl-k">import</span> MultiPartUploadListResultSet</td>
+      </tr>
+      <tr>
+        <td id="L41" class="blob-num js-line-number" data-line-number="41"></td>
+        <td id="LC41" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.lifecycle <span class="pl-k">import</span> Lifecycle</td>
+      </tr>
+      <tr>
+        <td id="L42" class="blob-num js-line-number" data-line-number="42"></td>
+        <td id="LC42" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.tagging <span class="pl-k">import</span> Tags</td>
+      </tr>
+      <tr>
+        <td id="L43" class="blob-num js-line-number" data-line-number="43"></td>
+        <td id="LC43" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.cors <span class="pl-k">import</span> CORSConfiguration</td>
+      </tr>
+      <tr>
+        <td id="L44" class="blob-num js-line-number" data-line-number="44"></td>
+        <td id="LC44" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.bucketlogging <span class="pl-k">import</span> BucketLogging</td>
+      </tr>
+      <tr>
+        <td id="L45" class="blob-num js-line-number" data-line-number="45"></td>
+        <td id="LC45" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3 <span class="pl-k">import</span> website</td>
+      </tr>
+      <tr>
+        <td id="L46" class="blob-num js-line-number" data-line-number="46"></td>
+        <td id="LC46" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> boto.jsonresponse</td>
+      </tr>
+      <tr>
+        <td id="L47" class="blob-num js-line-number" data-line-number="47"></td>
+        <td id="LC47" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> boto.utils</td>
+      </tr>
+      <tr>
+        <td id="L48" class="blob-num js-line-number" data-line-number="48"></td>
+        <td id="LC48" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> xml.sax</td>
+      </tr>
+      <tr>
+        <td id="L49" class="blob-num js-line-number" data-line-number="49"></td>
+        <td id="LC49" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> xml.sax.saxutils</td>
+      </tr>
+      <tr>
+        <td id="L50" class="blob-num js-line-number" data-line-number="50"></td>
+        <td id="LC50" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> re</td>
+      </tr>
+      <tr>
+        <td id="L51" class="blob-num js-line-number" data-line-number="51"></td>
+        <td id="LC51" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> base64</td>
+      </tr>
+      <tr>
+        <td id="L52" class="blob-num js-line-number" data-line-number="52"></td>
+        <td id="LC52" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> collections <span class="pl-k">import</span> defaultdict</td>
+      </tr>
+      <tr>
+        <td id="L53" class="blob-num js-line-number" data-line-number="53"></td>
+        <td id="LC53" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.compat <span class="pl-k">import</span> BytesIO, six, StringIO, urllib</td>
+      </tr>
+      <tr>
+        <td id="L54" class="blob-num js-line-number" data-line-number="54"></td>
+        <td id="LC54" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L55" class="blob-num js-line-number" data-line-number="55"></td>
+        <td id="LC55" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> as per http://goo.gl/BDuud (02/19/2011)</span></td>
+      </tr>
+      <tr>
+        <td id="L56" class="blob-num js-line-number" data-line-number="56"></td>
+        <td id="LC56" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L57" class="blob-num js-line-number" data-line-number="57"></td>
+        <td id="LC57" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L58" class="blob-num js-line-number" data-line-number="58"></td>
+        <td id="LC58" class="blob-code blob-code-inner js-file-line"><span class="pl-k">class</span> <span class="pl-en">S3WebsiteEndpointTranslate</span>(<span class="pl-c1">object</span>):</td>
+      </tr>
+      <tr>
+        <td id="L59" class="blob-num js-line-number" data-line-number="59"></td>
+        <td id="LC59" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L60" class="blob-num js-line-number" data-line-number="60"></td>
+        <td id="LC60" class="blob-code blob-code-inner js-file-line">    trans_region <span class="pl-k">=</span> defaultdict(<span class="pl-k">lambda</span>: <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-us-east-1<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L61" class="blob-num js-line-number" data-line-number="61"></td>
+        <td id="LC61" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>eu-west-1<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-eu-west-1<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L62" class="blob-num js-line-number" data-line-number="62"></td>
+        <td id="LC62" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>eu-central-1<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website.eu-central-1<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L63" class="blob-num js-line-number" data-line-number="63"></td>
+        <td id="LC63" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>us-west-1<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-us-west-1<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L64" class="blob-num js-line-number" data-line-number="64"></td>
+        <td id="LC64" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>us-west-2<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-us-west-2<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L65" class="blob-num js-line-number" data-line-number="65"></td>
+        <td id="LC65" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>sa-east-1<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-sa-east-1<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L66" class="blob-num js-line-number" data-line-number="66"></td>
+        <td id="LC66" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>ap-northeast-1<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-ap-northeast-1<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L67" class="blob-num js-line-number" data-line-number="67"></td>
+        <td id="LC67" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>ap-southeast-1<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-ap-southeast-1<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L68" class="blob-num js-line-number" data-line-number="68"></td>
+        <td id="LC68" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>ap-southeast-2<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-ap-southeast-2<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L69" class="blob-num js-line-number" data-line-number="69"></td>
+        <td id="LC69" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>cn-north-1<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website.cn-north-1<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L70" class="blob-num js-line-number" data-line-number="70"></td>
+        <td id="LC70" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L71" class="blob-num js-line-number" data-line-number="71"></td>
+        <td id="LC71" class="blob-code blob-code-inner js-file-line">    <span class="pl-en">@</span><span class="pl-c1">classmethod</span></td>
+      </tr>
+      <tr>
+        <td id="L72" class="blob-num js-line-number" data-line-number="72"></td>
+        <td id="LC72" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">translate_region</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">reg</span>):</td>
+      </tr>
+      <tr>
+        <td id="L73" class="blob-num js-line-number" data-line-number="73"></td>
+        <td id="LC73" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.trans_region[reg]</td>
+      </tr>
+      <tr>
+        <td id="L74" class="blob-num js-line-number" data-line-number="74"></td>
+        <td id="LC74" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L75" class="blob-num js-line-number" data-line-number="75"></td>
+        <td id="LC75" class="blob-code blob-code-inner js-file-line">S3Permissions <span class="pl-k">=</span> [<span class="pl-s"><span class="pl-pds">&#39;</span>READ<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>WRITE<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>READ_ACP<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>WRITE_ACP<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>FULL_CONTROL<span class="pl-pds">&#39;</span></span>]</td>
+      </tr>
+      <tr>
+        <td id="L76" class="blob-num js-line-number" data-line-number="76"></td>
+        <td id="LC76" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L77" class="blob-num js-line-number" data-line-number="77"></td>
+        <td id="LC77" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L78" class="blob-num js-line-number" data-line-number="78"></td>
+        <td id="LC78" class="blob-code blob-code-inner js-file-line"><span class="pl-k">class</span> <span class="pl-en">Bucket</span>(<span class="pl-c1">object</span>):</td>
+      </tr>
+      <tr>
+        <td id="L79" class="blob-num js-line-number" data-line-number="79"></td>
+        <td id="LC79" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L80" class="blob-num js-line-number" data-line-number="80"></td>
+        <td id="LC80" class="blob-code blob-code-inner js-file-line">    LoggingGroup <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>http://acs.amazonaws.com/groups/s3/LogDelivery<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L81" class="blob-num js-line-number" data-line-number="81"></td>
+        <td id="LC81" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L82" class="blob-num js-line-number" data-line-number="82"></td>
+        <td id="LC82" class="blob-code blob-code-inner js-file-line">    BucketPaymentBody <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;</span></td>
+      </tr>
+      <tr>
+        <td id="L83" class="blob-num js-line-number" data-line-number="83"></td>
+        <td id="LC83" class="blob-code blob-code-inner js-file-line"><span class="pl-s">       &lt;RequestPaymentConfiguration xmlns=&quot;http://s3.amazonaws.com/doc/2006-03-01/&quot;&gt;</span></td>
+      </tr>
+      <tr>
+        <td id="L84" class="blob-num js-line-number" data-line-number="84"></td>
+        <td id="LC84" class="blob-code blob-code-inner js-file-line"><span class="pl-s">         &lt;Payer&gt;<span class="pl-c1">%s</span>&lt;/Payer&gt;</span></td>
+      </tr>
+      <tr>
+        <td id="L85" class="blob-num js-line-number" data-line-number="85"></td>
+        <td id="LC85" class="blob-code blob-code-inner js-file-line"><span class="pl-s">       &lt;/RequestPaymentConfiguration&gt;<span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L86" class="blob-num js-line-number" data-line-number="86"></td>
+        <td id="LC86" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L87" class="blob-num js-line-number" data-line-number="87"></td>
+        <td id="LC87" class="blob-code blob-code-inner js-file-line">    VersioningBody <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;</span></td>
+      </tr>
+      <tr>
+        <td id="L88" class="blob-num js-line-number" data-line-number="88"></td>
+        <td id="LC88" class="blob-code blob-code-inner js-file-line"><span class="pl-s">       &lt;VersioningConfiguration xmlns=&quot;http://s3.amazonaws.com/doc/2006-03-01/&quot;&gt;</span></td>
+      </tr>
+      <tr>
+        <td id="L89" class="blob-num js-line-number" data-line-number="89"></td>
+        <td id="LC89" class="blob-code blob-code-inner js-file-line"><span class="pl-s">         &lt;Status&gt;<span class="pl-c1">%s</span>&lt;/Status&gt;</span></td>
+      </tr>
+      <tr>
+        <td id="L90" class="blob-num js-line-number" data-line-number="90"></td>
+        <td id="LC90" class="blob-code blob-code-inner js-file-line"><span class="pl-s">         &lt;MfaDelete&gt;<span class="pl-c1">%s</span>&lt;/MfaDelete&gt;</span></td>
+      </tr>
+      <tr>
+        <td id="L91" class="blob-num js-line-number" data-line-number="91"></td>
+        <td id="LC91" class="blob-code blob-code-inner js-file-line"><span class="pl-s">       &lt;/VersioningConfiguration&gt;<span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L92" class="blob-num js-line-number" data-line-number="92"></td>
+        <td id="LC92" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L93" class="blob-num js-line-number" data-line-number="93"></td>
+        <td id="LC93" class="blob-code blob-code-inner js-file-line">    VersionRE <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&lt;Status&gt;([A-Za-z]+)&lt;/Status&gt;<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L94" class="blob-num js-line-number" data-line-number="94"></td>
+        <td id="LC94" class="blob-code blob-code-inner js-file-line">    MFADeleteRE <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&lt;MfaDelete&gt;([A-Za-z]+)&lt;/MfaDelete&gt;<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L95" class="blob-num js-line-number" data-line-number="95"></td>
+        <td id="LC95" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L96" class="blob-num js-line-number" data-line-number="96"></td>
+        <td id="LC96" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-c1">__init__</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">connection</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">name</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">key_class</span><span class="pl-k">=</span>Key):</td>
+      </tr>
+      <tr>
+        <td id="L97" class="blob-num js-line-number" data-line-number="97"></td>
+        <td id="LC97" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.name <span class="pl-k">=</span> name</td>
+      </tr>
+      <tr>
+        <td id="L98" class="blob-num js-line-number" data-line-number="98"></td>
+        <td id="LC98" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.connection <span class="pl-k">=</span> connection</td>
+      </tr>
+      <tr>
+        <td id="L99" class="blob-num js-line-number" data-line-number="99"></td>
+        <td id="LC99" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.key_class <span class="pl-k">=</span> key_class</td>
+      </tr>
+      <tr>
+        <td id="L100" class="blob-num js-line-number" data-line-number="100"></td>
+        <td id="LC100" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L101" class="blob-num js-line-number" data-line-number="101"></td>
+        <td id="LC101" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-c1">__repr__</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>):</td>
+      </tr>
+      <tr>
+        <td id="L102" class="blob-num js-line-number" data-line-number="102"></td>
+        <td id="LC102" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&lt;Bucket: <span class="pl-c1">%s</span>&gt;<span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> <span class="pl-c1">self</span>.name</td>
+      </tr>
+      <tr>
+        <td id="L103" class="blob-num js-line-number" data-line-number="103"></td>
+        <td id="LC103" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L104" class="blob-num js-line-number" data-line-number="104"></td>
+        <td id="LC104" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-c1">__iter__</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>):</td>
+      </tr>
+      <tr>
+        <td id="L105" class="blob-num js-line-number" data-line-number="105"></td>
+        <td id="LC105" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">iter</span>(BucketListResultSet(<span class="pl-c1">self</span>))</td>
+      </tr>
+      <tr>
+        <td id="L106" class="blob-num js-line-number" data-line-number="106"></td>
+        <td id="LC106" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L107" class="blob-num js-line-number" data-line-number="107"></td>
+        <td id="LC107" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-c1">__contains__</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>):</td>
+      </tr>
+      <tr>
+        <td id="L108" class="blob-num js-line-number" data-line-number="108"></td>
+        <td id="LC108" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-k">not</span> (<span class="pl-c1">self</span>.get_key(key_name) <span class="pl-k">is</span> <span class="pl-c1">None</span>)</td>
+      </tr>
+      <tr>
+        <td id="L109" class="blob-num js-line-number" data-line-number="109"></td>
+        <td id="LC109" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L110" class="blob-num js-line-number" data-line-number="110"></td>
+        <td id="LC110" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">startElement</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">name</span>, <span class="pl-smi">attrs</span>, <span class="pl-smi">connection</span>):</td>
+      </tr>
+      <tr>
+        <td id="L111" class="blob-num js-line-number" data-line-number="111"></td>
+        <td id="LC111" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">None</span></td>
+      </tr>
+      <tr>
+        <td id="L112" class="blob-num js-line-number" data-line-number="112"></td>
+        <td id="LC112" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L113" class="blob-num js-line-number" data-line-number="113"></td>
+        <td id="LC113" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">endElement</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">name</span>, <span class="pl-smi">value</span>, <span class="pl-smi">connection</span>):</td>
+      </tr>
+      <tr>
+        <td id="L114" class="blob-num js-line-number" data-line-number="114"></td>
+        <td id="LC114" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> name <span class="pl-k">==</span> <span class="pl-s"><span class="pl-pds">&#39;</span>Name<span class="pl-pds">&#39;</span></span>:</td>
+      </tr>
+      <tr>
+        <td id="L115" class="blob-num js-line-number" data-line-number="115"></td>
+        <td id="LC115" class="blob-code blob-code-inner js-file-line">            <span class="pl-c1">self</span>.name <span class="pl-k">=</span> value</td>
+      </tr>
+      <tr>
+        <td id="L116" class="blob-num js-line-number" data-line-number="116"></td>
+        <td id="LC116" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">elif</span> name <span class="pl-k">==</span> <span class="pl-s"><span class="pl-pds">&#39;</span>CreationDate<span class="pl-pds">&#39;</span></span>:</td>
+      </tr>
+      <tr>
+        <td id="L117" class="blob-num js-line-number" data-line-number="117"></td>
+        <td id="LC117" class="blob-code blob-code-inner js-file-line">            <span class="pl-c1">self</span>.creation_date <span class="pl-k">=</span> value</td>
+      </tr>
+      <tr>
+        <td id="L118" class="blob-num js-line-number" data-line-number="118"></td>
+        <td id="LC118" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L119" class="blob-num js-line-number" data-line-number="119"></td>
+        <td id="LC119" class="blob-code blob-code-inner js-file-line">            <span class="pl-c1">setattr</span>(<span class="pl-c1">self</span>, name, value)</td>
+      </tr>
+      <tr>
+        <td id="L120" class="blob-num js-line-number" data-line-number="120"></td>
+        <td id="LC120" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L121" class="blob-num js-line-number" data-line-number="121"></td>
+        <td id="LC121" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_key_class</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_class</span>):</td>
+      </tr>
+      <tr>
+        <td id="L122" class="blob-num js-line-number" data-line-number="122"></td>
+        <td id="LC122" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L123" class="blob-num js-line-number" data-line-number="123"></td>
+        <td id="LC123" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Set the Key class associated with this bucket.  By default, this</span></td>
+      </tr>
+      <tr>
+        <td id="L124" class="blob-num js-line-number" data-line-number="124"></td>
+        <td id="LC124" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        would be the boto.s3.key.Key class but if you want to subclass that</span></td>
+      </tr>
+      <tr>
+        <td id="L125" class="blob-num js-line-number" data-line-number="125"></td>
+        <td id="LC125" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        for some reason this allows you to associate your new class with a</span></td>
+      </tr>
+      <tr>
+        <td id="L126" class="blob-num js-line-number" data-line-number="126"></td>
+        <td id="LC126" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        bucket so that when you call bucket.new_key() or when you get a listing</span></td>
+      </tr>
+      <tr>
+        <td id="L127" class="blob-num js-line-number" data-line-number="127"></td>
+        <td id="LC127" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        of keys in the bucket you will get an instances of your key class</span></td>
+      </tr>
+      <tr>
+        <td id="L128" class="blob-num js-line-number" data-line-number="128"></td>
+        <td id="LC128" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        rather than the default.</span></td>
+      </tr>
+      <tr>
+        <td id="L129" class="blob-num js-line-number" data-line-number="129"></td>
+        <td id="LC129" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L130" class="blob-num js-line-number" data-line-number="130"></td>
+        <td id="LC130" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_class: class</span></td>
+      </tr>
+      <tr>
+        <td id="L131" class="blob-num js-line-number" data-line-number="131"></td>
+        <td id="LC131" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_class: A subclass of Key that can be more specific</span></td>
+      </tr>
+      <tr>
+        <td id="L132" class="blob-num js-line-number" data-line-number="132"></td>
+        <td id="LC132" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L133" class="blob-num js-line-number" data-line-number="133"></td>
+        <td id="LC133" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.key_class <span class="pl-k">=</span> key_class</td>
+      </tr>
+      <tr>
+        <td id="L134" class="blob-num js-line-number" data-line-number="134"></td>
+        <td id="LC134" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L135" class="blob-num js-line-number" data-line-number="135"></td>
+        <td id="LC135" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">lookup</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L136" class="blob-num js-line-number" data-line-number="136"></td>
+        <td id="LC136" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L137" class="blob-num js-line-number" data-line-number="137"></td>
+        <td id="LC137" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Deprecated: Please use get_key method.</span></td>
+      </tr>
+      <tr>
+        <td id="L138" class="blob-num js-line-number" data-line-number="138"></td>
+        <td id="LC138" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L139" class="blob-num js-line-number" data-line-number="139"></td>
+        <td id="LC139" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_name: string</span></td>
+      </tr>
+      <tr>
+        <td id="L140" class="blob-num js-line-number" data-line-number="140"></td>
+        <td id="LC140" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_name: The name of the key to retrieve</span></td>
+      </tr>
+      <tr>
+        <td id="L141" class="blob-num js-line-number" data-line-number="141"></td>
+        <td id="LC141" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L142" class="blob-num js-line-number" data-line-number="142"></td>
+        <td id="LC142" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.key.Key`</span></td>
+      </tr>
+      <tr>
+        <td id="L143" class="blob-num js-line-number" data-line-number="143"></td>
+        <td id="LC143" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: A Key object from this bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L144" class="blob-num js-line-number" data-line-number="144"></td>
+        <td id="LC144" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L145" class="blob-num js-line-number" data-line-number="145"></td>
+        <td id="LC145" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.get_key(key_name, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L146" class="blob-num js-line-number" data-line-number="146"></td>
+        <td id="LC146" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L147" class="blob-num js-line-number" data-line-number="147"></td>
+        <td id="LC147" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_key</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
+      </tr>
+      <tr>
+        <td id="L148" class="blob-num js-line-number" data-line-number="148"></td>
+        <td id="LC148" class="blob-code blob-code-inner js-file-line">                <span class="pl-smi">response_headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">validate</span><span class="pl-k">=</span><span class="pl-c1">True</span>):</td>
+      </tr>
+      <tr>
+        <td id="L149" class="blob-num js-line-number" data-line-number="149"></td>
+        <td id="LC149" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L150" class="blob-num js-line-number" data-line-number="150"></td>
+        <td id="LC150" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Check to see if a particular key exists within the bucket.  This</span></td>
+      </tr>
+      <tr>
+        <td id="L151" class="blob-num js-line-number" data-line-number="151"></td>
+        <td id="LC151" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        method uses a HEAD request to check for the existence of the key.</span></td>
+      </tr>
+      <tr>
+        <td id="L152" class="blob-num js-line-number" data-line-number="152"></td>
+        <td id="LC152" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns: An instance of a Key object or None</span></td>
+      </tr>
+      <tr>
+        <td id="L153" class="blob-num js-line-number" data-line-number="153"></td>
+        <td id="LC153" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L154" class="blob-num js-line-number" data-line-number="154"></td>
+        <td id="LC154" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_name: The name of the key to retrieve</span></td>
+      </tr>
+      <tr>
+        <td id="L155" class="blob-num js-line-number" data-line-number="155"></td>
+        <td id="LC155" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_name: string</span></td>
+      </tr>
+      <tr>
+        <td id="L156" class="blob-num js-line-number" data-line-number="156"></td>
+        <td id="LC156" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L157" class="blob-num js-line-number" data-line-number="157"></td>
+        <td id="LC157" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param headers: The headers to send when retrieving the key</span></td>
+      </tr>
+      <tr>
+        <td id="L158" class="blob-num js-line-number" data-line-number="158"></td>
+        <td id="LC158" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type headers: dict</span></td>
+      </tr>
+      <tr>
+        <td id="L159" class="blob-num js-line-number" data-line-number="159"></td>
+        <td id="LC159" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L160" class="blob-num js-line-number" data-line-number="160"></td>
+        <td id="LC160" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param version_id:</span></td>
+      </tr>
+      <tr>
+        <td id="L161" class="blob-num js-line-number" data-line-number="161"></td>
+        <td id="LC161" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type version_id: string</span></td>
+      </tr>
+      <tr>
+        <td id="L162" class="blob-num js-line-number" data-line-number="162"></td>
+        <td id="LC162" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L163" class="blob-num js-line-number" data-line-number="163"></td>
+        <td id="LC163" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param response_headers: A dictionary containing HTTP</span></td>
+      </tr>
+      <tr>
+        <td id="L164" class="blob-num js-line-number" data-line-number="164"></td>
+        <td id="LC164" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            headers/values that will override any headers associated</span></td>
+      </tr>
+      <tr>
+        <td id="L165" class="blob-num js-line-number" data-line-number="165"></td>
+        <td id="LC165" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            with the stored object in the response.  See</span></td>
+      </tr>
+      <tr>
+        <td id="L166" class="blob-num js-line-number" data-line-number="166"></td>
+        <td id="LC166" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            http://goo.gl/EWOPb for details.</span></td>
+      </tr>
+      <tr>
+        <td id="L167" class="blob-num js-line-number" data-line-number="167"></td>
+        <td id="LC167" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type response_headers: dict</span></td>
+      </tr>
+      <tr>
+        <td id="L168" class="blob-num js-line-number" data-line-number="168"></td>
+        <td id="LC168" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L169" class="blob-num js-line-number" data-line-number="169"></td>
+        <td id="LC169" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param validate: Verifies whether the key exists. If ``False``, this</span></td>
+      </tr>
+      <tr>
+        <td id="L170" class="blob-num js-line-number" data-line-number="170"></td>
+        <td id="LC170" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            will not hit the service, constructing an in-memory object.</span></td>
+      </tr>
+      <tr>
+        <td id="L171" class="blob-num js-line-number" data-line-number="171"></td>
+        <td id="LC171" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Default is ``True``.</span></td>
+      </tr>
+      <tr>
+        <td id="L172" class="blob-num js-line-number" data-line-number="172"></td>
+        <td id="LC172" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type validate: bool</span></td>
+      </tr>
+      <tr>
+        <td id="L173" class="blob-num js-line-number" data-line-number="173"></td>
+        <td id="LC173" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L174" class="blob-num js-line-number" data-line-number="174"></td>
+        <td id="LC174" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.key.Key`</span></td>
+      </tr>
+      <tr>
+        <td id="L175" class="blob-num js-line-number" data-line-number="175"></td>
+        <td id="LC175" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: A Key object from this bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L176" class="blob-num js-line-number" data-line-number="176"></td>
+        <td id="LC176" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L177" class="blob-num js-line-number" data-line-number="177"></td>
+        <td id="LC177" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> validate <span class="pl-k">is</span> <span class="pl-c1">False</span>:</td>
+      </tr>
+      <tr>
+        <td id="L178" class="blob-num js-line-number" data-line-number="178"></td>
+        <td id="LC178" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> headers <span class="pl-k">or</span> version_id <span class="pl-k">or</span> response_headers:</td>
+      </tr>
+      <tr>
+        <td id="L179" class="blob-num js-line-number" data-line-number="179"></td>
+        <td id="LC179" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">raise</span> BotoClientError(</td>
+      </tr>
+      <tr>
+        <td id="L180" class="blob-num js-line-number" data-line-number="180"></td>
+        <td id="LC180" class="blob-code blob-code-inner js-file-line">                    <span class="pl-s"><span class="pl-pds">&quot;</span>When providing &#39;validate=False&#39;, no other params <span class="pl-pds">&quot;</span></span> <span class="pl-k">+</span> \</td>
+      </tr>
+      <tr>
+        <td id="L181" class="blob-num js-line-number" data-line-number="181"></td>
+        <td id="LC181" class="blob-code blob-code-inner js-file-line">                    <span class="pl-s"><span class="pl-pds">&quot;</span>are allowed.<span class="pl-pds">&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L182" class="blob-num js-line-number" data-line-number="182"></td>
+        <td id="LC182" class="blob-code blob-code-inner js-file-line">                )</td>
+      </tr>
+      <tr>
+        <td id="L183" class="blob-num js-line-number" data-line-number="183"></td>
+        <td id="LC183" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L184" class="blob-num js-line-number" data-line-number="184"></td>
+        <td id="LC184" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> This leans on the default behavior of ``new_key`` (not hitting</span></td>
+      </tr>
+      <tr>
+        <td id="L185" class="blob-num js-line-number" data-line-number="185"></td>
+        <td id="LC185" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> the service). If that changes, that behavior should migrate here.</span></td>
+      </tr>
+      <tr>
+        <td id="L186" class="blob-num js-line-number" data-line-number="186"></td>
+        <td id="LC186" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">self</span>.new_key(key_name)</td>
+      </tr>
+      <tr>
+        <td id="L187" class="blob-num js-line-number" data-line-number="187"></td>
+        <td id="LC187" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L188" class="blob-num js-line-number" data-line-number="188"></td>
+        <td id="LC188" class="blob-code blob-code-inner js-file-line">        query_args_l <span class="pl-k">=</span> []</td>
+      </tr>
+      <tr>
+        <td id="L189" class="blob-num js-line-number" data-line-number="189"></td>
+        <td id="LC189" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
+      </tr>
+      <tr>
+        <td id="L190" class="blob-num js-line-number" data-line-number="190"></td>
+        <td id="LC190" class="blob-code blob-code-inner js-file-line">            query_args_l.append(<span class="pl-s"><span class="pl-pds">&#39;</span>versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id)</td>
+      </tr>
+      <tr>
+        <td id="L191" class="blob-num js-line-number" data-line-number="191"></td>
+        <td id="LC191" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response_headers:</td>
+      </tr>
+      <tr>
+        <td id="L192" class="blob-num js-line-number" data-line-number="192"></td>
+        <td id="LC192" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">for</span> rk, rv <span class="pl-k">in</span> six.iteritems(response_headers):</td>
+      </tr>
+      <tr>
+        <td id="L193" class="blob-num js-line-number" data-line-number="193"></td>
+        <td id="LC193" class="blob-code blob-code-inner js-file-line">                query_args_l.append(<span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-c1">%s</span>=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> (rk, urllib.parse.quote(rv)))</td>
+      </tr>
+      <tr>
+        <td id="L194" class="blob-num js-line-number" data-line-number="194"></td>
+        <td id="LC194" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L195" class="blob-num js-line-number" data-line-number="195"></td>
+        <td id="LC195" class="blob-code blob-code-inner js-file-line">        key, resp <span class="pl-k">=</span> <span class="pl-c1">self</span>._get_key_internal(key_name, headers, query_args_l)</td>
+      </tr>
+      <tr>
+        <td id="L196" class="blob-num js-line-number" data-line-number="196"></td>
+        <td id="LC196" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> key</td>
+      </tr>
+      <tr>
+        <td id="L197" class="blob-num js-line-number" data-line-number="197"></td>
+        <td id="LC197" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L198" class="blob-num js-line-number" data-line-number="198"></td>
+        <td id="LC198" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">_get_key_internal</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">headers</span>, <span class="pl-smi">query_args_l</span>):</td>
+      </tr>
+      <tr>
+        <td id="L199" class="blob-num js-line-number" data-line-number="199"></td>
+        <td id="LC199" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;<span class="pl-pds">&#39;</span></span>.join(query_args_l) <span class="pl-k">or</span> <span class="pl-c1">None</span></td>
+      </tr>
+      <tr>
+        <td id="L200" class="blob-num js-line-number" data-line-number="200"></td>
+        <td id="LC200" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>HEAD<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
+      </tr>
+      <tr>
+        <td id="L201" class="blob-num js-line-number" data-line-number="201"></td>
+        <td id="LC201" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
+      </tr>
+      <tr>
+        <td id="L202" class="blob-num js-line-number" data-line-number="202"></td>
+        <td id="LC202" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args)</td>
+      </tr>
+      <tr>
+        <td id="L203" class="blob-num js-line-number" data-line-number="203"></td>
+        <td id="LC203" class="blob-code blob-code-inner js-file-line">        response.read()</td>
+      </tr>
+      <tr>
+        <td id="L204" class="blob-num js-line-number" data-line-number="204"></td>
+        <td id="LC204" class="blob-code blob-code-inner js-file-line">        <span class="pl-c"><span class="pl-c">#</span> Allow any success status (2xx) - for example this lets us</span></td>
+      </tr>
+      <tr>
+        <td id="L205" class="blob-num js-line-number" data-line-number="205"></td>
+        <td id="LC205" class="blob-code blob-code-inner js-file-line">        <span class="pl-c"><span class="pl-c">#</span> support Range gets, which return status 206:</span></td>
+      </tr>
+      <tr>
+        <td id="L206" class="blob-num js-line-number" data-line-number="206"></td>
+        <td id="LC206" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">//</span> <span class="pl-c1">100</span> <span class="pl-k">==</span> <span class="pl-c1">2</span>:</td>
+      </tr>
+      <tr>
+        <td id="L207" class="blob-num js-line-number" data-line-number="207"></td>
+        <td id="LC207" class="blob-code blob-code-inner js-file-line">            k <span class="pl-k">=</span> <span class="pl-c1">self</span>.key_class(<span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L208" class="blob-num js-line-number" data-line-number="208"></td>
+        <td id="LC208" class="blob-code blob-code-inner js-file-line">            provider <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.provider</td>
+      </tr>
+      <tr>
+        <td id="L209" class="blob-num js-line-number" data-line-number="209"></td>
+        <td id="LC209" class="blob-code blob-code-inner js-file-line">            k.metadata <span class="pl-k">=</span> boto.utils.get_aws_metadata(response.msg, provider)</td>
+      </tr>
+      <tr>
+        <td id="L210" class="blob-num js-line-number" data-line-number="210"></td>
+        <td id="LC210" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">for</span> field <span class="pl-k">in</span> Key.base_fields:</td>
+      </tr>
+      <tr>
+        <td id="L211" class="blob-num js-line-number" data-line-number="211"></td>
+        <td id="LC211" class="blob-code blob-code-inner js-file-line">                k.<span class="pl-c1">__dict__</span>[field.lower().replace(<span class="pl-s"><span class="pl-pds">&#39;</span>-<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>_<span class="pl-pds">&#39;</span></span>)] <span class="pl-k">=</span> \</td>
+      </tr>
+      <tr>
+        <td id="L212" class="blob-num js-line-number" data-line-number="212"></td>
+        <td id="LC212" class="blob-code blob-code-inner js-file-line">                    response.getheader(field)</td>
+      </tr>
+      <tr>
+        <td id="L213" class="blob-num js-line-number" data-line-number="213"></td>
+        <td id="LC213" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> the following machinations are a workaround to the fact that</span></td>
+      </tr>
+      <tr>
+        <td id="L214" class="blob-num js-line-number" data-line-number="214"></td>
+        <td id="LC214" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> apache/fastcgi omits the content-length header on HEAD</span></td>
+      </tr>
+      <tr>
+        <td id="L215" class="blob-num js-line-number" data-line-number="215"></td>
+        <td id="LC215" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> requests when the content-length is zero.</span></td>
+      </tr>
+      <tr>
+        <td id="L216" class="blob-num js-line-number" data-line-number="216"></td>
+        <td id="LC216" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> See http://goo.gl/0Tdax for more details.</span></td>
+      </tr>
+      <tr>
+        <td id="L217" class="blob-num js-line-number" data-line-number="217"></td>
+        <td id="LC217" class="blob-code blob-code-inner js-file-line">            clen <span class="pl-k">=</span> response.getheader(<span class="pl-s"><span class="pl-pds">&#39;</span>content-length<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L218" class="blob-num js-line-number" data-line-number="218"></td>
+        <td id="LC218" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> clen:</td>
+      </tr>
+      <tr>
+        <td id="L219" class="blob-num js-line-number" data-line-number="219"></td>
+        <td id="LC219" class="blob-code blob-code-inner js-file-line">                k.size <span class="pl-k">=</span> <span class="pl-c1">int</span>(response.getheader(<span class="pl-s"><span class="pl-pds">&#39;</span>content-length<span class="pl-pds">&#39;</span></span>))</td>
+      </tr>
+      <tr>
+        <td id="L220" class="blob-num js-line-number" data-line-number="220"></td>
+        <td id="LC220" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L221" class="blob-num js-line-number" data-line-number="221"></td>
+        <td id="LC221" class="blob-code blob-code-inner js-file-line">                k.size <span class="pl-k">=</span> <span class="pl-c1">0</span></td>
+      </tr>
+      <tr>
+        <td id="L222" class="blob-num js-line-number" data-line-number="222"></td>
+        <td id="LC222" class="blob-code blob-code-inner js-file-line">            k.name <span class="pl-k">=</span> key_name</td>
+      </tr>
+      <tr>
+        <td id="L223" class="blob-num js-line-number" data-line-number="223"></td>
+        <td id="LC223" class="blob-code blob-code-inner js-file-line">            k.handle_version_headers(response)</td>
+      </tr>
+      <tr>
+        <td id="L224" class="blob-num js-line-number" data-line-number="224"></td>
+        <td id="LC224" class="blob-code blob-code-inner js-file-line">            k.handle_encryption_headers(response)</td>
+      </tr>
+      <tr>
+        <td id="L225" class="blob-num js-line-number" data-line-number="225"></td>
+        <td id="LC225" class="blob-code blob-code-inner js-file-line">            k.handle_restore_headers(response)</td>
+      </tr>
+      <tr>
+        <td id="L226" class="blob-num js-line-number" data-line-number="226"></td>
+        <td id="LC226" class="blob-code blob-code-inner js-file-line">            k.handle_storage_class_header(response)</td>
+      </tr>
+      <tr>
+        <td id="L227" class="blob-num js-line-number" data-line-number="227"></td>
+        <td id="LC227" class="blob-code blob-code-inner js-file-line">            k.handle_addl_headers(response.getheaders())</td>
+      </tr>
+      <tr>
+        <td id="L228" class="blob-num js-line-number" data-line-number="228"></td>
+        <td id="LC228" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> k, response</td>
+      </tr>
+      <tr>
+        <td id="L229" class="blob-num js-line-number" data-line-number="229"></td>
+        <td id="LC229" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L230" class="blob-num js-line-number" data-line-number="230"></td>
+        <td id="LC230" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">404</span>:</td>
+      </tr>
+      <tr>
+        <td id="L231" class="blob-num js-line-number" data-line-number="231"></td>
+        <td id="LC231" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">return</span> <span class="pl-c1">None</span>, response</td>
+      </tr>
+      <tr>
+        <td id="L232" class="blob-num js-line-number" data-line-number="232"></td>
+        <td id="LC232" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L233" class="blob-num js-line-number" data-line-number="233"></td>
+        <td id="LC233" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L234" class="blob-num js-line-number" data-line-number="234"></td>
+        <td id="LC234" class="blob-code blob-code-inner js-file-line">                    response.status, response.reason, <span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L235" class="blob-num js-line-number" data-line-number="235"></td>
+        <td id="LC235" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L236" class="blob-num js-line-number" data-line-number="236"></td>
+        <td id="LC236" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-c1">list</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">prefix</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">delimiter</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">marker</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
+      </tr>
+      <tr>
+        <td id="L237" class="blob-num js-line-number" data-line-number="237"></td>
+        <td id="LC237" class="blob-code blob-code-inner js-file-line">             <span class="pl-smi">encoding_type</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L238" class="blob-num js-line-number" data-line-number="238"></td>
+        <td id="LC238" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L239" class="blob-num js-line-number" data-line-number="239"></td>
+        <td id="LC239" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        List key objects within a bucket.  This returns an instance of an</span></td>
+      </tr>
+      <tr>
+        <td id="L240" class="blob-num js-line-number" data-line-number="240"></td>
+        <td id="LC240" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        BucketListResultSet that automatically handles all of the result</span></td>
+      </tr>
+      <tr>
+        <td id="L241" class="blob-num js-line-number" data-line-number="241"></td>
+        <td id="LC241" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        paging, etc. from S3.  You just need to keep iterating until</span></td>
+      </tr>
+      <tr>
+        <td id="L242" class="blob-num js-line-number" data-line-number="242"></td>
+        <td id="LC242" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        there are no more results.</span></td>
+      </tr>
+      <tr>
+        <td id="L243" class="blob-num js-line-number" data-line-number="243"></td>
+        <td id="LC243" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L244" class="blob-num js-line-number" data-line-number="244"></td>
+        <td id="LC244" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Called with no arguments, this will return an iterator object across</span></td>
+      </tr>
+      <tr>
+        <td id="L245" class="blob-num js-line-number" data-line-number="245"></td>
+        <td id="LC245" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        all keys within the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L246" class="blob-num js-line-number" data-line-number="246"></td>
+        <td id="LC246" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L247" class="blob-num js-line-number" data-line-number="247"></td>
+        <td id="LC247" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        The Key objects returned by the iterator are obtained by parsing</span></td>
+      </tr>
+      <tr>
+        <td id="L248" class="blob-num js-line-number" data-line-number="248"></td>
+        <td id="LC248" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        the results of a GET on the bucket, also known as the List Objects</span></td>
+      </tr>
+      <tr>
+        <td id="L249" class="blob-num js-line-number" data-line-number="249"></td>
+        <td id="LC249" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        request.  The XML returned by this request contains only a subset</span></td>
+      </tr>
+      <tr>
+        <td id="L250" class="blob-num js-line-number" data-line-number="250"></td>
+        <td id="LC250" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        of the information about each key.  Certain metadata fields such</span></td>
+      </tr>
+      <tr>
+        <td id="L251" class="blob-num js-line-number" data-line-number="251"></td>
+        <td id="LC251" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        as Content-Type and user metadata are not available in the XML.</span></td>
+      </tr>
+      <tr>
+        <td id="L252" class="blob-num js-line-number" data-line-number="252"></td>
+        <td id="LC252" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Therefore, if you want these additional metadata fields you will</span></td>
+      </tr>
+      <tr>
+        <td id="L253" class="blob-num js-line-number" data-line-number="253"></td>
+        <td id="LC253" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        have to do a HEAD request on the Key in the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L254" class="blob-num js-line-number" data-line-number="254"></td>
+        <td id="LC254" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L255" class="blob-num js-line-number" data-line-number="255"></td>
+        <td id="LC255" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type prefix: string</span></td>
+      </tr>
+      <tr>
+        <td id="L256" class="blob-num js-line-number" data-line-number="256"></td>
+        <td id="LC256" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param prefix: allows you to limit the listing to a particular</span></td>
+      </tr>
+      <tr>
+        <td id="L257" class="blob-num js-line-number" data-line-number="257"></td>
+        <td id="LC257" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            prefix.  For example, if you call the method with</span></td>
+      </tr>
+      <tr>
+        <td id="L258" class="blob-num js-line-number" data-line-number="258"></td>
+        <td id="LC258" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            prefix=&#39;/foo/&#39; then the iterator will only cycle through</span></td>
+      </tr>
+      <tr>
+        <td id="L259" class="blob-num js-line-number" data-line-number="259"></td>
+        <td id="LC259" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the keys that begin with the string &#39;/foo/&#39;.</span></td>
+      </tr>
+      <tr>
+        <td id="L260" class="blob-num js-line-number" data-line-number="260"></td>
+        <td id="LC260" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L261" class="blob-num js-line-number" data-line-number="261"></td>
+        <td id="LC261" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type delimiter: string</span></td>
+      </tr>
+      <tr>
+        <td id="L262" class="blob-num js-line-number" data-line-number="262"></td>
+        <td id="LC262" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param delimiter: can be used in conjunction with the prefix</span></td>
+      </tr>
+      <tr>
+        <td id="L263" class="blob-num js-line-number" data-line-number="263"></td>
+        <td id="LC263" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            to allow you to organize and browse your keys</span></td>
+      </tr>
+      <tr>
+        <td id="L264" class="blob-num js-line-number" data-line-number="264"></td>
+        <td id="LC264" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            hierarchically. See http://goo.gl/Xx63h for more details.</span></td>
+      </tr>
+      <tr>
+        <td id="L265" class="blob-num js-line-number" data-line-number="265"></td>
+        <td id="LC265" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L266" class="blob-num js-line-number" data-line-number="266"></td>
+        <td id="LC266" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type marker: string</span></td>
+      </tr>
+      <tr>
+        <td id="L267" class="blob-num js-line-number" data-line-number="267"></td>
+        <td id="LC267" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param marker: The &quot;marker&quot; of where you are in the result set</span></td>
+      </tr>
+      <tr>
+        <td id="L268" class="blob-num js-line-number" data-line-number="268"></td>
+        <td id="LC268" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L269" class="blob-num js-line-number" data-line-number="269"></td>
+        <td id="LC269" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encoding_type: Requests Amazon S3 to encode the response and</span></td>
+      </tr>
+      <tr>
+        <td id="L270" class="blob-num js-line-number" data-line-number="270"></td>
+        <td id="LC270" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specifies the encoding method to use.</span></td>
+      </tr>
+      <tr>
+        <td id="L271" class="blob-num js-line-number" data-line-number="271"></td>
+        <td id="LC271" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L272" class="blob-num js-line-number" data-line-number="272"></td>
+        <td id="LC272" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            An object key can contain any Unicode character; however, XML 1.0</span></td>
+      </tr>
+      <tr>
+        <td id="L273" class="blob-num js-line-number" data-line-number="273"></td>
+        <td id="LC273" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parser cannot parse some characters, such as characters with an</span></td>
+      </tr>
+      <tr>
+        <td id="L274" class="blob-num js-line-number" data-line-number="274"></td>
+        <td id="LC274" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ASCII value from 0 to 10. For characters that are not supported in</span></td>
+      </tr>
+      <tr>
+        <td id="L275" class="blob-num js-line-number" data-line-number="275"></td>
+        <td id="LC275" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            XML 1.0, you can add this parameter to request that Amazon S3</span></td>
+      </tr>
+      <tr>
+        <td id="L276" class="blob-num js-line-number" data-line-number="276"></td>
+        <td id="LC276" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            encode the keys in the response.</span></td>
+      </tr>
+      <tr>
+        <td id="L277" class="blob-num js-line-number" data-line-number="277"></td>
+        <td id="LC277" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L278" class="blob-num js-line-number" data-line-number="278"></td>
+        <td id="LC278" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Valid options: ``url``</span></td>
+      </tr>
+      <tr>
+        <td id="L279" class="blob-num js-line-number" data-line-number="279"></td>
+        <td id="LC279" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encoding_type: string</span></td>
+      </tr>
+      <tr>
+        <td id="L280" class="blob-num js-line-number" data-line-number="280"></td>
+        <td id="LC280" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L281" class="blob-num js-line-number" data-line-number="281"></td>
+        <td id="LC281" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.bucketlistresultset.BucketListResultSet`</span></td>
+      </tr>
+      <tr>
+        <td id="L282" class="blob-num js-line-number" data-line-number="282"></td>
+        <td id="LC282" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: an instance of a BucketListResultSet that handles paging, etc</span></td>
+      </tr>
+      <tr>
+        <td id="L283" class="blob-num js-line-number" data-line-number="283"></td>
+        <td id="LC283" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L284" class="blob-num js-line-number" data-line-number="284"></td>
+        <td id="LC284" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> BucketListResultSet(<span class="pl-c1">self</span>, prefix, delimiter, marker, headers,</td>
+      </tr>
+      <tr>
+        <td id="L285" class="blob-num js-line-number" data-line-number="285"></td>
+        <td id="LC285" class="blob-code blob-code-inner js-file-line">                                   <span class="pl-v">encoding_type</span><span class="pl-k">=</span>encoding_type)</td>
+      </tr>
+      <tr>
+        <td id="L286" class="blob-num js-line-number" data-line-number="286"></td>
+        <td id="LC286" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L287" class="blob-num js-line-number" data-line-number="287"></td>
+        <td id="LC287" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">list_versions</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">prefix</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">delimiter</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">key_marker</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L288" class="blob-num js-line-number" data-line-number="288"></td>
+        <td id="LC288" class="blob-code blob-code-inner js-file-line">                      <span class="pl-smi">version_id_marker</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">encoding_type</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L289" class="blob-num js-line-number" data-line-number="289"></td>
+        <td id="LC289" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L290" class="blob-num js-line-number" data-line-number="290"></td>
+        <td id="LC290" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        List version objects within a bucket.  This returns an</span></td>
+      </tr>
+      <tr>
+        <td id="L291" class="blob-num js-line-number" data-line-number="291"></td>
+        <td id="LC291" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        instance of an VersionedBucketListResultSet that automatically</span></td>
+      </tr>
+      <tr>
+        <td id="L292" class="blob-num js-line-number" data-line-number="292"></td>
+        <td id="LC292" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        handles all of the result paging, etc. from S3.  You just need</span></td>
+      </tr>
+      <tr>
+        <td id="L293" class="blob-num js-line-number" data-line-number="293"></td>
+        <td id="LC293" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        to keep iterating until there are no more results.  Called</span></td>
+      </tr>
+      <tr>
+        <td id="L294" class="blob-num js-line-number" data-line-number="294"></td>
+        <td id="LC294" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        with no arguments, this will return an iterator object across</span></td>
+      </tr>
+      <tr>
+        <td id="L295" class="blob-num js-line-number" data-line-number="295"></td>
+        <td id="LC295" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        all keys within the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L296" class="blob-num js-line-number" data-line-number="296"></td>
+        <td id="LC296" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L297" class="blob-num js-line-number" data-line-number="297"></td>
+        <td id="LC297" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type prefix: string</span></td>
+      </tr>
+      <tr>
+        <td id="L298" class="blob-num js-line-number" data-line-number="298"></td>
+        <td id="LC298" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param prefix: allows you to limit the listing to a particular</span></td>
+      </tr>
+      <tr>
+        <td id="L299" class="blob-num js-line-number" data-line-number="299"></td>
+        <td id="LC299" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            prefix.  For example, if you call the method with</span></td>
+      </tr>
+      <tr>
+        <td id="L300" class="blob-num js-line-number" data-line-number="300"></td>
+        <td id="LC300" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            prefix=&#39;/foo/&#39; then the iterator will only cycle through</span></td>
+      </tr>
+      <tr>
+        <td id="L301" class="blob-num js-line-number" data-line-number="301"></td>
+        <td id="LC301" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the keys that begin with the string &#39;/foo/&#39;.</span></td>
+      </tr>
+      <tr>
+        <td id="L302" class="blob-num js-line-number" data-line-number="302"></td>
+        <td id="LC302" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L303" class="blob-num js-line-number" data-line-number="303"></td>
+        <td id="LC303" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type delimiter: string</span></td>
+      </tr>
+      <tr>
+        <td id="L304" class="blob-num js-line-number" data-line-number="304"></td>
+        <td id="LC304" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param delimiter: can be used in conjunction with the prefix</span></td>
+      </tr>
+      <tr>
+        <td id="L305" class="blob-num js-line-number" data-line-number="305"></td>
+        <td id="LC305" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            to allow you to organize and browse your keys</span></td>
+      </tr>
+      <tr>
+        <td id="L306" class="blob-num js-line-number" data-line-number="306"></td>
+        <td id="LC306" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            hierarchically. See:</span></td>
+      </tr>
+      <tr>
+        <td id="L307" class="blob-num js-line-number" data-line-number="307"></td>
+        <td id="LC307" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L308" class="blob-num js-line-number" data-line-number="308"></td>
+        <td id="LC308" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            http://aws.amazon.com/releasenotes/Amazon-S3/213</span></td>
+      </tr>
+      <tr>
+        <td id="L309" class="blob-num js-line-number" data-line-number="309"></td>
+        <td id="LC309" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L310" class="blob-num js-line-number" data-line-number="310"></td>
+        <td id="LC310" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            for more details.</span></td>
+      </tr>
+      <tr>
+        <td id="L311" class="blob-num js-line-number" data-line-number="311"></td>
+        <td id="LC311" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L312" class="blob-num js-line-number" data-line-number="312"></td>
+        <td id="LC312" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_marker: string</span></td>
+      </tr>
+      <tr>
+        <td id="L313" class="blob-num js-line-number" data-line-number="313"></td>
+        <td id="LC313" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_marker: The &quot;marker&quot; of where you are in the result set</span></td>
+      </tr>
+      <tr>
+        <td id="L314" class="blob-num js-line-number" data-line-number="314"></td>
+        <td id="LC314" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L315" class="blob-num js-line-number" data-line-number="315"></td>
+        <td id="LC315" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encoding_type: Requests Amazon S3 to encode the response and</span></td>
+      </tr>
+      <tr>
+        <td id="L316" class="blob-num js-line-number" data-line-number="316"></td>
+        <td id="LC316" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specifies the encoding method to use.</span></td>
+      </tr>
+      <tr>
+        <td id="L317" class="blob-num js-line-number" data-line-number="317"></td>
+        <td id="LC317" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L318" class="blob-num js-line-number" data-line-number="318"></td>
+        <td id="LC318" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            An object key can contain any Unicode character; however, XML 1.0</span></td>
+      </tr>
+      <tr>
+        <td id="L319" class="blob-num js-line-number" data-line-number="319"></td>
+        <td id="LC319" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parser cannot parse some characters, such as characters with an</span></td>
+      </tr>
+      <tr>
+        <td id="L320" class="blob-num js-line-number" data-line-number="320"></td>
+        <td id="LC320" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ASCII value from 0 to 10. For characters that are not supported in</span></td>
+      </tr>
+      <tr>
+        <td id="L321" class="blob-num js-line-number" data-line-number="321"></td>
+        <td id="LC321" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            XML 1.0, you can add this parameter to request that Amazon S3</span></td>
+      </tr>
+      <tr>
+        <td id="L322" class="blob-num js-line-number" data-line-number="322"></td>
+        <td id="LC322" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            encode the keys in the response.</span></td>
+      </tr>
+      <tr>
+        <td id="L323" class="blob-num js-line-number" data-line-number="323"></td>
+        <td id="LC323" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L324" class="blob-num js-line-number" data-line-number="324"></td>
+        <td id="LC324" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Valid options: ``url``</span></td>
+      </tr>
+      <tr>
+        <td id="L325" class="blob-num js-line-number" data-line-number="325"></td>
+        <td id="LC325" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encoding_type: string</span></td>
+      </tr>
+      <tr>
+        <td id="L326" class="blob-num js-line-number" data-line-number="326"></td>
+        <td id="LC326" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L327" class="blob-num js-line-number" data-line-number="327"></td>
+        <td id="LC327" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.bucketlistresultset.BucketListResultSet`</span></td>
+      </tr>
+      <tr>
+        <td id="L328" class="blob-num js-line-number" data-line-number="328"></td>
+        <td id="LC328" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: an instance of a BucketListResultSet that handles paging, etc</span></td>
+      </tr>
+      <tr>
+        <td id="L329" class="blob-num js-line-number" data-line-number="329"></td>
+        <td id="LC329" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L330" class="blob-num js-line-number" data-line-number="330"></td>
+        <td id="LC330" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> VersionedBucketListResultSet(<span class="pl-c1">self</span>, prefix, delimiter,</td>
+      </tr>
+      <tr>
+        <td id="L331" class="blob-num js-line-number" data-line-number="331"></td>
+        <td id="LC331" class="blob-code blob-code-inner js-file-line">                                            key_marker, version_id_marker,</td>
+      </tr>
+      <tr>
+        <td id="L332" class="blob-num js-line-number" data-line-number="332"></td>
+        <td id="LC332" class="blob-code blob-code-inner js-file-line">                                            headers,</td>
+      </tr>
+      <tr>
+        <td id="L333" class="blob-num js-line-number" data-line-number="333"></td>
+        <td id="LC333" class="blob-code blob-code-inner js-file-line">                                            <span class="pl-v">encoding_type</span><span class="pl-k">=</span>encoding_type)</td>
+      </tr>
+      <tr>
+        <td id="L334" class="blob-num js-line-number" data-line-number="334"></td>
+        <td id="LC334" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L335" class="blob-num js-line-number" data-line-number="335"></td>
+        <td id="LC335" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">list_multipart_uploads</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_marker</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L336" class="blob-num js-line-number" data-line-number="336"></td>
+        <td id="LC336" class="blob-code blob-code-inner js-file-line">                               <span class="pl-smi">upload_id_marker</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L337" class="blob-num js-line-number" data-line-number="337"></td>
+        <td id="LC337" class="blob-code blob-code-inner js-file-line">                               <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">encoding_type</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L338" class="blob-num js-line-number" data-line-number="338"></td>
+        <td id="LC338" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L339" class="blob-num js-line-number" data-line-number="339"></td>
+        <td id="LC339" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        List multipart upload objects within a bucket.  This returns an</span></td>
+      </tr>
+      <tr>
+        <td id="L340" class="blob-num js-line-number" data-line-number="340"></td>
+        <td id="LC340" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        instance of an MultiPartUploadListResultSet that automatically</span></td>
+      </tr>
+      <tr>
+        <td id="L341" class="blob-num js-line-number" data-line-number="341"></td>
+        <td id="LC341" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        handles all of the result paging, etc. from S3.  You just need</span></td>
+      </tr>
+      <tr>
+        <td id="L342" class="blob-num js-line-number" data-line-number="342"></td>
+        <td id="LC342" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        to keep iterating until there are no more results.</span></td>
+      </tr>
+      <tr>
+        <td id="L343" class="blob-num js-line-number" data-line-number="343"></td>
+        <td id="LC343" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L344" class="blob-num js-line-number" data-line-number="344"></td>
+        <td id="LC344" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_marker: string</span></td>
+      </tr>
+      <tr>
+        <td id="L345" class="blob-num js-line-number" data-line-number="345"></td>
+        <td id="LC345" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_marker: The &quot;marker&quot; of where you are in the result set</span></td>
+      </tr>
+      <tr>
+        <td id="L346" class="blob-num js-line-number" data-line-number="346"></td>
+        <td id="LC346" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L347" class="blob-num js-line-number" data-line-number="347"></td>
+        <td id="LC347" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type upload_id_marker: string</span></td>
+      </tr>
+      <tr>
+        <td id="L348" class="blob-num js-line-number" data-line-number="348"></td>
+        <td id="LC348" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param upload_id_marker: The upload identifier</span></td>
+      </tr>
+      <tr>
+        <td id="L349" class="blob-num js-line-number" data-line-number="349"></td>
+        <td id="LC349" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L350" class="blob-num js-line-number" data-line-number="350"></td>
+        <td id="LC350" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encoding_type: Requests Amazon S3 to encode the response and</span></td>
+      </tr>
+      <tr>
+        <td id="L351" class="blob-num js-line-number" data-line-number="351"></td>
+        <td id="LC351" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specifies the encoding method to use.</span></td>
+      </tr>
+      <tr>
+        <td id="L352" class="blob-num js-line-number" data-line-number="352"></td>
+        <td id="LC352" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L353" class="blob-num js-line-number" data-line-number="353"></td>
+        <td id="LC353" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            An object key can contain any Unicode character; however, XML 1.0</span></td>
+      </tr>
+      <tr>
+        <td id="L354" class="blob-num js-line-number" data-line-number="354"></td>
+        <td id="LC354" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parser cannot parse some characters, such as characters with an</span></td>
+      </tr>
+      <tr>
+        <td id="L355" class="blob-num js-line-number" data-line-number="355"></td>
+        <td id="LC355" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ASCII value from 0 to 10. For characters that are not supported in</span></td>
+      </tr>
+      <tr>
+        <td id="L356" class="blob-num js-line-number" data-line-number="356"></td>
+        <td id="LC356" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            XML 1.0, you can add this parameter to request that Amazon S3</span></td>
+      </tr>
+      <tr>
+        <td id="L357" class="blob-num js-line-number" data-line-number="357"></td>
+        <td id="LC357" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            encode the keys in the response.</span></td>
+      </tr>
+      <tr>
+        <td id="L358" class="blob-num js-line-number" data-line-number="358"></td>
+        <td id="LC358" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L359" class="blob-num js-line-number" data-line-number="359"></td>
+        <td id="LC359" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Valid options: ``url``</span></td>
+      </tr>
+      <tr>
+        <td id="L360" class="blob-num js-line-number" data-line-number="360"></td>
+        <td id="LC360" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encoding_type: string</span></td>
+      </tr>
+      <tr>
+        <td id="L361" class="blob-num js-line-number" data-line-number="361"></td>
+        <td id="LC361" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L362" class="blob-num js-line-number" data-line-number="362"></td>
+        <td id="LC362" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.bucketlistresultset.MultiPartUploadListResultSet`</span></td>
+      </tr>
+      <tr>
+        <td id="L363" class="blob-num js-line-number" data-line-number="363"></td>
+        <td id="LC363" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: an instance of a BucketListResultSet that handles paging, etc</span></td>
+      </tr>
+      <tr>
+        <td id="L364" class="blob-num js-line-number" data-line-number="364"></td>
+        <td id="LC364" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L365" class="blob-num js-line-number" data-line-number="365"></td>
+        <td id="LC365" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> MultiPartUploadListResultSet(<span class="pl-c1">self</span>, key_marker,</td>
+      </tr>
+      <tr>
+        <td id="L366" class="blob-num js-line-number" data-line-number="366"></td>
+        <td id="LC366" class="blob-code blob-code-inner js-file-line">                                            upload_id_marker,</td>
+      </tr>
+      <tr>
+        <td id="L367" class="blob-num js-line-number" data-line-number="367"></td>
+        <td id="LC367" class="blob-code blob-code-inner js-file-line">                                            headers,</td>
+      </tr>
+      <tr>
+        <td id="L368" class="blob-num js-line-number" data-line-number="368"></td>
+        <td id="LC368" class="blob-code blob-code-inner js-file-line">                                            <span class="pl-v">encoding_type</span><span class="pl-k">=</span>encoding_type)</td>
+      </tr>
+      <tr>
+        <td id="L369" class="blob-num js-line-number" data-line-number="369"></td>
+        <td id="LC369" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L370" class="blob-num js-line-number" data-line-number="370"></td>
+        <td id="LC370" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">_get_all_query_args</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">params</span>, <span class="pl-smi">initial_query_string</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>):</td>
+      </tr>
+      <tr>
+        <td id="L371" class="blob-num js-line-number" data-line-number="371"></td>
+        <td id="LC371" class="blob-code blob-code-inner js-file-line">        pairs <span class="pl-k">=</span> []</td>
+      </tr>
+      <tr>
+        <td id="L372" class="blob-num js-line-number" data-line-number="372"></td>
+        <td id="LC372" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L373" class="blob-num js-line-number" data-line-number="373"></td>
+        <td id="LC373" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> initial_query_string:</td>
+      </tr>
+      <tr>
+        <td id="L374" class="blob-num js-line-number" data-line-number="374"></td>
+        <td id="LC374" class="blob-code blob-code-inner js-file-line">            pairs.append(initial_query_string)</td>
+      </tr>
+      <tr>
+        <td id="L375" class="blob-num js-line-number" data-line-number="375"></td>
+        <td id="LC375" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L376" class="blob-num js-line-number" data-line-number="376"></td>
+        <td id="LC376" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">for</span> key, value <span class="pl-k">in</span> <span class="pl-c1">sorted</span>(params.items(), <span class="pl-v">key</span><span class="pl-k">=</span><span class="pl-k">lambda</span> <span class="pl-smi">x</span>: x[<span class="pl-c1">0</span>]):</td>
+      </tr>
+      <tr>
+        <td id="L377" class="blob-num js-line-number" data-line-number="377"></td>
+        <td id="LC377" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> value <span class="pl-k">is</span> <span class="pl-c1">None</span>:</td>
+      </tr>
+      <tr>
+        <td id="L378" class="blob-num js-line-number" data-line-number="378"></td>
+        <td id="LC378" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">continue</span></td>
+      </tr>
+      <tr>
+        <td id="L379" class="blob-num js-line-number" data-line-number="379"></td>
+        <td id="LC379" class="blob-code blob-code-inner js-file-line">            key <span class="pl-k">=</span> key.replace(<span class="pl-s"><span class="pl-pds">&#39;</span>_<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>-<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L380" class="blob-num js-line-number" data-line-number="380"></td>
+        <td id="LC380" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> key <span class="pl-k">==</span> <span class="pl-s"><span class="pl-pds">&#39;</span>maxkeys<span class="pl-pds">&#39;</span></span>:</td>
+      </tr>
+      <tr>
+        <td id="L381" class="blob-num js-line-number" data-line-number="381"></td>
+        <td id="LC381" class="blob-code blob-code-inner js-file-line">                key <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>max-keys<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L382" class="blob-num js-line-number" data-line-number="382"></td>
+        <td id="LC382" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(value, six.string_types <span class="pl-k">+</span> (six.binary_type,)):</td>
+      </tr>
+      <tr>
+        <td id="L383" class="blob-num js-line-number" data-line-number="383"></td>
+        <td id="LC383" class="blob-code blob-code-inner js-file-line">                value <span class="pl-k">=</span> six.text_type(value)</td>
+      </tr>
+      <tr>
+        <td id="L384" class="blob-num js-line-number" data-line-number="384"></td>
+        <td id="LC384" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(value, six.binary_type):</td>
+      </tr>
+      <tr>
+        <td id="L385" class="blob-num js-line-number" data-line-number="385"></td>
+        <td id="LC385" class="blob-code blob-code-inner js-file-line">                value <span class="pl-k">=</span> value.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L386" class="blob-num js-line-number" data-line-number="386"></td>
+        <td id="LC386" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> value:</td>
+      </tr>
+      <tr>
+        <td id="L387" class="blob-num js-line-number" data-line-number="387"></td>
+        <td id="LC387" class="blob-code blob-code-inner js-file-line">                pairs.append(<span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&#39;</span><span class="pl-c1">%s</span>=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> (</td>
+      </tr>
+      <tr>
+        <td id="L388" class="blob-num js-line-number" data-line-number="388"></td>
+        <td id="LC388" class="blob-code blob-code-inner js-file-line">                    urllib.parse.quote(key),</td>
+      </tr>
+      <tr>
+        <td id="L389" class="blob-num js-line-number" data-line-number="389"></td>
+        <td id="LC389" class="blob-code blob-code-inner js-file-line">                    urllib.parse.quote(value)</td>
+      </tr>
+      <tr>
+        <td id="L390" class="blob-num js-line-number" data-line-number="390"></td>
+        <td id="LC390" class="blob-code blob-code-inner js-file-line">                ))</td>
+      </tr>
+      <tr>
+        <td id="L391" class="blob-num js-line-number" data-line-number="391"></td>
+        <td id="LC391" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L392" class="blob-num js-line-number" data-line-number="392"></td>
+        <td id="LC392" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;<span class="pl-pds">&#39;</span></span>.join(pairs)</td>
+      </tr>
+      <tr>
+        <td id="L393" class="blob-num js-line-number" data-line-number="393"></td>
+        <td id="LC393" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L394" class="blob-num js-line-number" data-line-number="394"></td>
+        <td id="LC394" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">_get_all</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">element_map</span>, <span class="pl-smi">initial_query_string</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L395" class="blob-num js-line-number" data-line-number="395"></td>
+        <td id="LC395" class="blob-code blob-code-inner js-file-line">                 <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-k">**</span><span class="pl-smi">params</span>):</td>
+      </tr>
+      <tr>
+        <td id="L396" class="blob-num js-line-number" data-line-number="396"></td>
+        <td id="LC396" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-c1">self</span>._get_all_query_args(</td>
+      </tr>
+      <tr>
+        <td id="L397" class="blob-num js-line-number" data-line-number="397"></td>
+        <td id="LC397" class="blob-code blob-code-inner js-file-line">            params,</td>
+      </tr>
+      <tr>
+        <td id="L398" class="blob-num js-line-number" data-line-number="398"></td>
+        <td id="LC398" class="blob-code blob-code-inner js-file-line">            <span class="pl-v">initial_query_string</span><span class="pl-k">=</span>initial_query_string</td>
+      </tr>
+      <tr>
+        <td id="L399" class="blob-num js-line-number" data-line-number="399"></td>
+        <td id="LC399" class="blob-code blob-code-inner js-file-line">        )</td>
+      </tr>
+      <tr>
+        <td id="L400" class="blob-num js-line-number" data-line-number="400"></td>
+        <td id="LC400" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L401" class="blob-num js-line-number" data-line-number="401"></td>
+        <td id="LC401" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
+      </tr>
+      <tr>
+        <td id="L402" class="blob-num js-line-number" data-line-number="402"></td>
+        <td id="LC402" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args)</td>
+      </tr>
+      <tr>
+        <td id="L403" class="blob-num js-line-number" data-line-number="403"></td>
+        <td id="LC403" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L404" class="blob-num js-line-number" data-line-number="404"></td>
+        <td id="LC404" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
+      </tr>
+      <tr>
+        <td id="L405" class="blob-num js-line-number" data-line-number="405"></td>
+        <td id="LC405" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L406" class="blob-num js-line-number" data-line-number="406"></td>
+        <td id="LC406" class="blob-code blob-code-inner js-file-line">            rs <span class="pl-k">=</span> ResultSet(element_map)</td>
+      </tr>
+      <tr>
+        <td id="L407" class="blob-num js-line-number" data-line-number="407"></td>
+        <td id="LC407" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(rs, <span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L408" class="blob-num js-line-number" data-line-number="408"></td>
+        <td id="LC408" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
+      </tr>
+      <tr>
+        <td id="L409" class="blob-num js-line-number" data-line-number="409"></td>
+        <td id="LC409" class="blob-code blob-code-inner js-file-line">                body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L410" class="blob-num js-line-number" data-line-number="410"></td>
+        <td id="LC410" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
+      </tr>
+      <tr>
+        <td id="L411" class="blob-num js-line-number" data-line-number="411"></td>
+        <td id="LC411" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> rs</td>
+      </tr>
+      <tr>
+        <td id="L412" class="blob-num js-line-number" data-line-number="412"></td>
+        <td id="LC412" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L413" class="blob-num js-line-number" data-line-number="413"></td>
+        <td id="LC413" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L414" class="blob-num js-line-number" data-line-number="414"></td>
+        <td id="LC414" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L415" class="blob-num js-line-number" data-line-number="415"></td>
+        <td id="LC415" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L416" class="blob-num js-line-number" data-line-number="416"></td>
+        <td id="LC416" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">validate_kwarg_names</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">kwargs</span>, <span class="pl-smi">names</span>):</td>
+      </tr>
+      <tr>
+        <td id="L417" class="blob-num js-line-number" data-line-number="417"></td>
+        <td id="LC417" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L418" class="blob-num js-line-number" data-line-number="418"></td>
+        <td id="LC418" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Checks that all named arguments are in the specified list of names.</span></td>
+      </tr>
+      <tr>
+        <td id="L419" class="blob-num js-line-number" data-line-number="419"></td>
+        <td id="LC419" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L420" class="blob-num js-line-number" data-line-number="420"></td>
+        <td id="LC420" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type kwargs: dict</span></td>
+      </tr>
+      <tr>
+        <td id="L421" class="blob-num js-line-number" data-line-number="421"></td>
+        <td id="LC421" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param kwargs: Dictionary of kwargs to validate.</span></td>
+      </tr>
+      <tr>
+        <td id="L422" class="blob-num js-line-number" data-line-number="422"></td>
+        <td id="LC422" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L423" class="blob-num js-line-number" data-line-number="423"></td>
+        <td id="LC423" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type names: list</span></td>
+      </tr>
+      <tr>
+        <td id="L424" class="blob-num js-line-number" data-line-number="424"></td>
+        <td id="LC424" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param names: List of possible named arguments.</span></td>
+      </tr>
+      <tr>
+        <td id="L425" class="blob-num js-line-number" data-line-number="425"></td>
+        <td id="LC425" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L426" class="blob-num js-line-number" data-line-number="426"></td>
+        <td id="LC426" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">for</span> kwarg <span class="pl-k">in</span> kwargs:</td>
+      </tr>
+      <tr>
+        <td id="L427" class="blob-num js-line-number" data-line-number="427"></td>
+        <td id="LC427" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> kwarg <span class="pl-k">not</span> <span class="pl-k">in</span> names:</td>
+      </tr>
+      <tr>
+        <td id="L428" class="blob-num js-line-number" data-line-number="428"></td>
+        <td id="LC428" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">raise</span> <span class="pl-c1">TypeError</span>(<span class="pl-s"><span class="pl-pds">&#39;</span>Invalid argument &quot;<span class="pl-c1">%s</span>&quot;!<span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> kwarg)</td>
+      </tr>
+      <tr>
+        <td id="L429" class="blob-num js-line-number" data-line-number="429"></td>
+        <td id="LC429" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L430" class="blob-num js-line-number" data-line-number="430"></td>
+        <td id="LC430" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_all_keys</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-k">**</span><span class="pl-smi">params</span>):</td>
+      </tr>
+      <tr>
+        <td id="L431" class="blob-num js-line-number" data-line-number="431"></td>
+        <td id="LC431" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L432" class="blob-num js-line-number" data-line-number="432"></td>
+        <td id="LC432" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        A lower-level method for listing contents of a bucket.  This</span></td>
+      </tr>
+      <tr>
+        <td id="L433" class="blob-num js-line-number" data-line-number="433"></td>
+        <td id="LC433" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        closely models the actual S3 API and requires you to manually</span></td>
+      </tr>
+      <tr>
+        <td id="L434" class="blob-num js-line-number" data-line-number="434"></td>
+        <td id="LC434" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        handle the paging of results.  For a higher-level method that</span></td>
+      </tr>
+      <tr>
+        <td id="L435" class="blob-num js-line-number" data-line-number="435"></td>
+        <td id="LC435" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        handles the details of paging for you, you can use the list</span></td>
+      </tr>
+      <tr>
+        <td id="L436" class="blob-num js-line-number" data-line-number="436"></td>
+        <td id="LC436" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        method.</span></td>
+      </tr>
+      <tr>
+        <td id="L437" class="blob-num js-line-number" data-line-number="437"></td>
+        <td id="LC437" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L438" class="blob-num js-line-number" data-line-number="438"></td>
+        <td id="LC438" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type max_keys: int</span></td>
+      </tr>
+      <tr>
+        <td id="L439" class="blob-num js-line-number" data-line-number="439"></td>
+        <td id="LC439" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param max_keys: The maximum number of keys to retrieve</span></td>
+      </tr>
+      <tr>
+        <td id="L440" class="blob-num js-line-number" data-line-number="440"></td>
+        <td id="LC440" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L441" class="blob-num js-line-number" data-line-number="441"></td>
+        <td id="LC441" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type prefix: string</span></td>
+      </tr>
+      <tr>
+        <td id="L442" class="blob-num js-line-number" data-line-number="442"></td>
+        <td id="LC442" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param prefix: The prefix of the keys you want to retrieve</span></td>
+      </tr>
+      <tr>
+        <td id="L443" class="blob-num js-line-number" data-line-number="443"></td>
+        <td id="LC443" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L444" class="blob-num js-line-number" data-line-number="444"></td>
+        <td id="LC444" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type marker: string</span></td>
+      </tr>
+      <tr>
+        <td id="L445" class="blob-num js-line-number" data-line-number="445"></td>
+        <td id="LC445" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param marker: The &quot;marker&quot; of where you are in the result set</span></td>
+      </tr>
+      <tr>
+        <td id="L446" class="blob-num js-line-number" data-line-number="446"></td>
+        <td id="LC446" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L447" class="blob-num js-line-number" data-line-number="447"></td>
+        <td id="LC447" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type delimiter: string</span></td>
+      </tr>
+      <tr>
+        <td id="L448" class="blob-num js-line-number" data-line-number="448"></td>
+        <td id="LC448" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param delimiter: If this optional, Unicode string parameter</span></td>
+      </tr>
+      <tr>
+        <td id="L449" class="blob-num js-line-number" data-line-number="449"></td>
+        <td id="LC449" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            is included with your request, then keys that contain the</span></td>
+      </tr>
+      <tr>
+        <td id="L450" class="blob-num js-line-number" data-line-number="450"></td>
+        <td id="LC450" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            same string between the prefix and the first occurrence of</span></td>
+      </tr>
+      <tr>
+        <td id="L451" class="blob-num js-line-number" data-line-number="451"></td>
+        <td id="LC451" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the delimiter will be rolled up into a single result</span></td>
+      </tr>
+      <tr>
+        <td id="L452" class="blob-num js-line-number" data-line-number="452"></td>
+        <td id="LC452" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            element in the CommonPrefixes collection. These rolled-up</span></td>
+      </tr>
+      <tr>
+        <td id="L453" class="blob-num js-line-number" data-line-number="453"></td>
+        <td id="LC453" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            keys are not returned elsewhere in the response.</span></td>
+      </tr>
+      <tr>
+        <td id="L454" class="blob-num js-line-number" data-line-number="454"></td>
+        <td id="LC454" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L455" class="blob-num js-line-number" data-line-number="455"></td>
+        <td id="LC455" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encoding_type: Requests Amazon S3 to encode the response and</span></td>
+      </tr>
+      <tr>
+        <td id="L456" class="blob-num js-line-number" data-line-number="456"></td>
+        <td id="LC456" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specifies the encoding method to use.</span></td>
+      </tr>
+      <tr>
+        <td id="L457" class="blob-num js-line-number" data-line-number="457"></td>
+        <td id="LC457" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L458" class="blob-num js-line-number" data-line-number="458"></td>
+        <td id="LC458" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            An object key can contain any Unicode character; however, XML 1.0</span></td>
+      </tr>
+      <tr>
+        <td id="L459" class="blob-num js-line-number" data-line-number="459"></td>
+        <td id="LC459" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parser cannot parse some characters, such as characters with an</span></td>
+      </tr>
+      <tr>
+        <td id="L460" class="blob-num js-line-number" data-line-number="460"></td>
+        <td id="LC460" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ASCII value from 0 to 10. For characters that are not supported in</span></td>
+      </tr>
+      <tr>
+        <td id="L461" class="blob-num js-line-number" data-line-number="461"></td>
+        <td id="LC461" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            XML 1.0, you can add this parameter to request that Amazon S3</span></td>
+      </tr>
+      <tr>
+        <td id="L462" class="blob-num js-line-number" data-line-number="462"></td>
+        <td id="LC462" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            encode the keys in the response.</span></td>
+      </tr>
+      <tr>
+        <td id="L463" class="blob-num js-line-number" data-line-number="463"></td>
+        <td id="LC463" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L464" class="blob-num js-line-number" data-line-number="464"></td>
+        <td id="LC464" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Valid options: ``url``</span></td>
+      </tr>
+      <tr>
+        <td id="L465" class="blob-num js-line-number" data-line-number="465"></td>
+        <td id="LC465" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encoding_type: string</span></td>
+      </tr>
+      <tr>
+        <td id="L466" class="blob-num js-line-number" data-line-number="466"></td>
+        <td id="LC466" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L467" class="blob-num js-line-number" data-line-number="467"></td>
+        <td id="LC467" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: ResultSet</span></td>
+      </tr>
+      <tr>
+        <td id="L468" class="blob-num js-line-number" data-line-number="468"></td>
+        <td id="LC468" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: The result from S3 listing the keys requested</span></td>
+      </tr>
+      <tr>
+        <td id="L469" class="blob-num js-line-number" data-line-number="469"></td>
+        <td id="LC469" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L470" class="blob-num js-line-number" data-line-number="470"></td>
+        <td id="LC470" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L471" class="blob-num js-line-number" data-line-number="471"></td>
+        <td id="LC471" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.validate_kwarg_names(params, [<span class="pl-s"><span class="pl-pds">&#39;</span>maxkeys<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>max_keys<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>prefix<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L472" class="blob-num js-line-number" data-line-number="472"></td>
+        <td id="LC472" class="blob-code blob-code-inner js-file-line">                                           <span class="pl-s"><span class="pl-pds">&#39;</span>marker<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>delimiter<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L473" class="blob-num js-line-number" data-line-number="473"></td>
+        <td id="LC473" class="blob-code blob-code-inner js-file-line">                                           <span class="pl-s"><span class="pl-pds">&#39;</span>encoding_type<span class="pl-pds">&#39;</span></span>])</td>
+      </tr>
+      <tr>
+        <td id="L474" class="blob-num js-line-number" data-line-number="474"></td>
+        <td id="LC474" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>._get_all([(<span class="pl-s"><span class="pl-pds">&#39;</span>Contents<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.key_class),</td>
+      </tr>
+      <tr>
+        <td id="L475" class="blob-num js-line-number" data-line-number="475"></td>
+        <td id="LC475" class="blob-code blob-code-inner js-file-line">                              (<span class="pl-s"><span class="pl-pds">&#39;</span>CommonPrefixes<span class="pl-pds">&#39;</span></span>, Prefix)],</td>
+      </tr>
+      <tr>
+        <td id="L476" class="blob-num js-line-number" data-line-number="476"></td>
+        <td id="LC476" class="blob-code blob-code-inner js-file-line">                             <span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, headers, <span class="pl-k">**</span>params)</td>
+      </tr>
+      <tr>
+        <td id="L477" class="blob-num js-line-number" data-line-number="477"></td>
+        <td id="LC477" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L478" class="blob-num js-line-number" data-line-number="478"></td>
+        <td id="LC478" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_all_versions</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-k">**</span><span class="pl-smi">params</span>):</td>
+      </tr>
+      <tr>
+        <td id="L479" class="blob-num js-line-number" data-line-number="479"></td>
+        <td id="LC479" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L480" class="blob-num js-line-number" data-line-number="480"></td>
+        <td id="LC480" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        A lower-level, version-aware method for listing contents of a</span></td>
+      </tr>
+      <tr>
+        <td id="L481" class="blob-num js-line-number" data-line-number="481"></td>
+        <td id="LC481" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        bucket.  This closely models the actual S3 API and requires</span></td>
+      </tr>
+      <tr>
+        <td id="L482" class="blob-num js-line-number" data-line-number="482"></td>
+        <td id="LC482" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        you to manually handle the paging of results.  For a</span></td>
+      </tr>
+      <tr>
+        <td id="L483" class="blob-num js-line-number" data-line-number="483"></td>
+        <td id="LC483" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        higher-level method that handles the details of paging for</span></td>
+      </tr>
+      <tr>
+        <td id="L484" class="blob-num js-line-number" data-line-number="484"></td>
+        <td id="LC484" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        you, you can use the list method.</span></td>
+      </tr>
+      <tr>
+        <td id="L485" class="blob-num js-line-number" data-line-number="485"></td>
+        <td id="LC485" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L486" class="blob-num js-line-number" data-line-number="486"></td>
+        <td id="LC486" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type max_keys: int</span></td>
+      </tr>
+      <tr>
+        <td id="L487" class="blob-num js-line-number" data-line-number="487"></td>
+        <td id="LC487" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param max_keys: The maximum number of keys to retrieve</span></td>
+      </tr>
+      <tr>
+        <td id="L488" class="blob-num js-line-number" data-line-number="488"></td>
+        <td id="LC488" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L489" class="blob-num js-line-number" data-line-number="489"></td>
+        <td id="LC489" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type prefix: string</span></td>
+      </tr>
+      <tr>
+        <td id="L490" class="blob-num js-line-number" data-line-number="490"></td>
+        <td id="LC490" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param prefix: The prefix of the keys you want to retrieve</span></td>
+      </tr>
+      <tr>
+        <td id="L491" class="blob-num js-line-number" data-line-number="491"></td>
+        <td id="LC491" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L492" class="blob-num js-line-number" data-line-number="492"></td>
+        <td id="LC492" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_marker: string</span></td>
+      </tr>
+      <tr>
+        <td id="L493" class="blob-num js-line-number" data-line-number="493"></td>
+        <td id="LC493" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_marker: The &quot;marker&quot; of where you are in the result set</span></td>
+      </tr>
+      <tr>
+        <td id="L494" class="blob-num js-line-number" data-line-number="494"></td>
+        <td id="LC494" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            with respect to keys.</span></td>
+      </tr>
+      <tr>
+        <td id="L495" class="blob-num js-line-number" data-line-number="495"></td>
+        <td id="LC495" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L496" class="blob-num js-line-number" data-line-number="496"></td>
+        <td id="LC496" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type version_id_marker: string</span></td>
+      </tr>
+      <tr>
+        <td id="L497" class="blob-num js-line-number" data-line-number="497"></td>
+        <td id="LC497" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param version_id_marker: The &quot;marker&quot; of where you are in the result</span></td>
+      </tr>
+      <tr>
+        <td id="L498" class="blob-num js-line-number" data-line-number="498"></td>
+        <td id="LC498" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            set with respect to version-id&#39;s.</span></td>
+      </tr>
+      <tr>
+        <td id="L499" class="blob-num js-line-number" data-line-number="499"></td>
+        <td id="LC499" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L500" class="blob-num js-line-number" data-line-number="500"></td>
+        <td id="LC500" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type delimiter: string</span></td>
+      </tr>
+      <tr>
+        <td id="L501" class="blob-num js-line-number" data-line-number="501"></td>
+        <td id="LC501" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param delimiter: If this optional, Unicode string parameter</span></td>
+      </tr>
+      <tr>
+        <td id="L502" class="blob-num js-line-number" data-line-number="502"></td>
+        <td id="LC502" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            is included with your request, then keys that contain the</span></td>
+      </tr>
+      <tr>
+        <td id="L503" class="blob-num js-line-number" data-line-number="503"></td>
+        <td id="LC503" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            same string between the prefix and the first occurrence of</span></td>
+      </tr>
+      <tr>
+        <td id="L504" class="blob-num js-line-number" data-line-number="504"></td>
+        <td id="LC504" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the delimiter will be rolled up into a single result</span></td>
+      </tr>
+      <tr>
+        <td id="L505" class="blob-num js-line-number" data-line-number="505"></td>
+        <td id="LC505" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            element in the CommonPrefixes collection. These rolled-up</span></td>
+      </tr>
+      <tr>
+        <td id="L506" class="blob-num js-line-number" data-line-number="506"></td>
+        <td id="LC506" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            keys are not returned elsewhere in the response.</span></td>
+      </tr>
+      <tr>
+        <td id="L507" class="blob-num js-line-number" data-line-number="507"></td>
+        <td id="LC507" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L508" class="blob-num js-line-number" data-line-number="508"></td>
+        <td id="LC508" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encoding_type: Requests Amazon S3 to encode the response and</span></td>
+      </tr>
+      <tr>
+        <td id="L509" class="blob-num js-line-number" data-line-number="509"></td>
+        <td id="LC509" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specifies the encoding method to use.</span></td>
+      </tr>
+      <tr>
+        <td id="L510" class="blob-num js-line-number" data-line-number="510"></td>
+        <td id="LC510" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L511" class="blob-num js-line-number" data-line-number="511"></td>
+        <td id="LC511" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            An object key can contain any Unicode character; however, XML 1.0</span></td>
+      </tr>
+      <tr>
+        <td id="L512" class="blob-num js-line-number" data-line-number="512"></td>
+        <td id="LC512" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parser cannot parse some characters, such as characters with an</span></td>
+      </tr>
+      <tr>
+        <td id="L513" class="blob-num js-line-number" data-line-number="513"></td>
+        <td id="LC513" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ASCII value from 0 to 10. For characters that are not supported in</span></td>
+      </tr>
+      <tr>
+        <td id="L514" class="blob-num js-line-number" data-line-number="514"></td>
+        <td id="LC514" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            XML 1.0, you can add this parameter to request that Amazon S3</span></td>
+      </tr>
+      <tr>
+        <td id="L515" class="blob-num js-line-number" data-line-number="515"></td>
+        <td id="LC515" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            encode the keys in the response.</span></td>
+      </tr>
+      <tr>
+        <td id="L516" class="blob-num js-line-number" data-line-number="516"></td>
+        <td id="LC516" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L517" class="blob-num js-line-number" data-line-number="517"></td>
+        <td id="LC517" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Valid options: ``url``</span></td>
+      </tr>
+      <tr>
+        <td id="L518" class="blob-num js-line-number" data-line-number="518"></td>
+        <td id="LC518" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encoding_type: string</span></td>
+      </tr>
+      <tr>
+        <td id="L519" class="blob-num js-line-number" data-line-number="519"></td>
+        <td id="LC519" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L520" class="blob-num js-line-number" data-line-number="520"></td>
+        <td id="LC520" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: ResultSet</span></td>
+      </tr>
+      <tr>
+        <td id="L521" class="blob-num js-line-number" data-line-number="521"></td>
+        <td id="LC521" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: The result from S3 listing the keys requested</span></td>
+      </tr>
+      <tr>
+        <td id="L522" class="blob-num js-line-number" data-line-number="522"></td>
+        <td id="LC522" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L523" class="blob-num js-line-number" data-line-number="523"></td>
+        <td id="LC523" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.validate_get_all_versions_params(params)</td>
+      </tr>
+      <tr>
+        <td id="L524" class="blob-num js-line-number" data-line-number="524"></td>
+        <td id="LC524" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>._get_all([(<span class="pl-s"><span class="pl-pds">&#39;</span>Version<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.key_class),</td>
+      </tr>
+      <tr>
+        <td id="L525" class="blob-num js-line-number" data-line-number="525"></td>
+        <td id="LC525" class="blob-code blob-code-inner js-file-line">                              (<span class="pl-s"><span class="pl-pds">&#39;</span>CommonPrefixes<span class="pl-pds">&#39;</span></span>, Prefix),</td>
+      </tr>
+      <tr>
+        <td id="L526" class="blob-num js-line-number" data-line-number="526"></td>
+        <td id="LC526" class="blob-code blob-code-inner js-file-line">                              (<span class="pl-s"><span class="pl-pds">&#39;</span>DeleteMarker<span class="pl-pds">&#39;</span></span>, DeleteMarker)],</td>
+      </tr>
+      <tr>
+        <td id="L527" class="blob-num js-line-number" data-line-number="527"></td>
+        <td id="LC527" class="blob-code blob-code-inner js-file-line">                             <span class="pl-s"><span class="pl-pds">&#39;</span>versions<span class="pl-pds">&#39;</span></span>, headers, <span class="pl-k">**</span>params)</td>
+      </tr>
+      <tr>
+        <td id="L528" class="blob-num js-line-number" data-line-number="528"></td>
+        <td id="LC528" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L529" class="blob-num js-line-number" data-line-number="529"></td>
+        <td id="LC529" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">validate_get_all_versions_params</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">params</span>):</td>
+      </tr>
+      <tr>
+        <td id="L530" class="blob-num js-line-number" data-line-number="530"></td>
+        <td id="LC530" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L531" class="blob-num js-line-number" data-line-number="531"></td>
+        <td id="LC531" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Validate that the parameters passed to get_all_versions are valid.</span></td>
+      </tr>
+      <tr>
+        <td id="L532" class="blob-num js-line-number" data-line-number="532"></td>
+        <td id="LC532" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Overridden by subclasses that allow a different set of parameters.</span></td>
+      </tr>
+      <tr>
+        <td id="L533" class="blob-num js-line-number" data-line-number="533"></td>
+        <td id="LC533" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L534" class="blob-num js-line-number" data-line-number="534"></td>
+        <td id="LC534" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type params: dict</span></td>
+      </tr>
+      <tr>
+        <td id="L535" class="blob-num js-line-number" data-line-number="535"></td>
+        <td id="LC535" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param params: Parameters to validate.</span></td>
+      </tr>
+      <tr>
+        <td id="L536" class="blob-num js-line-number" data-line-number="536"></td>
+        <td id="LC536" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L537" class="blob-num js-line-number" data-line-number="537"></td>
+        <td id="LC537" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.validate_kwarg_names(</td>
+      </tr>
+      <tr>
+        <td id="L538" class="blob-num js-line-number" data-line-number="538"></td>
+        <td id="LC538" class="blob-code blob-code-inner js-file-line">                params, [<span class="pl-s"><span class="pl-pds">&#39;</span>maxkeys<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>max_keys<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>prefix<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>key_marker<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L539" class="blob-num js-line-number" data-line-number="539"></td>
+        <td id="LC539" class="blob-code blob-code-inner js-file-line">                         <span class="pl-s"><span class="pl-pds">&#39;</span>version_id_marker<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>delimiter<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>encoding_type<span class="pl-pds">&#39;</span></span>])</td>
+      </tr>
+      <tr>
+        <td id="L540" class="blob-num js-line-number" data-line-number="540"></td>
+        <td id="LC540" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L541" class="blob-num js-line-number" data-line-number="541"></td>
+        <td id="LC541" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_all_multipart_uploads</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-k">**</span><span class="pl-smi">params</span>):</td>
+      </tr>
+      <tr>
+        <td id="L542" class="blob-num js-line-number" data-line-number="542"></td>
+        <td id="LC542" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L543" class="blob-num js-line-number" data-line-number="543"></td>
+        <td id="LC543" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        A lower-level, version-aware method for listing active</span></td>
+      </tr>
+      <tr>
+        <td id="L544" class="blob-num js-line-number" data-line-number="544"></td>
+        <td id="LC544" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        MultiPart uploads for a bucket.  This closely models the</span></td>
+      </tr>
+      <tr>
+        <td id="L545" class="blob-num js-line-number" data-line-number="545"></td>
+        <td id="LC545" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        actual S3 API and requires you to manually handle the paging</span></td>
+      </tr>
+      <tr>
+        <td id="L546" class="blob-num js-line-number" data-line-number="546"></td>
+        <td id="LC546" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        of results.  For a higher-level method that handles the</span></td>
+      </tr>
+      <tr>
+        <td id="L547" class="blob-num js-line-number" data-line-number="547"></td>
+        <td id="LC547" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        details of paging for you, you can use the list method.</span></td>
+      </tr>
+      <tr>
+        <td id="L548" class="blob-num js-line-number" data-line-number="548"></td>
+        <td id="LC548" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L549" class="blob-num js-line-number" data-line-number="549"></td>
+        <td id="LC549" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type max_uploads: int</span></td>
+      </tr>
+      <tr>
+        <td id="L550" class="blob-num js-line-number" data-line-number="550"></td>
+        <td id="LC550" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param max_uploads: The maximum number of uploads to retrieve.</span></td>
+      </tr>
+      <tr>
+        <td id="L551" class="blob-num js-line-number" data-line-number="551"></td>
+        <td id="LC551" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Default value is 1000.</span></td>
+      </tr>
+      <tr>
+        <td id="L552" class="blob-num js-line-number" data-line-number="552"></td>
+        <td id="LC552" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L553" class="blob-num js-line-number" data-line-number="553"></td>
+        <td id="LC553" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_marker: string</span></td>
+      </tr>
+      <tr>
+        <td id="L554" class="blob-num js-line-number" data-line-number="554"></td>
+        <td id="LC554" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_marker: Together with upload_id_marker, this</span></td>
+      </tr>
+      <tr>
+        <td id="L555" class="blob-num js-line-number" data-line-number="555"></td>
+        <td id="LC555" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parameter specifies the multipart upload after which</span></td>
+      </tr>
+      <tr>
+        <td id="L556" class="blob-num js-line-number" data-line-number="556"></td>
+        <td id="LC556" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            listing should begin.  If upload_id_marker is not</span></td>
+      </tr>
+      <tr>
+        <td id="L557" class="blob-num js-line-number" data-line-number="557"></td>
+        <td id="LC557" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specified, only the keys lexicographically greater than</span></td>
+      </tr>
+      <tr>
+        <td id="L558" class="blob-num js-line-number" data-line-number="558"></td>
+        <td id="LC558" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the specified key_marker will be included in the list.</span></td>
+      </tr>
+      <tr>
+        <td id="L559" class="blob-num js-line-number" data-line-number="559"></td>
+        <td id="LC559" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L560" class="blob-num js-line-number" data-line-number="560"></td>
+        <td id="LC560" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            If upload_id_marker is specified, any multipart uploads</span></td>
+      </tr>
+      <tr>
+        <td id="L561" class="blob-num js-line-number" data-line-number="561"></td>
+        <td id="LC561" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            for a key equal to the key_marker might also be included,</span></td>
+      </tr>
+      <tr>
+        <td id="L562" class="blob-num js-line-number" data-line-number="562"></td>
+        <td id="LC562" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            provided those multipart uploads have upload IDs</span></td>
+      </tr>
+      <tr>
+        <td id="L563" class="blob-num js-line-number" data-line-number="563"></td>
+        <td id="LC563" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            lexicographically greater than the specified</span></td>
+      </tr>
+      <tr>
+        <td id="L564" class="blob-num js-line-number" data-line-number="564"></td>
+        <td id="LC564" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            upload_id_marker.</span></td>
+      </tr>
+      <tr>
+        <td id="L565" class="blob-num js-line-number" data-line-number="565"></td>
+        <td id="LC565" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L566" class="blob-num js-line-number" data-line-number="566"></td>
+        <td id="LC566" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type upload_id_marker: string</span></td>
+      </tr>
+      <tr>
+        <td id="L567" class="blob-num js-line-number" data-line-number="567"></td>
+        <td id="LC567" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param upload_id_marker: Together with key-marker, specifies</span></td>
+      </tr>
+      <tr>
+        <td id="L568" class="blob-num js-line-number" data-line-number="568"></td>
+        <td id="LC568" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the multipart upload after which listing should begin. If</span></td>
+      </tr>
+      <tr>
+        <td id="L569" class="blob-num js-line-number" data-line-number="569"></td>
+        <td id="LC569" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            key_marker is not specified, the upload_id_marker</span></td>
+      </tr>
+      <tr>
+        <td id="L570" class="blob-num js-line-number" data-line-number="570"></td>
+        <td id="LC570" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parameter is ignored.  Otherwise, any multipart uploads</span></td>
+      </tr>
+      <tr>
+        <td id="L571" class="blob-num js-line-number" data-line-number="571"></td>
+        <td id="LC571" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            for a key equal to the key_marker might be included in the</span></td>
+      </tr>
+      <tr>
+        <td id="L572" class="blob-num js-line-number" data-line-number="572"></td>
+        <td id="LC572" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            list only if they have an upload ID lexicographically</span></td>
+      </tr>
+      <tr>
+        <td id="L573" class="blob-num js-line-number" data-line-number="573"></td>
+        <td id="LC573" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            greater than the specified upload_id_marker.</span></td>
+      </tr>
+      <tr>
+        <td id="L574" class="blob-num js-line-number" data-line-number="574"></td>
+        <td id="LC574" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L575" class="blob-num js-line-number" data-line-number="575"></td>
+        <td id="LC575" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encoding_type: string</span></td>
+      </tr>
+      <tr>
+        <td id="L576" class="blob-num js-line-number" data-line-number="576"></td>
+        <td id="LC576" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encoding_type: Requests Amazon S3 to encode the response and</span></td>
+      </tr>
+      <tr>
+        <td id="L577" class="blob-num js-line-number" data-line-number="577"></td>
+        <td id="LC577" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specifies the encoding method to use.</span></td>
+      </tr>
+      <tr>
+        <td id="L578" class="blob-num js-line-number" data-line-number="578"></td>
+        <td id="LC578" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L579" class="blob-num js-line-number" data-line-number="579"></td>
+        <td id="LC579" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            An object key can contain any Unicode character; however, XML 1.0</span></td>
+      </tr>
+      <tr>
+        <td id="L580" class="blob-num js-line-number" data-line-number="580"></td>
+        <td id="LC580" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parser cannot parse some characters, such as characters with an</span></td>
+      </tr>
+      <tr>
+        <td id="L581" class="blob-num js-line-number" data-line-number="581"></td>
+        <td id="LC581" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ASCII value from 0 to 10. For characters that are not supported in</span></td>
+      </tr>
+      <tr>
+        <td id="L582" class="blob-num js-line-number" data-line-number="582"></td>
+        <td id="LC582" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            XML 1.0, you can add this parameter to request that Amazon S3</span></td>
+      </tr>
+      <tr>
+        <td id="L583" class="blob-num js-line-number" data-line-number="583"></td>
+        <td id="LC583" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            encode the keys in the response.</span></td>
+      </tr>
+      <tr>
+        <td id="L584" class="blob-num js-line-number" data-line-number="584"></td>
+        <td id="LC584" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L585" class="blob-num js-line-number" data-line-number="585"></td>
+        <td id="LC585" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Valid options: ``url``</span></td>
+      </tr>
+      <tr>
+        <td id="L586" class="blob-num js-line-number" data-line-number="586"></td>
+        <td id="LC586" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L587" class="blob-num js-line-number" data-line-number="587"></td>
+        <td id="LC587" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type delimiter: string</span></td>
+      </tr>
+      <tr>
+        <td id="L588" class="blob-num js-line-number" data-line-number="588"></td>
+        <td id="LC588" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param delimiter: Character you use to group keys.</span></td>
+      </tr>
+      <tr>
+        <td id="L589" class="blob-num js-line-number" data-line-number="589"></td>
+        <td id="LC589" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            All keys that contain the same string between the prefix, if</span></td>
+      </tr>
+      <tr>
+        <td id="L590" class="blob-num js-line-number" data-line-number="590"></td>
+        <td id="LC590" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specified, and the first occurrence of the delimiter after the</span></td>
+      </tr>
+      <tr>
+        <td id="L591" class="blob-num js-line-number" data-line-number="591"></td>
+        <td id="LC591" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            prefix are grouped under a single result element, CommonPrefixes.</span></td>
+      </tr>
+      <tr>
+        <td id="L592" class="blob-num js-line-number" data-line-number="592"></td>
+        <td id="LC592" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            If you don&#39;t specify the prefix parameter, then the substring</span></td>
+      </tr>
+      <tr>
+        <td id="L593" class="blob-num js-line-number" data-line-number="593"></td>
+        <td id="LC593" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            starts at the beginning of the key. The keys that are grouped</span></td>
+      </tr>
+      <tr>
+        <td id="L594" class="blob-num js-line-number" data-line-number="594"></td>
+        <td id="LC594" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            under CommonPrefixes result element are not returned elsewhere</span></td>
+      </tr>
+      <tr>
+        <td id="L595" class="blob-num js-line-number" data-line-number="595"></td>
+        <td id="LC595" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            in the response.</span></td>
+      </tr>
+      <tr>
+        <td id="L596" class="blob-num js-line-number" data-line-number="596"></td>
+        <td id="LC596" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L597" class="blob-num js-line-number" data-line-number="597"></td>
+        <td id="LC597" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type prefix: string</span></td>
+      </tr>
+      <tr>
+        <td id="L598" class="blob-num js-line-number" data-line-number="598"></td>
+        <td id="LC598" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param prefix: Lists in-progress uploads only for those keys that</span></td>
+      </tr>
+      <tr>
+        <td id="L599" class="blob-num js-line-number" data-line-number="599"></td>
+        <td id="LC599" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            begin with the specified prefix. You can use prefixes to separate</span></td>
+      </tr>
+      <tr>
+        <td id="L600" class="blob-num js-line-number" data-line-number="600"></td>
+        <td id="LC600" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            a bucket into different grouping of keys. (You can think of using</span></td>
+      </tr>
+      <tr>
+        <td id="L601" class="blob-num js-line-number" data-line-number="601"></td>
+        <td id="LC601" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            prefix to make groups in the same way you&#39;d use a folder in a</span></td>
+      </tr>
+      <tr>
+        <td id="L602" class="blob-num js-line-number" data-line-number="602"></td>
+        <td id="LC602" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            file system.)</span></td>
+      </tr>
+      <tr>
+        <td id="L603" class="blob-num js-line-number" data-line-number="603"></td>
+        <td id="LC603" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L604" class="blob-num js-line-number" data-line-number="604"></td>
+        <td id="LC604" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: ResultSet</span></td>
+      </tr>
+      <tr>
+        <td id="L605" class="blob-num js-line-number" data-line-number="605"></td>
+        <td id="LC605" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: The result from S3 listing the uploads requested</span></td>
+      </tr>
+      <tr>
+        <td id="L606" class="blob-num js-line-number" data-line-number="606"></td>
+        <td id="LC606" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L607" class="blob-num js-line-number" data-line-number="607"></td>
+        <td id="LC607" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L608" class="blob-num js-line-number" data-line-number="608"></td>
+        <td id="LC608" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.validate_kwarg_names(params, [<span class="pl-s"><span class="pl-pds">&#39;</span>max_uploads<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>key_marker<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L609" class="blob-num js-line-number" data-line-number="609"></td>
+        <td id="LC609" class="blob-code blob-code-inner js-file-line">                                           <span class="pl-s"><span class="pl-pds">&#39;</span>upload_id_marker<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>encoding_type<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L610" class="blob-num js-line-number" data-line-number="610"></td>
+        <td id="LC610" class="blob-code blob-code-inner js-file-line">                                           <span class="pl-s"><span class="pl-pds">&#39;</span>delimiter<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>prefix<span class="pl-pds">&#39;</span></span>])</td>
+      </tr>
+      <tr>
+        <td id="L611" class="blob-num js-line-number" data-line-number="611"></td>
+        <td id="LC611" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>._get_all([(<span class="pl-s"><span class="pl-pds">&#39;</span>Upload<span class="pl-pds">&#39;</span></span>, MultiPartUpload),</td>
+      </tr>
+      <tr>
+        <td id="L612" class="blob-num js-line-number" data-line-number="612"></td>
+        <td id="LC612" class="blob-code blob-code-inner js-file-line">                              (<span class="pl-s"><span class="pl-pds">&#39;</span>CommonPrefixes<span class="pl-pds">&#39;</span></span>, Prefix)],</td>
+      </tr>
+      <tr>
+        <td id="L613" class="blob-num js-line-number" data-line-number="613"></td>
+        <td id="LC613" class="blob-code blob-code-inner js-file-line">                             <span class="pl-s"><span class="pl-pds">&#39;</span>uploads<span class="pl-pds">&#39;</span></span>, headers, <span class="pl-k">**</span>params)</td>
+      </tr>
+      <tr>
+        <td id="L614" class="blob-num js-line-number" data-line-number="614"></td>
+        <td id="LC614" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L615" class="blob-num js-line-number" data-line-number="615"></td>
+        <td id="LC615" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">new_key</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L616" class="blob-num js-line-number" data-line-number="616"></td>
+        <td id="LC616" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L617" class="blob-num js-line-number" data-line-number="617"></td>
+        <td id="LC617" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Creates a new key</span></td>
+      </tr>
+      <tr>
+        <td id="L618" class="blob-num js-line-number" data-line-number="618"></td>
+        <td id="LC618" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L619" class="blob-num js-line-number" data-line-number="619"></td>
+        <td id="LC619" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_name: string</span></td>
+      </tr>
+      <tr>
+        <td id="L620" class="blob-num js-line-number" data-line-number="620"></td>
+        <td id="LC620" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_name: The name of the key to create</span></td>
+      </tr>
+      <tr>
+        <td id="L621" class="blob-num js-line-number" data-line-number="621"></td>
+        <td id="LC621" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L622" class="blob-num js-line-number" data-line-number="622"></td>
+        <td id="LC622" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.key.Key` or subclass</span></td>
+      </tr>
+      <tr>
+        <td id="L623" class="blob-num js-line-number" data-line-number="623"></td>
+        <td id="LC623" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: An instance of the newly created key object</span></td>
+      </tr>
+      <tr>
+        <td id="L624" class="blob-num js-line-number" data-line-number="624"></td>
+        <td id="LC624" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L625" class="blob-num js-line-number" data-line-number="625"></td>
+        <td id="LC625" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> key_name:</td>
+      </tr>
+      <tr>
+        <td id="L626" class="blob-num js-line-number" data-line-number="626"></td>
+        <td id="LC626" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">ValueError</span>(<span class="pl-s"><span class="pl-pds">&#39;</span>Empty key names are not allowed<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L627" class="blob-num js-line-number" data-line-number="627"></td>
+        <td id="LC627" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.key_class(<span class="pl-c1">self</span>, key_name)</td>
+      </tr>
+      <tr>
+        <td id="L628" class="blob-num js-line-number" data-line-number="628"></td>
+        <td id="LC628" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L629" class="blob-num js-line-number" data-line-number="629"></td>
+        <td id="LC629" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">generate_url</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">expires_in</span>, <span class="pl-smi">method</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
+      </tr>
+      <tr>
+        <td id="L630" class="blob-num js-line-number" data-line-number="630"></td>
+        <td id="LC630" class="blob-code blob-code-inner js-file-line">                     <span class="pl-smi">force_http</span><span class="pl-k">=</span><span class="pl-c1">False</span>, <span class="pl-smi">response_headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
+      </tr>
+      <tr>
+        <td id="L631" class="blob-num js-line-number" data-line-number="631"></td>
+        <td id="LC631" class="blob-code blob-code-inner js-file-line">                     <span class="pl-smi">expires_in_absolute</span><span class="pl-k">=</span><span class="pl-c1">False</span>):</td>
+      </tr>
+      <tr>
+        <td id="L632" class="blob-num js-line-number" data-line-number="632"></td>
+        <td id="LC632" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.connection.generate_url(expires_in, method, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L633" class="blob-num js-line-number" data-line-number="633"></td>
+        <td id="LC633" class="blob-code blob-code-inner js-file-line">                                            <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
+      </tr>
+      <tr>
+        <td id="L634" class="blob-num js-line-number" data-line-number="634"></td>
+        <td id="LC634" class="blob-code blob-code-inner js-file-line">                                            <span class="pl-v">force_http</span><span class="pl-k">=</span>force_http,</td>
+      </tr>
+      <tr>
+        <td id="L635" class="blob-num js-line-number" data-line-number="635"></td>
+        <td id="LC635" class="blob-code blob-code-inner js-file-line">                                            <span class="pl-v">response_headers</span><span class="pl-k">=</span>response_headers,</td>
+      </tr>
+      <tr>
+        <td id="L636" class="blob-num js-line-number" data-line-number="636"></td>
+        <td id="LC636" class="blob-code blob-code-inner js-file-line">                                            <span class="pl-v">expires_in_absolute</span><span class="pl-k">=</span>expires_in_absolute)</td>
+      </tr>
+      <tr>
+        <td id="L637" class="blob-num js-line-number" data-line-number="637"></td>
+        <td id="LC637" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L638" class="blob-num js-line-number" data-line-number="638"></td>
+        <td id="LC638" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete_keys</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">keys</span>, <span class="pl-smi">quiet</span><span class="pl-k">=</span><span class="pl-c1">False</span>, <span class="pl-smi">mfa_token</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L639" class="blob-num js-line-number" data-line-number="639"></td>
+        <td id="LC639" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L640" class="blob-num js-line-number" data-line-number="640"></td>
+        <td id="LC640" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Deletes a set of keys using S3&#39;s Multi-object delete API. If a</span></td>
+      </tr>
+      <tr>
+        <td id="L641" class="blob-num js-line-number" data-line-number="641"></td>
+        <td id="LC641" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        VersionID is specified for that key then that version is removed.</span></td>
+      </tr>
+      <tr>
+        <td id="L642" class="blob-num js-line-number" data-line-number="642"></td>
+        <td id="LC642" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns a MultiDeleteResult Object, which contains Deleted</span></td>
+      </tr>
+      <tr>
+        <td id="L643" class="blob-num js-line-number" data-line-number="643"></td>
+        <td id="LC643" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        and Error elements for each key you ask to delete.</span></td>
+      </tr>
+      <tr>
+        <td id="L644" class="blob-num js-line-number" data-line-number="644"></td>
+        <td id="LC644" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L645" class="blob-num js-line-number" data-line-number="645"></td>
+        <td id="LC645" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type keys: list</span></td>
+      </tr>
+      <tr>
+        <td id="L646" class="blob-num js-line-number" data-line-number="646"></td>
+        <td id="LC646" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param keys: A list of either key_names or (key_name, versionid) pairs</span></td>
+      </tr>
+      <tr>
+        <td id="L647" class="blob-num js-line-number" data-line-number="647"></td>
+        <td id="LC647" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            or a list of Key instances.</span></td>
+      </tr>
+      <tr>
+        <td id="L648" class="blob-num js-line-number" data-line-number="648"></td>
+        <td id="LC648" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L649" class="blob-num js-line-number" data-line-number="649"></td>
+        <td id="LC649" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type quiet: boolean</span></td>
+      </tr>
+      <tr>
+        <td id="L650" class="blob-num js-line-number" data-line-number="650"></td>
+        <td id="LC650" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param quiet: In quiet mode the response includes only keys</span></td>
+      </tr>
+      <tr>
+        <td id="L651" class="blob-num js-line-number" data-line-number="651"></td>
+        <td id="LC651" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            where the delete operation encountered an error. For a</span></td>
+      </tr>
+      <tr>
+        <td id="L652" class="blob-num js-line-number" data-line-number="652"></td>
+        <td id="LC652" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            successful deletion, the operation does not return any</span></td>
+      </tr>
+      <tr>
+        <td id="L653" class="blob-num js-line-number" data-line-number="653"></td>
+        <td id="LC653" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            information about the delete in the response body.</span></td>
+      </tr>
+      <tr>
+        <td id="L654" class="blob-num js-line-number" data-line-number="654"></td>
+        <td id="LC654" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L655" class="blob-num js-line-number" data-line-number="655"></td>
+        <td id="LC655" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type mfa_token: tuple or list of strings</span></td>
+      </tr>
+      <tr>
+        <td id="L656" class="blob-num js-line-number" data-line-number="656"></td>
+        <td id="LC656" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param mfa_token: A tuple or list consisting of the serial</span></td>
+      </tr>
+      <tr>
+        <td id="L657" class="blob-num js-line-number" data-line-number="657"></td>
+        <td id="LC657" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            number from the MFA device and the current value of the</span></td>
+      </tr>
+      <tr>
+        <td id="L658" class="blob-num js-line-number" data-line-number="658"></td>
+        <td id="LC658" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            six-digit token associated with the device.  This value is</span></td>
+      </tr>
+      <tr>
+        <td id="L659" class="blob-num js-line-number" data-line-number="659"></td>
+        <td id="LC659" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            required anytime you are deleting versioned objects from a</span></td>
+      </tr>
+      <tr>
+        <td id="L660" class="blob-num js-line-number" data-line-number="660"></td>
+        <td id="LC660" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            bucket that has the MFADelete option on the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L661" class="blob-num js-line-number" data-line-number="661"></td>
+        <td id="LC661" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L662" class="blob-num js-line-number" data-line-number="662"></td>
+        <td id="LC662" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: An instance of MultiDeleteResult</span></td>
+      </tr>
+      <tr>
+        <td id="L663" class="blob-num js-line-number" data-line-number="663"></td>
+        <td id="LC663" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L664" class="blob-num js-line-number" data-line-number="664"></td>
+        <td id="LC664" class="blob-code blob-code-inner js-file-line">        ikeys <span class="pl-k">=</span> <span class="pl-c1">iter</span>(keys)</td>
+      </tr>
+      <tr>
+        <td id="L665" class="blob-num js-line-number" data-line-number="665"></td>
+        <td id="LC665" class="blob-code blob-code-inner js-file-line">        result <span class="pl-k">=</span> MultiDeleteResult(<span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L666" class="blob-num js-line-number" data-line-number="666"></td>
+        <td id="LC666" class="blob-code blob-code-inner js-file-line">        provider <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.provider</td>
+      </tr>
+      <tr>
+        <td id="L667" class="blob-num js-line-number" data-line-number="667"></td>
+        <td id="LC667" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>delete<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L668" class="blob-num js-line-number" data-line-number="668"></td>
+        <td id="LC668" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L669" class="blob-num js-line-number" data-line-number="669"></td>
+        <td id="LC669" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">def</span> <span class="pl-en">delete_keys2</span>(<span class="pl-smi">hdrs</span>):</td>
+      </tr>
+      <tr>
+        <td id="L670" class="blob-num js-line-number" data-line-number="670"></td>
+        <td id="LC670" class="blob-code blob-code-inner js-file-line">            hdrs <span class="pl-k">=</span> hdrs <span class="pl-k">or</span> {}</td>
+      </tr>
+      <tr>
+        <td id="L671" class="blob-num js-line-number" data-line-number="671"></td>
+        <td id="LC671" class="blob-code blob-code-inner js-file-line">            data <span class="pl-k">=</span> <span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&quot;&quot;&quot;</span>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;<span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L672" class="blob-num js-line-number" data-line-number="672"></td>
+        <td id="LC672" class="blob-code blob-code-inner js-file-line">            data <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&quot;</span>&lt;Delete&gt;<span class="pl-pds">&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L673" class="blob-num js-line-number" data-line-number="673"></td>
+        <td id="LC673" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> quiet:</td>
+      </tr>
+      <tr>
+        <td id="L674" class="blob-num js-line-number" data-line-number="674"></td>
+        <td id="LC674" class="blob-code blob-code-inner js-file-line">                data <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&quot;</span>&lt;Quiet&gt;true&lt;/Quiet&gt;<span class="pl-pds">&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L675" class="blob-num js-line-number" data-line-number="675"></td>
+        <td id="LC675" class="blob-code blob-code-inner js-file-line">            count <span class="pl-k">=</span> <span class="pl-c1">0</span></td>
+      </tr>
+      <tr>
+        <td id="L676" class="blob-num js-line-number" data-line-number="676"></td>
+        <td id="LC676" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">while</span> count <span class="pl-k">&lt;</span> <span class="pl-c1">1000</span>:</td>
+      </tr>
+      <tr>
+        <td id="L677" class="blob-num js-line-number" data-line-number="677"></td>
+        <td id="LC677" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">try</span>:</td>
+      </tr>
+      <tr>
+        <td id="L678" class="blob-num js-line-number" data-line-number="678"></td>
+        <td id="LC678" class="blob-code blob-code-inner js-file-line">                    key <span class="pl-k">=</span> <span class="pl-c1">next</span>(ikeys)</td>
+      </tr>
+      <tr>
+        <td id="L679" class="blob-num js-line-number" data-line-number="679"></td>
+        <td id="LC679" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">except</span> <span class="pl-c1">StopIteration</span>:</td>
+      </tr>
+      <tr>
+        <td id="L680" class="blob-num js-line-number" data-line-number="680"></td>
+        <td id="LC680" class="blob-code blob-code-inner js-file-line">                    <span class="pl-k">break</span></td>
+      </tr>
+      <tr>
+        <td id="L681" class="blob-num js-line-number" data-line-number="681"></td>
+        <td id="LC681" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">if</span> <span class="pl-c1">isinstance</span>(key, six.string_types):</td>
+      </tr>
+      <tr>
+        <td id="L682" class="blob-num js-line-number" data-line-number="682"></td>
+        <td id="LC682" class="blob-code blob-code-inner js-file-line">                    key_name <span class="pl-k">=</span> key</td>
+      </tr>
+      <tr>
+        <td id="L683" class="blob-num js-line-number" data-line-number="683"></td>
+        <td id="LC683" class="blob-code blob-code-inner js-file-line">                    version_id <span class="pl-k">=</span> <span class="pl-c1">None</span></td>
+      </tr>
+      <tr>
+        <td id="L684" class="blob-num js-line-number" data-line-number="684"></td>
+        <td id="LC684" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">elif</span> <span class="pl-c1">isinstance</span>(key, <span class="pl-c1">tuple</span>) <span class="pl-k">and</span> <span class="pl-c1">len</span>(key) <span class="pl-k">==</span> <span class="pl-c1">2</span>:</td>
+      </tr>
+      <tr>
+        <td id="L685" class="blob-num js-line-number" data-line-number="685"></td>
+        <td id="LC685" class="blob-code blob-code-inner js-file-line">                    key_name, version_id <span class="pl-k">=</span> key</td>
+      </tr>
+      <tr>
+        <td id="L686" class="blob-num js-line-number" data-line-number="686"></td>
+        <td id="LC686" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">elif</span> (<span class="pl-c1">isinstance</span>(key, Key) <span class="pl-k">or</span> <span class="pl-c1">isinstance</span>(key, DeleteMarker)) <span class="pl-k">and</span> key.name:</td>
+      </tr>
+      <tr>
+        <td id="L687" class="blob-num js-line-number" data-line-number="687"></td>
+        <td id="LC687" class="blob-code blob-code-inner js-file-line">                    key_name <span class="pl-k">=</span> key.name</td>
+      </tr>
+      <tr>
+        <td id="L688" class="blob-num js-line-number" data-line-number="688"></td>
+        <td id="LC688" class="blob-code blob-code-inner js-file-line">                    version_id <span class="pl-k">=</span> key.version_id</td>
+      </tr>
+      <tr>
+        <td id="L689" class="blob-num js-line-number" data-line-number="689"></td>
+        <td id="LC689" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L690" class="blob-num js-line-number" data-line-number="690"></td>
+        <td id="LC690" class="blob-code blob-code-inner js-file-line">                    <span class="pl-k">if</span> <span class="pl-c1">isinstance</span>(key, Prefix):</td>
+      </tr>
+      <tr>
+        <td id="L691" class="blob-num js-line-number" data-line-number="691"></td>
+        <td id="LC691" class="blob-code blob-code-inner js-file-line">                        key_name <span class="pl-k">=</span> key.name</td>
+      </tr>
+      <tr>
+        <td id="L692" class="blob-num js-line-number" data-line-number="692"></td>
+        <td id="LC692" class="blob-code blob-code-inner js-file-line">                        code <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>PrefixSkipped<span class="pl-pds">&#39;</span></span>   <span class="pl-c"><span class="pl-c">#</span> Don&#39;t delete Prefix</span></td>
+      </tr>
+      <tr>
+        <td id="L693" class="blob-num js-line-number" data-line-number="693"></td>
+        <td id="LC693" class="blob-code blob-code-inner js-file-line">                    <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L694" class="blob-num js-line-number" data-line-number="694"></td>
+        <td id="LC694" class="blob-code blob-code-inner js-file-line">                        key_name <span class="pl-k">=</span> <span class="pl-c1">repr</span>(key)   <span class="pl-c"><span class="pl-c">#</span> try get a string</span></td>
+      </tr>
+      <tr>
+        <td id="L695" class="blob-num js-line-number" data-line-number="695"></td>
+        <td id="LC695" class="blob-code blob-code-inner js-file-line">                        code <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>InvalidArgument<span class="pl-pds">&#39;</span></span>  <span class="pl-c"><span class="pl-c">#</span> other unknown type</span></td>
+      </tr>
+      <tr>
+        <td id="L696" class="blob-num js-line-number" data-line-number="696"></td>
+        <td id="LC696" class="blob-code blob-code-inner js-file-line">                    message <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>Invalid. No delete action taken for this object.<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L697" class="blob-num js-line-number" data-line-number="697"></td>
+        <td id="LC697" class="blob-code blob-code-inner js-file-line">                    error <span class="pl-k">=</span> Error(key_name, <span class="pl-v">code</span><span class="pl-k">=</span>code, <span class="pl-v">message</span><span class="pl-k">=</span>message)</td>
+      </tr>
+      <tr>
+        <td id="L698" class="blob-num js-line-number" data-line-number="698"></td>
+        <td id="LC698" class="blob-code blob-code-inner js-file-line">                    result.errors.append(error)</td>
+      </tr>
+      <tr>
+        <td id="L699" class="blob-num js-line-number" data-line-number="699"></td>
+        <td id="LC699" class="blob-code blob-code-inner js-file-line">                    <span class="pl-k">continue</span></td>
+      </tr>
+      <tr>
+        <td id="L700" class="blob-num js-line-number" data-line-number="700"></td>
+        <td id="LC700" class="blob-code blob-code-inner js-file-line">                count <span class="pl-k">+=</span> <span class="pl-c1">1</span></td>
+      </tr>
+      <tr>
+        <td id="L701" class="blob-num js-line-number" data-line-number="701"></td>
+        <td id="LC701" class="blob-code blob-code-inner js-file-line">                data <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&quot;</span>&lt;Object&gt;&lt;Key&gt;<span class="pl-c1">%s</span>&lt;/Key&gt;<span class="pl-pds">&quot;</span></span> <span class="pl-k">%</span> xml.sax.saxutils.escape(key_name)</td>
+      </tr>
+      <tr>
+        <td id="L702" class="blob-num js-line-number" data-line-number="702"></td>
+        <td id="LC702" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">if</span> version_id:</td>
+      </tr>
+      <tr>
+        <td id="L703" class="blob-num js-line-number" data-line-number="703"></td>
+        <td id="LC703" class="blob-code blob-code-inner js-file-line">                    data <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&quot;</span>&lt;VersionId&gt;<span class="pl-c1">%s</span>&lt;/VersionId&gt;<span class="pl-pds">&quot;</span></span> <span class="pl-k">%</span> version_id</td>
+      </tr>
+      <tr>
+        <td id="L704" class="blob-num js-line-number" data-line-number="704"></td>
+        <td id="LC704" class="blob-code blob-code-inner js-file-line">                data <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&quot;</span>&lt;/Object&gt;<span class="pl-pds">&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L705" class="blob-num js-line-number" data-line-number="705"></td>
+        <td id="LC705" class="blob-code blob-code-inner js-file-line">            data <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&quot;</span>&lt;/Delete&gt;<span class="pl-pds">&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L706" class="blob-num js-line-number" data-line-number="706"></td>
+        <td id="LC706" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> count <span class="pl-k">&lt;=</span> <span class="pl-c1">0</span>:</td>
+      </tr>
+      <tr>
+        <td id="L707" class="blob-num js-line-number" data-line-number="707"></td>
+        <td id="LC707" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">return</span> <span class="pl-c1">False</span>  <span class="pl-c"><span class="pl-c">#</span> no more</span></td>
+      </tr>
+      <tr>
+        <td id="L708" class="blob-num js-line-number" data-line-number="708"></td>
+        <td id="LC708" class="blob-code blob-code-inner js-file-line">            data <span class="pl-k">=</span> data.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L709" class="blob-num js-line-number" data-line-number="709"></td>
+        <td id="LC709" class="blob-code blob-code-inner js-file-line">            fp <span class="pl-k">=</span> BytesIO(data)</td>
+      </tr>
+      <tr>
+        <td id="L710" class="blob-num js-line-number" data-line-number="710"></td>
+        <td id="LC710" class="blob-code blob-code-inner js-file-line">            md5 <span class="pl-k">=</span> boto.utils.compute_md5(fp)</td>
+      </tr>
+      <tr>
+        <td id="L711" class="blob-num js-line-number" data-line-number="711"></td>
+        <td id="LC711" class="blob-code blob-code-inner js-file-line">            hdrs[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-MD5<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> md5[<span class="pl-c1">1</span>]</td>
+      </tr>
+      <tr>
+        <td id="L712" class="blob-num js-line-number" data-line-number="712"></td>
+        <td id="LC712" class="blob-code blob-code-inner js-file-line">            hdrs[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-Type<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>text/xml<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L713" class="blob-num js-line-number" data-line-number="713"></td>
+        <td id="LC713" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> mfa_token:</td>
+      </tr>
+      <tr>
+        <td id="L714" class="blob-num js-line-number" data-line-number="714"></td>
+        <td id="LC714" class="blob-code blob-code-inner js-file-line">                hdrs[provider.mfa_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span> <span class="pl-pds">&#39;</span></span>.join(mfa_token)</td>
+      </tr>
+      <tr>
+        <td id="L715" class="blob-num js-line-number" data-line-number="715"></td>
+        <td id="LC715" class="blob-code blob-code-inner js-file-line">            response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>POST<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L716" class="blob-num js-line-number" data-line-number="716"></td>
+        <td id="LC716" class="blob-code blob-code-inner js-file-line">                                                    <span class="pl-v">headers</span><span class="pl-k">=</span>hdrs,</td>
+      </tr>
+      <tr>
+        <td id="L717" class="blob-num js-line-number" data-line-number="717"></td>
+        <td id="LC717" class="blob-code blob-code-inner js-file-line">                                                    <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
+      </tr>
+      <tr>
+        <td id="L718" class="blob-num js-line-number" data-line-number="718"></td>
+        <td id="LC718" class="blob-code blob-code-inner js-file-line">                                                    <span class="pl-v">data</span><span class="pl-k">=</span>data)</td>
+      </tr>
+      <tr>
+        <td id="L719" class="blob-num js-line-number" data-line-number="719"></td>
+        <td id="LC719" class="blob-code blob-code-inner js-file-line">            body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L720" class="blob-num js-line-number" data-line-number="720"></td>
+        <td id="LC720" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L721" class="blob-num js-line-number" data-line-number="721"></td>
+        <td id="LC721" class="blob-code blob-code-inner js-file-line">                h <span class="pl-k">=</span> handler.XmlHandler(result, <span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L722" class="blob-num js-line-number" data-line-number="722"></td>
+        <td id="LC722" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
+      </tr>
+      <tr>
+        <td id="L723" class="blob-num js-line-number" data-line-number="723"></td>
+        <td id="LC723" class="blob-code blob-code-inner js-file-line">                    body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L724" class="blob-num js-line-number" data-line-number="724"></td>
+        <td id="LC724" class="blob-code blob-code-inner js-file-line">                xml.sax.parseString(body, h)</td>
+      </tr>
+      <tr>
+        <td id="L725" class="blob-num js-line-number" data-line-number="725"></td>
+        <td id="LC725" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">return</span> count <span class="pl-k">&gt;=</span> <span class="pl-c1">1000</span>  <span class="pl-c"><span class="pl-c">#</span> more?</span></td>
+      </tr>
+      <tr>
+        <td id="L726" class="blob-num js-line-number" data-line-number="726"></td>
+        <td id="LC726" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L727" class="blob-num js-line-number" data-line-number="727"></td>
+        <td id="LC727" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">raise</span> provider.storage_response_error(response.status,</td>
+      </tr>
+      <tr>
+        <td id="L728" class="blob-num js-line-number" data-line-number="728"></td>
+        <td id="LC728" class="blob-code blob-code-inner js-file-line">                                                      response.reason,</td>
+      </tr>
+      <tr>
+        <td id="L729" class="blob-num js-line-number" data-line-number="729"></td>
+        <td id="LC729" class="blob-code blob-code-inner js-file-line">                                                      body)</td>
+      </tr>
+      <tr>
+        <td id="L730" class="blob-num js-line-number" data-line-number="730"></td>
+        <td id="LC730" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">while</span> delete_keys2(headers):</td>
+      </tr>
+      <tr>
+        <td id="L731" class="blob-num js-line-number" data-line-number="731"></td>
+        <td id="LC731" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">pass</span></td>
+      </tr>
+      <tr>
+        <td id="L732" class="blob-num js-line-number" data-line-number="732"></td>
+        <td id="LC732" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> result</td>
+      </tr>
+      <tr>
+        <td id="L733" class="blob-num js-line-number" data-line-number="733"></td>
+        <td id="LC733" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L734" class="blob-num js-line-number" data-line-number="734"></td>
+        <td id="LC734" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete_key</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
+      </tr>
+      <tr>
+        <td id="L735" class="blob-num js-line-number" data-line-number="735"></td>
+        <td id="LC735" class="blob-code blob-code-inner js-file-line">                   <span class="pl-smi">mfa_token</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L736" class="blob-num js-line-number" data-line-number="736"></td>
+        <td id="LC736" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L737" class="blob-num js-line-number" data-line-number="737"></td>
+        <td id="LC737" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Deletes a key from the bucket.  If a version_id is provided,</span></td>
+      </tr>
+      <tr>
+        <td id="L738" class="blob-num js-line-number" data-line-number="738"></td>
+        <td id="LC738" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        only that version of the key will be deleted.</span></td>
+      </tr>
+      <tr>
+        <td id="L739" class="blob-num js-line-number" data-line-number="739"></td>
+        <td id="LC739" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L740" class="blob-num js-line-number" data-line-number="740"></td>
+        <td id="LC740" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_name: string</span></td>
+      </tr>
+      <tr>
+        <td id="L741" class="blob-num js-line-number" data-line-number="741"></td>
+        <td id="LC741" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_name: The key name to delete</span></td>
+      </tr>
+      <tr>
+        <td id="L742" class="blob-num js-line-number" data-line-number="742"></td>
+        <td id="LC742" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L743" class="blob-num js-line-number" data-line-number="743"></td>
+        <td id="LC743" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type version_id: string</span></td>
+      </tr>
+      <tr>
+        <td id="L744" class="blob-num js-line-number" data-line-number="744"></td>
+        <td id="LC744" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param version_id: The version ID (optional)</span></td>
+      </tr>
+      <tr>
+        <td id="L745" class="blob-num js-line-number" data-line-number="745"></td>
+        <td id="LC745" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L746" class="blob-num js-line-number" data-line-number="746"></td>
+        <td id="LC746" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type mfa_token: tuple or list of strings</span></td>
+      </tr>
+      <tr>
+        <td id="L747" class="blob-num js-line-number" data-line-number="747"></td>
+        <td id="LC747" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param mfa_token: A tuple or list consisting of the serial</span></td>
+      </tr>
+      <tr>
+        <td id="L748" class="blob-num js-line-number" data-line-number="748"></td>
+        <td id="LC748" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            number from the MFA device and the current value of the</span></td>
+      </tr>
+      <tr>
+        <td id="L749" class="blob-num js-line-number" data-line-number="749"></td>
+        <td id="LC749" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            six-digit token associated with the device.  This value is</span></td>
+      </tr>
+      <tr>
+        <td id="L750" class="blob-num js-line-number" data-line-number="750"></td>
+        <td id="LC750" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            required anytime you are deleting versioned objects from a</span></td>
+      </tr>
+      <tr>
+        <td id="L751" class="blob-num js-line-number" data-line-number="751"></td>
+        <td id="LC751" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            bucket that has the MFADelete option on the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L752" class="blob-num js-line-number" data-line-number="752"></td>
+        <td id="LC752" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L753" class="blob-num js-line-number" data-line-number="753"></td>
+        <td id="LC753" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.key.Key` or subclass</span></td>
+      </tr>
+      <tr>
+        <td id="L754" class="blob-num js-line-number" data-line-number="754"></td>
+        <td id="LC754" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: A key object holding information on what was</span></td>
+      </tr>
+      <tr>
+        <td id="L755" class="blob-num js-line-number" data-line-number="755"></td>
+        <td id="LC755" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            deleted.  The Caller can see if a delete_marker was</span></td>
+      </tr>
+      <tr>
+        <td id="L756" class="blob-num js-line-number" data-line-number="756"></td>
+        <td id="LC756" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            created or removed and what version_id the delete created</span></td>
+      </tr>
+      <tr>
+        <td id="L757" class="blob-num js-line-number" data-line-number="757"></td>
+        <td id="LC757" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            or removed.</span></td>
+      </tr>
+      <tr>
+        <td id="L758" class="blob-num js-line-number" data-line-number="758"></td>
+        <td id="LC758" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L759" class="blob-num js-line-number" data-line-number="759"></td>
+        <td id="LC759" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> key_name:</td>
+      </tr>
+      <tr>
+        <td id="L760" class="blob-num js-line-number" data-line-number="760"></td>
+        <td id="LC760" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">ValueError</span>(<span class="pl-s"><span class="pl-pds">&#39;</span>Empty key names are not allowed<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L761" class="blob-num js-line-number" data-line-number="761"></td>
+        <td id="LC761" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>._delete_key_internal(key_name, <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
+      </tr>
+      <tr>
+        <td id="L762" class="blob-num js-line-number" data-line-number="762"></td>
+        <td id="LC762" class="blob-code blob-code-inner js-file-line">                                         <span class="pl-v">version_id</span><span class="pl-k">=</span>version_id,</td>
+      </tr>
+      <tr>
+        <td id="L763" class="blob-num js-line-number" data-line-number="763"></td>
+        <td id="LC763" class="blob-code blob-code-inner js-file-line">                                         <span class="pl-v">mfa_token</span><span class="pl-k">=</span>mfa_token,</td>
+      </tr>
+      <tr>
+        <td id="L764" class="blob-num js-line-number" data-line-number="764"></td>
+        <td id="LC764" class="blob-code blob-code-inner js-file-line">                                         <span class="pl-v">query_args_l</span><span class="pl-k">=</span><span class="pl-c1">None</span>)</td>
+      </tr>
+      <tr>
+        <td id="L765" class="blob-num js-line-number" data-line-number="765"></td>
+        <td id="LC765" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L766" class="blob-num js-line-number" data-line-number="766"></td>
+        <td id="LC766" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">_delete_key_internal</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
+      </tr>
+      <tr>
+        <td id="L767" class="blob-num js-line-number" data-line-number="767"></td>
+        <td id="LC767" class="blob-code blob-code-inner js-file-line">                             <span class="pl-smi">mfa_token</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">query_args_l</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L768" class="blob-num js-line-number" data-line-number="768"></td>
+        <td id="LC768" class="blob-code blob-code-inner js-file-line">        query_args_l <span class="pl-k">=</span> query_args_l <span class="pl-k">or</span> []</td>
+      </tr>
+      <tr>
+        <td id="L769" class="blob-num js-line-number" data-line-number="769"></td>
+        <td id="LC769" class="blob-code blob-code-inner js-file-line">        provider <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.provider</td>
+      </tr>
+      <tr>
+        <td id="L770" class="blob-num js-line-number" data-line-number="770"></td>
+        <td id="LC770" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
+      </tr>
+      <tr>
+        <td id="L771" class="blob-num js-line-number" data-line-number="771"></td>
+        <td id="LC771" class="blob-code blob-code-inner js-file-line">            query_args_l.append(<span class="pl-s"><span class="pl-pds">&#39;</span>versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id)</td>
+      </tr>
+      <tr>
+        <td id="L772" class="blob-num js-line-number" data-line-number="772"></td>
+        <td id="LC772" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;<span class="pl-pds">&#39;</span></span>.join(query_args_l) <span class="pl-k">or</span> <span class="pl-c1">None</span></td>
+      </tr>
+      <tr>
+        <td id="L773" class="blob-num js-line-number" data-line-number="773"></td>
+        <td id="LC773" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> mfa_token:</td>
+      </tr>
+      <tr>
+        <td id="L774" class="blob-num js-line-number" data-line-number="774"></td>
+        <td id="LC774" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> headers:</td>
+      </tr>
+      <tr>
+        <td id="L775" class="blob-num js-line-number" data-line-number="775"></td>
+        <td id="LC775" class="blob-code blob-code-inner js-file-line">                headers <span class="pl-k">=</span> {}</td>
+      </tr>
+      <tr>
+        <td id="L776" class="blob-num js-line-number" data-line-number="776"></td>
+        <td id="LC776" class="blob-code blob-code-inner js-file-line">            headers[provider.mfa_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span> <span class="pl-pds">&#39;</span></span>.join(mfa_token)</td>
+      </tr>
+      <tr>
+        <td id="L777" class="blob-num js-line-number" data-line-number="777"></td>
+        <td id="LC777" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>DELETE<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
+      </tr>
+      <tr>
+        <td id="L778" class="blob-num js-line-number" data-line-number="778"></td>
+        <td id="LC778" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
+      </tr>
+      <tr>
+        <td id="L779" class="blob-num js-line-number" data-line-number="779"></td>
+        <td id="LC779" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args)</td>
+      </tr>
+      <tr>
+        <td id="L780" class="blob-num js-line-number" data-line-number="780"></td>
+        <td id="LC780" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L781" class="blob-num js-line-number" data-line-number="781"></td>
+        <td id="LC781" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">204</span>:</td>
+      </tr>
+      <tr>
+        <td id="L782" class="blob-num js-line-number" data-line-number="782"></td>
+        <td id="LC782" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> provider.storage_response_error(response.status,</td>
+      </tr>
+      <tr>
+        <td id="L783" class="blob-num js-line-number" data-line-number="783"></td>
+        <td id="LC783" class="blob-code blob-code-inner js-file-line">                                                  response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L784" class="blob-num js-line-number" data-line-number="784"></td>
+        <td id="LC784" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L785" class="blob-num js-line-number" data-line-number="785"></td>
+        <td id="LC785" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> return a key object with information on what was deleted.</span></td>
+      </tr>
+      <tr>
+        <td id="L786" class="blob-num js-line-number" data-line-number="786"></td>
+        <td id="LC786" class="blob-code blob-code-inner js-file-line">            k <span class="pl-k">=</span> <span class="pl-c1">self</span>.key_class(<span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L787" class="blob-num js-line-number" data-line-number="787"></td>
+        <td id="LC787" class="blob-code blob-code-inner js-file-line">            k.name <span class="pl-k">=</span> key_name</td>
+      </tr>
+      <tr>
+        <td id="L788" class="blob-num js-line-number" data-line-number="788"></td>
+        <td id="LC788" class="blob-code blob-code-inner js-file-line">            k.handle_version_headers(response)</td>
+      </tr>
+      <tr>
+        <td id="L789" class="blob-num js-line-number" data-line-number="789"></td>
+        <td id="LC789" class="blob-code blob-code-inner js-file-line">            k.handle_addl_headers(response.getheaders())</td>
+      </tr>
+      <tr>
+        <td id="L790" class="blob-num js-line-number" data-line-number="790"></td>
+        <td id="LC790" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> k</td>
+      </tr>
+      <tr>
+        <td id="L791" class="blob-num js-line-number" data-line-number="791"></td>
+        <td id="LC791" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L792" class="blob-num js-line-number" data-line-number="792"></td>
+        <td id="LC792" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">copy_key</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">new_key_name</span>, <span class="pl-smi">src_bucket_name</span>,</td>
+      </tr>
+      <tr>
+        <td id="L793" class="blob-num js-line-number" data-line-number="793"></td>
+        <td id="LC793" class="blob-code blob-code-inner js-file-line">                 <span class="pl-smi">src_key_name</span>, <span class="pl-smi">metadata</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">src_version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
+      </tr>
+      <tr>
+        <td id="L794" class="blob-num js-line-number" data-line-number="794"></td>
+        <td id="LC794" class="blob-code blob-code-inner js-file-line">                 <span class="pl-smi">storage_class</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>STANDARD<span class="pl-pds">&#39;</span></span>, <span class="pl-smi">preserve_acl</span><span class="pl-k">=</span><span class="pl-c1">False</span>,</td>
+      </tr>
+      <tr>
+        <td id="L795" class="blob-num js-line-number" data-line-number="795"></td>
+        <td id="LC795" class="blob-code blob-code-inner js-file-line">                 <span class="pl-smi">encrypt_key</span><span class="pl-k">=</span><span class="pl-c1">False</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">query_args</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L796" class="blob-num js-line-number" data-line-number="796"></td>
+        <td id="LC796" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L797" class="blob-num js-line-number" data-line-number="797"></td>
+        <td id="LC797" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Create a new key in the bucket by copying another existing key.</span></td>
+      </tr>
+      <tr>
+        <td id="L798" class="blob-num js-line-number" data-line-number="798"></td>
+        <td id="LC798" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L799" class="blob-num js-line-number" data-line-number="799"></td>
+        <td id="LC799" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type new_key_name: string</span></td>
+      </tr>
+      <tr>
+        <td id="L800" class="blob-num js-line-number" data-line-number="800"></td>
+        <td id="LC800" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param new_key_name: The name of the new key</span></td>
+      </tr>
+      <tr>
+        <td id="L801" class="blob-num js-line-number" data-line-number="801"></td>
+        <td id="LC801" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L802" class="blob-num js-line-number" data-line-number="802"></td>
+        <td id="LC802" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type src_bucket_name: string</span></td>
+      </tr>
+      <tr>
+        <td id="L803" class="blob-num js-line-number" data-line-number="803"></td>
+        <td id="LC803" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param src_bucket_name: The name of the source bucket</span></td>
+      </tr>
+      <tr>
+        <td id="L804" class="blob-num js-line-number" data-line-number="804"></td>
+        <td id="LC804" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L805" class="blob-num js-line-number" data-line-number="805"></td>
+        <td id="LC805" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type src_key_name: string</span></td>
+      </tr>
+      <tr>
+        <td id="L806" class="blob-num js-line-number" data-line-number="806"></td>
+        <td id="LC806" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param src_key_name: The name of the source key</span></td>
+      </tr>
+      <tr>
+        <td id="L807" class="blob-num js-line-number" data-line-number="807"></td>
+        <td id="LC807" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L808" class="blob-num js-line-number" data-line-number="808"></td>
+        <td id="LC808" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type src_version_id: string</span></td>
+      </tr>
+      <tr>
+        <td id="L809" class="blob-num js-line-number" data-line-number="809"></td>
+        <td id="LC809" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param src_version_id: The version id for the key.  This param</span></td>
+      </tr>
+      <tr>
+        <td id="L810" class="blob-num js-line-number" data-line-number="810"></td>
+        <td id="LC810" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            is optional.  If not specified, the newest version of the</span></td>
+      </tr>
+      <tr>
+        <td id="L811" class="blob-num js-line-number" data-line-number="811"></td>
+        <td id="LC811" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            key will be copied.</span></td>
+      </tr>
+      <tr>
+        <td id="L812" class="blob-num js-line-number" data-line-number="812"></td>
+        <td id="LC812" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L813" class="blob-num js-line-number" data-line-number="813"></td>
+        <td id="LC813" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type metadata: dict</span></td>
+      </tr>
+      <tr>
+        <td id="L814" class="blob-num js-line-number" data-line-number="814"></td>
+        <td id="LC814" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param metadata: Metadata to be associated with new key.  If</span></td>
+      </tr>
+      <tr>
+        <td id="L815" class="blob-num js-line-number" data-line-number="815"></td>
+        <td id="LC815" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            metadata is supplied, it will replace the metadata of the</span></td>
+      </tr>
+      <tr>
+        <td id="L816" class="blob-num js-line-number" data-line-number="816"></td>
+        <td id="LC816" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            source key being copied.  If no metadata is supplied, the</span></td>
+      </tr>
+      <tr>
+        <td id="L817" class="blob-num js-line-number" data-line-number="817"></td>
+        <td id="LC817" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            source key&#39;s metadata will be copied to the new key.</span></td>
+      </tr>
+      <tr>
+        <td id="L818" class="blob-num js-line-number" data-line-number="818"></td>
+        <td id="LC818" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L819" class="blob-num js-line-number" data-line-number="819"></td>
+        <td id="LC819" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type storage_class: string</span></td>
+      </tr>
+      <tr>
+        <td id="L820" class="blob-num js-line-number" data-line-number="820"></td>
+        <td id="LC820" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param storage_class: The storage class of the new key.  By</span></td>
+      </tr>
+      <tr>
+        <td id="L821" class="blob-num js-line-number" data-line-number="821"></td>
+        <td id="LC821" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            default, the new key will use the standard storage class.</span></td>
+      </tr>
+      <tr>
+        <td id="L822" class="blob-num js-line-number" data-line-number="822"></td>
+        <td id="LC822" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Possible values are: STANDARD | REDUCED_REDUNDANCY</span></td>
+      </tr>
+      <tr>
+        <td id="L823" class="blob-num js-line-number" data-line-number="823"></td>
+        <td id="LC823" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L824" class="blob-num js-line-number" data-line-number="824"></td>
+        <td id="LC824" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type preserve_acl: bool</span></td>
+      </tr>
+      <tr>
+        <td id="L825" class="blob-num js-line-number" data-line-number="825"></td>
+        <td id="LC825" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param preserve_acl: If True, the ACL from the source key will</span></td>
+      </tr>
+      <tr>
+        <td id="L826" class="blob-num js-line-number" data-line-number="826"></td>
+        <td id="LC826" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            be copied to the destination key.  If False, the</span></td>
+      </tr>
+      <tr>
+        <td id="L827" class="blob-num js-line-number" data-line-number="827"></td>
+        <td id="LC827" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            destination key will have the default ACL.  Note that</span></td>
+      </tr>
+      <tr>
+        <td id="L828" class="blob-num js-line-number" data-line-number="828"></td>
+        <td id="LC828" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            preserving the ACL in the new key object will require two</span></td>
+      </tr>
+      <tr>
+        <td id="L829" class="blob-num js-line-number" data-line-number="829"></td>
+        <td id="LC829" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            additional API calls to S3, one to retrieve the current</span></td>
+      </tr>
+      <tr>
+        <td id="L830" class="blob-num js-line-number" data-line-number="830"></td>
+        <td id="LC830" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ACL and one to set that ACL on the new object.  If you</span></td>
+      </tr>
+      <tr>
+        <td id="L831" class="blob-num js-line-number" data-line-number="831"></td>
+        <td id="LC831" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            don&#39;t care about the ACL, a value of False will be</span></td>
+      </tr>
+      <tr>
+        <td id="L832" class="blob-num js-line-number" data-line-number="832"></td>
+        <td id="LC832" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            significantly more efficient.</span></td>
+      </tr>
+      <tr>
+        <td id="L833" class="blob-num js-line-number" data-line-number="833"></td>
+        <td id="LC833" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L834" class="blob-num js-line-number" data-line-number="834"></td>
+        <td id="LC834" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encrypt_key: bool</span></td>
+      </tr>
+      <tr>
+        <td id="L835" class="blob-num js-line-number" data-line-number="835"></td>
+        <td id="LC835" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encrypt_key: If True, the new copy of the object will</span></td>
+      </tr>
+      <tr>
+        <td id="L836" class="blob-num js-line-number" data-line-number="836"></td>
+        <td id="LC836" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            be encrypted on the server-side by S3 and will be stored</span></td>
+      </tr>
+      <tr>
+        <td id="L837" class="blob-num js-line-number" data-line-number="837"></td>
+        <td id="LC837" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            in an encrypted form while at rest in S3.</span></td>
+      </tr>
+      <tr>
+        <td id="L838" class="blob-num js-line-number" data-line-number="838"></td>
+        <td id="LC838" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L839" class="blob-num js-line-number" data-line-number="839"></td>
+        <td id="LC839" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type headers: dict</span></td>
+      </tr>
+      <tr>
+        <td id="L840" class="blob-num js-line-number" data-line-number="840"></td>
+        <td id="LC840" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param headers: A dictionary of header name/value pairs.</span></td>
+      </tr>
+      <tr>
+        <td id="L841" class="blob-num js-line-number" data-line-number="841"></td>
+        <td id="LC841" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L842" class="blob-num js-line-number" data-line-number="842"></td>
+        <td id="LC842" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type query_args: string</span></td>
+      </tr>
+      <tr>
+        <td id="L843" class="blob-num js-line-number" data-line-number="843"></td>
+        <td id="LC843" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param query_args: A string of additional querystring arguments</span></td>
+      </tr>
+      <tr>
+        <td id="L844" class="blob-num js-line-number" data-line-number="844"></td>
+        <td id="LC844" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            to append to the request</span></td>
+      </tr>
+      <tr>
+        <td id="L845" class="blob-num js-line-number" data-line-number="845"></td>
+        <td id="LC845" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L846" class="blob-num js-line-number" data-line-number="846"></td>
+        <td id="LC846" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.key.Key` or subclass</span></td>
+      </tr>
+      <tr>
+        <td id="L847" class="blob-num js-line-number" data-line-number="847"></td>
+        <td id="LC847" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: An instance of the newly created key object</span></td>
+      </tr>
+      <tr>
+        <td id="L848" class="blob-num js-line-number" data-line-number="848"></td>
+        <td id="LC848" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L849" class="blob-num js-line-number" data-line-number="849"></td>
+        <td id="LC849" class="blob-code blob-code-inner js-file-line">        headers <span class="pl-k">=</span> headers <span class="pl-k">or</span> {}</td>
+      </tr>
+      <tr>
+        <td id="L850" class="blob-num js-line-number" data-line-number="850"></td>
+        <td id="LC850" class="blob-code blob-code-inner js-file-line">        provider <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.provider</td>
+      </tr>
+      <tr>
+        <td id="L851" class="blob-num js-line-number" data-line-number="851"></td>
+        <td id="LC851" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> six.<span class="pl-c1">PY3</span>:</td>
+      </tr>
+      <tr>
+        <td id="L852" class="blob-num js-line-number" data-line-number="852"></td>
+        <td id="LC852" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-c1">isinstance</span>(src_key_name, <span class="pl-c1">bytes</span>):</td>
+      </tr>
+      <tr>
+        <td id="L853" class="blob-num js-line-number" data-line-number="853"></td>
+        <td id="LC853" class="blob-code blob-code-inner js-file-line">                src_key_name <span class="pl-k">=</span> src_key_name.decode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L854" class="blob-num js-line-number" data-line-number="854"></td>
+        <td id="LC854" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L855" class="blob-num js-line-number" data-line-number="855"></td>
+        <td id="LC855" class="blob-code blob-code-inner js-file-line">            src_key_name <span class="pl-k">=</span> boto.utils.get_utf8_value(src_key_name)</td>
+      </tr>
+      <tr>
+        <td id="L856" class="blob-num js-line-number" data-line-number="856"></td>
+        <td id="LC856" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> preserve_acl:</td>
+      </tr>
+      <tr>
+        <td id="L857" class="blob-num js-line-number" data-line-number="857"></td>
+        <td id="LC857" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-c1">self</span>.name <span class="pl-k">==</span> src_bucket_name:</td>
+      </tr>
+      <tr>
+        <td id="L858" class="blob-num js-line-number" data-line-number="858"></td>
+        <td id="LC858" class="blob-code blob-code-inner js-file-line">                src_bucket <span class="pl-k">=</span> <span class="pl-c1">self</span></td>
+      </tr>
+      <tr>
+        <td id="L859" class="blob-num js-line-number" data-line-number="859"></td>
+        <td id="LC859" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L860" class="blob-num js-line-number" data-line-number="860"></td>
+        <td id="LC860" class="blob-code blob-code-inner js-file-line">                src_bucket <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.get_bucket(</td>
+      </tr>
+      <tr>
+        <td id="L861" class="blob-num js-line-number" data-line-number="861"></td>
+        <td id="LC861" class="blob-code blob-code-inner js-file-line">                    src_bucket_name, <span class="pl-v">validate</span><span class="pl-k">=</span><span class="pl-c1">False</span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L862" class="blob-num js-line-number" data-line-number="862"></td>
+        <td id="LC862" class="blob-code blob-code-inner js-file-line">            acl <span class="pl-k">=</span> src_bucket.get_xml_acl(src_key_name, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L863" class="blob-num js-line-number" data-line-number="863"></td>
+        <td id="LC863" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> encrypt_key:</td>
+      </tr>
+      <tr>
+        <td id="L864" class="blob-num js-line-number" data-line-number="864"></td>
+        <td id="LC864" class="blob-code blob-code-inner js-file-line">            headers[provider.server_side_encryption_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>AES256<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L865" class="blob-num js-line-number" data-line-number="865"></td>
+        <td id="LC865" class="blob-code blob-code-inner js-file-line">        src <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-c1">%s</span>/<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> (src_bucket_name, urllib.parse.quote(src_key_name))</td>
+      </tr>
+      <tr>
+        <td id="L866" class="blob-num js-line-number" data-line-number="866"></td>
+        <td id="LC866" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> src_version_id:</td>
+      </tr>
+      <tr>
+        <td id="L867" class="blob-num js-line-number" data-line-number="867"></td>
+        <td id="LC867" class="blob-code blob-code-inner js-file-line">            src <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>?versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> src_version_id</td>
+      </tr>
+      <tr>
+        <td id="L868" class="blob-num js-line-number" data-line-number="868"></td>
+        <td id="LC868" class="blob-code blob-code-inner js-file-line">        headers[provider.copy_source_header] <span class="pl-k">=</span> <span class="pl-c1">str</span>(src)</td>
+      </tr>
+      <tr>
+        <td id="L869" class="blob-num js-line-number" data-line-number="869"></td>
+        <td id="LC869" class="blob-code blob-code-inner js-file-line">        <span class="pl-c"><span class="pl-c">#</span> make sure storage_class_header key exists before accessing it</span></td>
+      </tr>
+      <tr>
+        <td id="L870" class="blob-num js-line-number" data-line-number="870"></td>
+        <td id="LC870" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> provider.storage_class_header <span class="pl-k">and</span> storage_class:</td>
+      </tr>
+      <tr>
+        <td id="L871" class="blob-num js-line-number" data-line-number="871"></td>
+        <td id="LC871" class="blob-code blob-code-inner js-file-line">            headers[provider.storage_class_header] <span class="pl-k">=</span> storage_class</td>
+      </tr>
+      <tr>
+        <td id="L872" class="blob-num js-line-number" data-line-number="872"></td>
+        <td id="LC872" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> metadata <span class="pl-k">is</span> <span class="pl-k">not</span> <span class="pl-c1">None</span>:</td>
+      </tr>
+      <tr>
+        <td id="L873" class="blob-num js-line-number" data-line-number="873"></td>
+        <td id="LC873" class="blob-code blob-code-inner js-file-line">            headers[provider.metadata_directive_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>REPLACE<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L874" class="blob-num js-line-number" data-line-number="874"></td>
+        <td id="LC874" class="blob-code blob-code-inner js-file-line">            headers <span class="pl-k">=</span> boto.utils.merge_meta(headers, metadata, provider)</td>
+      </tr>
+      <tr>
+        <td id="L875" class="blob-num js-line-number" data-line-number="875"></td>
+        <td id="LC875" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">elif</span> <span class="pl-k">not</span> query_args:  <span class="pl-c"><span class="pl-c">#</span> Can&#39;t use this header with multi-part copy.</span></td>
+      </tr>
+      <tr>
+        <td id="L876" class="blob-num js-line-number" data-line-number="876"></td>
+        <td id="LC876" class="blob-code blob-code-inner js-file-line">            headers[provider.metadata_directive_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>COPY<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L877" class="blob-num js-line-number" data-line-number="877"></td>
+        <td id="LC877" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, new_key_name,</td>
+      </tr>
+      <tr>
+        <td id="L878" class="blob-num js-line-number" data-line-number="878"></td>
+        <td id="LC878" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
+      </tr>
+      <tr>
+        <td id="L879" class="blob-num js-line-number" data-line-number="879"></td>
+        <td id="LC879" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args)</td>
+      </tr>
+      <tr>
+        <td id="L880" class="blob-num js-line-number" data-line-number="880"></td>
+        <td id="LC880" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L881" class="blob-num js-line-number" data-line-number="881"></td>
+        <td id="LC881" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L882" class="blob-num js-line-number" data-line-number="882"></td>
+        <td id="LC882" class="blob-code blob-code-inner js-file-line">            key <span class="pl-k">=</span> <span class="pl-c1">self</span>.new_key(new_key_name)</td>
+      </tr>
+      <tr>
+        <td id="L883" class="blob-num js-line-number" data-line-number="883"></td>
+        <td id="LC883" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(key, <span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L884" class="blob-num js-line-number" data-line-number="884"></td>
+        <td id="LC884" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
+      </tr>
+      <tr>
+        <td id="L885" class="blob-num js-line-number" data-line-number="885"></td>
+        <td id="LC885" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-c1">hasattr</span>(key, <span class="pl-s"><span class="pl-pds">&#39;</span>Error<span class="pl-pds">&#39;</span></span>):</td>
+      </tr>
+      <tr>
+        <td id="L886" class="blob-num js-line-number" data-line-number="886"></td>
+        <td id="LC886" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">raise</span> provider.storage_copy_error(key.Code, key.Message, body)</td>
+      </tr>
+      <tr>
+        <td id="L887" class="blob-num js-line-number" data-line-number="887"></td>
+        <td id="LC887" class="blob-code blob-code-inner js-file-line">            key.handle_version_headers(response)</td>
+      </tr>
+      <tr>
+        <td id="L888" class="blob-num js-line-number" data-line-number="888"></td>
+        <td id="LC888" class="blob-code blob-code-inner js-file-line">            key.handle_addl_headers(response.getheaders())</td>
+      </tr>
+      <tr>
+        <td id="L889" class="blob-num js-line-number" data-line-number="889"></td>
+        <td id="LC889" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> preserve_acl:</td>
+      </tr>
+      <tr>
+        <td id="L890" class="blob-num js-line-number" data-line-number="890"></td>
+        <td id="LC890" class="blob-code blob-code-inner js-file-line">                <span class="pl-c1">self</span>.set_xml_acl(acl, new_key_name)</td>
+      </tr>
+      <tr>
+        <td id="L891" class="blob-num js-line-number" data-line-number="891"></td>
+        <td id="LC891" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> key</td>
+      </tr>
+      <tr>
+        <td id="L892" class="blob-num js-line-number" data-line-number="892"></td>
+        <td id="LC892" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L893" class="blob-num js-line-number" data-line-number="893"></td>
+        <td id="LC893" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> provider.storage_response_error(response.status,</td>
+      </tr>
+      <tr>
+        <td id="L894" class="blob-num js-line-number" data-line-number="894"></td>
+        <td id="LC894" class="blob-code blob-code-inner js-file-line">                                                  response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L895" class="blob-num js-line-number" data-line-number="895"></td>
+        <td id="LC895" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L896" class="blob-num js-line-number" data-line-number="896"></td>
+        <td id="LC896" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_canned_acl</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">acl_str</span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
+      </tr>
+      <tr>
+        <td id="L897" class="blob-num js-line-number" data-line-number="897"></td>
+        <td id="LC897" class="blob-code blob-code-inner js-file-line">                       <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L898" class="blob-num js-line-number" data-line-number="898"></td>
+        <td id="LC898" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">assert</span> acl_str <span class="pl-k">in</span> CannedACLStrings</td>
+      </tr>
+      <tr>
+        <td id="L899" class="blob-num js-line-number" data-line-number="899"></td>
+        <td id="LC899" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L900" class="blob-num js-line-number" data-line-number="900"></td>
+        <td id="LC900" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> headers:</td>
+      </tr>
+      <tr>
+        <td id="L901" class="blob-num js-line-number" data-line-number="901"></td>
+        <td id="LC901" class="blob-code blob-code-inner js-file-line">            headers[<span class="pl-c1">self</span>.connection.provider.acl_header] <span class="pl-k">=</span> acl_str</td>
+      </tr>
+      <tr>
+        <td id="L902" class="blob-num js-line-number" data-line-number="902"></td>
+        <td id="LC902" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L903" class="blob-num js-line-number" data-line-number="903"></td>
+        <td id="LC903" class="blob-code blob-code-inner js-file-line">            headers <span class="pl-k">=</span> {<span class="pl-c1">self</span>.connection.provider.acl_header: acl_str}</td>
+      </tr>
+      <tr>
+        <td id="L904" class="blob-num js-line-number" data-line-number="904"></td>
+        <td id="LC904" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L905" class="blob-num js-line-number" data-line-number="905"></td>
+        <td id="LC905" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>acl<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L906" class="blob-num js-line-number" data-line-number="906"></td>
+        <td id="LC906" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
+      </tr>
+      <tr>
+        <td id="L907" class="blob-num js-line-number" data-line-number="907"></td>
+        <td id="LC907" class="blob-code blob-code-inner js-file-line">            query_args <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id</td>
+      </tr>
+      <tr>
+        <td id="L908" class="blob-num js-line-number" data-line-number="908"></td>
+        <td id="LC908" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
+      </tr>
+      <tr>
+        <td id="L909" class="blob-num js-line-number" data-line-number="909"></td>
+        <td id="LC909" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">headers</span><span class="pl-k">=</span>headers, <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args)</td>
+      </tr>
+      <tr>
+        <td id="L910" class="blob-num js-line-number" data-line-number="910"></td>
+        <td id="LC910" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L911" class="blob-num js-line-number" data-line-number="911"></td>
+        <td id="LC911" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L912" class="blob-num js-line-number" data-line-number="912"></td>
+        <td id="LC912" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L913" class="blob-num js-line-number" data-line-number="913"></td>
+        <td id="LC913" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L914" class="blob-num js-line-number" data-line-number="914"></td>
+        <td id="LC914" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L915" class="blob-num js-line-number" data-line-number="915"></td>
+        <td id="LC915" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_xml_acl</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L916" class="blob-num js-line-number" data-line-number="916"></td>
+        <td id="LC916" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>acl<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L917" class="blob-num js-line-number" data-line-number="917"></td>
+        <td id="LC917" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
+      </tr>
+      <tr>
+        <td id="L918" class="blob-num js-line-number" data-line-number="918"></td>
+        <td id="LC918" class="blob-code blob-code-inner js-file-line">            query_args <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id</td>
+      </tr>
+      <tr>
+        <td id="L919" class="blob-num js-line-number" data-line-number="919"></td>
+        <td id="LC919" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
+      </tr>
+      <tr>
+        <td id="L920" class="blob-num js-line-number" data-line-number="920"></td>
+        <td id="LC920" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
+      </tr>
+      <tr>
+        <td id="L921" class="blob-num js-line-number" data-line-number="921"></td>
+        <td id="LC921" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L922" class="blob-num js-line-number" data-line-number="922"></td>
+        <td id="LC922" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L923" class="blob-num js-line-number" data-line-number="923"></td>
+        <td id="LC923" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L924" class="blob-num js-line-number" data-line-number="924"></td>
+        <td id="LC924" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L925" class="blob-num js-line-number" data-line-number="925"></td>
+        <td id="LC925" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L926" class="blob-num js-line-number" data-line-number="926"></td>
+        <td id="LC926" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> body</td>
+      </tr>
+      <tr>
+        <td id="L927" class="blob-num js-line-number" data-line-number="927"></td>
+        <td id="LC927" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L928" class="blob-num js-line-number" data-line-number="928"></td>
+        <td id="LC928" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_xml_acl</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">acl_str</span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
+      </tr>
+      <tr>
+        <td id="L929" class="blob-num js-line-number" data-line-number="929"></td>
+        <td id="LC929" class="blob-code blob-code-inner js-file-line">                    <span class="pl-smi">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>acl<span class="pl-pds">&#39;</span></span>):</td>
+      </tr>
+      <tr>
+        <td id="L930" class="blob-num js-line-number" data-line-number="930"></td>
+        <td id="LC930" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
+      </tr>
+      <tr>
+        <td id="L931" class="blob-num js-line-number" data-line-number="931"></td>
+        <td id="LC931" class="blob-code blob-code-inner js-file-line">            query_args <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id</td>
+      </tr>
+      <tr>
+        <td id="L932" class="blob-num js-line-number" data-line-number="932"></td>
+        <td id="LC932" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(acl_str, <span class="pl-c1">bytes</span>):</td>
+      </tr>
+      <tr>
+        <td id="L933" class="blob-num js-line-number" data-line-number="933"></td>
+        <td id="LC933" class="blob-code blob-code-inner js-file-line">            acl_str <span class="pl-k">=</span> acl_str.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L934" class="blob-num js-line-number" data-line-number="934"></td>
+        <td id="LC934" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
+      </tr>
+      <tr>
+        <td id="L935" class="blob-num js-line-number" data-line-number="935"></td>
+        <td id="LC935" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">data</span><span class="pl-k">=</span>acl_str,</td>
+      </tr>
+      <tr>
+        <td id="L936" class="blob-num js-line-number" data-line-number="936"></td>
+        <td id="LC936" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
+      </tr>
+      <tr>
+        <td id="L937" class="blob-num js-line-number" data-line-number="937"></td>
+        <td id="LC937" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L938" class="blob-num js-line-number" data-line-number="938"></td>
+        <td id="LC938" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L939" class="blob-num js-line-number" data-line-number="939"></td>
+        <td id="LC939" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L940" class="blob-num js-line-number" data-line-number="940"></td>
+        <td id="LC940" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L941" class="blob-num js-line-number" data-line-number="941"></td>
+        <td id="LC941" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L942" class="blob-num js-line-number" data-line-number="942"></td>
+        <td id="LC942" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L943" class="blob-num js-line-number" data-line-number="943"></td>
+        <td id="LC943" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_acl</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">acl_or_str</span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L944" class="blob-num js-line-number" data-line-number="944"></td>
+        <td id="LC944" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-c1">isinstance</span>(acl_or_str, Policy):</td>
+      </tr>
+      <tr>
+        <td id="L945" class="blob-num js-line-number" data-line-number="945"></td>
+        <td id="LC945" class="blob-code blob-code-inner js-file-line">            <span class="pl-c1">self</span>.set_xml_acl(acl_or_str.to_xml(), key_name,</td>
+      </tr>
+      <tr>
+        <td id="L946" class="blob-num js-line-number" data-line-number="946"></td>
+        <td id="LC946" class="blob-code blob-code-inner js-file-line">                             headers, version_id)</td>
+      </tr>
+      <tr>
+        <td id="L947" class="blob-num js-line-number" data-line-number="947"></td>
+        <td id="LC947" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L948" class="blob-num js-line-number" data-line-number="948"></td>
+        <td id="LC948" class="blob-code blob-code-inner js-file-line">            <span class="pl-c1">self</span>.set_canned_acl(acl_or_str, key_name,</td>
+      </tr>
+      <tr>
+        <td id="L949" class="blob-num js-line-number" data-line-number="949"></td>
+        <td id="LC949" class="blob-code blob-code-inner js-file-line">                                headers, version_id)</td>
+      </tr>
+      <tr>
+        <td id="L950" class="blob-num js-line-number" data-line-number="950"></td>
+        <td id="LC950" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L951" class="blob-num js-line-number" data-line-number="951"></td>
+        <td id="LC951" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_acl</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L952" class="blob-num js-line-number" data-line-number="952"></td>
+        <td id="LC952" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>acl<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L953" class="blob-num js-line-number" data-line-number="953"></td>
+        <td id="LC953" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
+      </tr>
+      <tr>
+        <td id="L954" class="blob-num js-line-number" data-line-number="954"></td>
+        <td id="LC954" class="blob-code blob-code-inner js-file-line">            query_args <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id</td>
+      </tr>
+      <tr>
+        <td id="L955" class="blob-num js-line-number" data-line-number="955"></td>
+        <td id="LC955" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
+      </tr>
+      <tr>
+        <td id="L956" class="blob-num js-line-number" data-line-number="956"></td>
+        <td id="LC956" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
+      </tr>
+      <tr>
+        <td id="L957" class="blob-num js-line-number" data-line-number="957"></td>
+        <td id="LC957" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L958" class="blob-num js-line-number" data-line-number="958"></td>
+        <td id="LC958" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L959" class="blob-num js-line-number" data-line-number="959"></td>
+        <td id="LC959" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L960" class="blob-num js-line-number" data-line-number="960"></td>
+        <td id="LC960" class="blob-code blob-code-inner js-file-line">            policy <span class="pl-k">=</span> Policy(<span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L961" class="blob-num js-line-number" data-line-number="961"></td>
+        <td id="LC961" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(policy, <span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L962" class="blob-num js-line-number" data-line-number="962"></td>
+        <td id="LC962" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
+      </tr>
+      <tr>
+        <td id="L963" class="blob-num js-line-number" data-line-number="963"></td>
+        <td id="LC963" class="blob-code blob-code-inner js-file-line">                body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L964" class="blob-num js-line-number" data-line-number="964"></td>
+        <td id="LC964" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
+      </tr>
+      <tr>
+        <td id="L965" class="blob-num js-line-number" data-line-number="965"></td>
+        <td id="LC965" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> policy</td>
+      </tr>
+      <tr>
+        <td id="L966" class="blob-num js-line-number" data-line-number="966"></td>
+        <td id="LC966" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L967" class="blob-num js-line-number" data-line-number="967"></td>
+        <td id="LC967" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L968" class="blob-num js-line-number" data-line-number="968"></td>
+        <td id="LC968" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L969" class="blob-num js-line-number" data-line-number="969"></td>
+        <td id="LC969" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L970" class="blob-num js-line-number" data-line-number="970"></td>
+        <td id="LC970" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_subresource</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">subresource</span>, <span class="pl-smi">value</span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
+      </tr>
+      <tr>
+        <td id="L971" class="blob-num js-line-number" data-line-number="971"></td>
+        <td id="LC971" class="blob-code blob-code-inner js-file-line">                        <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L972" class="blob-num js-line-number" data-line-number="972"></td>
+        <td id="LC972" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L973" class="blob-num js-line-number" data-line-number="973"></td>
+        <td id="LC973" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Set a subresource for a bucket or key.</span></td>
+      </tr>
+      <tr>
+        <td id="L974" class="blob-num js-line-number" data-line-number="974"></td>
+        <td id="LC974" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L975" class="blob-num js-line-number" data-line-number="975"></td>
+        <td id="LC975" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type subresource: string</span></td>
+      </tr>
+      <tr>
+        <td id="L976" class="blob-num js-line-number" data-line-number="976"></td>
+        <td id="LC976" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param subresource: The subresource to set.</span></td>
+      </tr>
+      <tr>
+        <td id="L977" class="blob-num js-line-number" data-line-number="977"></td>
+        <td id="LC977" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L978" class="blob-num js-line-number" data-line-number="978"></td>
+        <td id="LC978" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type value: string</span></td>
+      </tr>
+      <tr>
+        <td id="L979" class="blob-num js-line-number" data-line-number="979"></td>
+        <td id="LC979" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param value: The value of the subresource.</span></td>
+      </tr>
+      <tr>
+        <td id="L980" class="blob-num js-line-number" data-line-number="980"></td>
+        <td id="LC980" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L981" class="blob-num js-line-number" data-line-number="981"></td>
+        <td id="LC981" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_name: string</span></td>
+      </tr>
+      <tr>
+        <td id="L982" class="blob-num js-line-number" data-line-number="982"></td>
+        <td id="LC982" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_name: The key to operate on, or None to operate on the</span></td>
+      </tr>
+      <tr>
+        <td id="L983" class="blob-num js-line-number" data-line-number="983"></td>
+        <td id="LC983" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L984" class="blob-num js-line-number" data-line-number="984"></td>
+        <td id="LC984" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L985" class="blob-num js-line-number" data-line-number="985"></td>
+        <td id="LC985" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type headers: dict</span></td>
+      </tr>
+      <tr>
+        <td id="L986" class="blob-num js-line-number" data-line-number="986"></td>
+        <td id="LC986" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param headers: Additional HTTP headers to include in the request.</span></td>
+      </tr>
+      <tr>
+        <td id="L987" class="blob-num js-line-number" data-line-number="987"></td>
+        <td id="LC987" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L988" class="blob-num js-line-number" data-line-number="988"></td>
+        <td id="LC988" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type src_version_id: string</span></td>
+      </tr>
+      <tr>
+        <td id="L989" class="blob-num js-line-number" data-line-number="989"></td>
+        <td id="LC989" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param src_version_id: Optional. The version id of the key to</span></td>
+      </tr>
+      <tr>
+        <td id="L990" class="blob-num js-line-number" data-line-number="990"></td>
+        <td id="LC990" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            operate on. If not specified, operate on the newest</span></td>
+      </tr>
+      <tr>
+        <td id="L991" class="blob-num js-line-number" data-line-number="991"></td>
+        <td id="LC991" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            version.</span></td>
+      </tr>
+      <tr>
+        <td id="L992" class="blob-num js-line-number" data-line-number="992"></td>
+        <td id="LC992" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L993" class="blob-num js-line-number" data-line-number="993"></td>
+        <td id="LC993" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> subresource:</td>
+      </tr>
+      <tr>
+        <td id="L994" class="blob-num js-line-number" data-line-number="994"></td>
+        <td id="LC994" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">TypeError</span>(<span class="pl-s"><span class="pl-pds">&#39;</span>set_subresource called with subresource=None<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L995" class="blob-num js-line-number" data-line-number="995"></td>
+        <td id="LC995" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> subresource</td>
+      </tr>
+      <tr>
+        <td id="L996" class="blob-num js-line-number" data-line-number="996"></td>
+        <td id="LC996" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
+      </tr>
+      <tr>
+        <td id="L997" class="blob-num js-line-number" data-line-number="997"></td>
+        <td id="LC997" class="blob-code blob-code-inner js-file-line">            query_args <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id</td>
+      </tr>
+      <tr>
+        <td id="L998" class="blob-num js-line-number" data-line-number="998"></td>
+        <td id="LC998" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(value, <span class="pl-c1">bytes</span>):</td>
+      </tr>
+      <tr>
+        <td id="L999" class="blob-num js-line-number" data-line-number="999"></td>
+        <td id="LC999" class="blob-code blob-code-inner js-file-line">            value <span class="pl-k">=</span> value.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L1000" class="blob-num js-line-number" data-line-number="1000"></td>
+        <td id="LC1000" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
+      </tr>
+      <tr>
+        <td id="L1001" class="blob-num js-line-number" data-line-number="1001"></td>
+        <td id="LC1001" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">data</span><span class="pl-k">=</span>value,</td>
+      </tr>
+      <tr>
+        <td id="L1002" class="blob-num js-line-number" data-line-number="1002"></td>
+        <td id="LC1002" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
+      </tr>
+      <tr>
+        <td id="L1003" class="blob-num js-line-number" data-line-number="1003"></td>
+        <td id="LC1003" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1004" class="blob-num js-line-number" data-line-number="1004"></td>
+        <td id="LC1004" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1005" class="blob-num js-line-number" data-line-number="1005"></td>
+        <td id="LC1005" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1006" class="blob-num js-line-number" data-line-number="1006"></td>
+        <td id="LC1006" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1007" class="blob-num js-line-number" data-line-number="1007"></td>
+        <td id="LC1007" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1008" class="blob-num js-line-number" data-line-number="1008"></td>
+        <td id="LC1008" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1009" class="blob-num js-line-number" data-line-number="1009"></td>
+        <td id="LC1009" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_subresource</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">subresource</span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
+      </tr>
+      <tr>
+        <td id="L1010" class="blob-num js-line-number" data-line-number="1010"></td>
+        <td id="LC1010" class="blob-code blob-code-inner js-file-line">                        <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1011" class="blob-num js-line-number" data-line-number="1011"></td>
+        <td id="LC1011" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1012" class="blob-num js-line-number" data-line-number="1012"></td>
+        <td id="LC1012" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Get a subresource for a bucket or key.</span></td>
+      </tr>
+      <tr>
+        <td id="L1013" class="blob-num js-line-number" data-line-number="1013"></td>
+        <td id="LC1013" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1014" class="blob-num js-line-number" data-line-number="1014"></td>
+        <td id="LC1014" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type subresource: string</span></td>
+      </tr>
+      <tr>
+        <td id="L1015" class="blob-num js-line-number" data-line-number="1015"></td>
+        <td id="LC1015" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param subresource: The subresource to get.</span></td>
+      </tr>
+      <tr>
+        <td id="L1016" class="blob-num js-line-number" data-line-number="1016"></td>
+        <td id="LC1016" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1017" class="blob-num js-line-number" data-line-number="1017"></td>
+        <td id="LC1017" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_name: string</span></td>
+      </tr>
+      <tr>
+        <td id="L1018" class="blob-num js-line-number" data-line-number="1018"></td>
+        <td id="LC1018" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_name: The key to operate on, or None to operate on the</span></td>
+      </tr>
+      <tr>
+        <td id="L1019" class="blob-num js-line-number" data-line-number="1019"></td>
+        <td id="LC1019" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1020" class="blob-num js-line-number" data-line-number="1020"></td>
+        <td id="LC1020" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1021" class="blob-num js-line-number" data-line-number="1021"></td>
+        <td id="LC1021" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type headers: dict</span></td>
+      </tr>
+      <tr>
+        <td id="L1022" class="blob-num js-line-number" data-line-number="1022"></td>
+        <td id="LC1022" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param headers: Additional HTTP headers to include in the request.</span></td>
+      </tr>
+      <tr>
+        <td id="L1023" class="blob-num js-line-number" data-line-number="1023"></td>
+        <td id="LC1023" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1024" class="blob-num js-line-number" data-line-number="1024"></td>
+        <td id="LC1024" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type src_version_id: string</span></td>
+      </tr>
+      <tr>
+        <td id="L1025" class="blob-num js-line-number" data-line-number="1025"></td>
+        <td id="LC1025" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param src_version_id: Optional. The version id of the key to</span></td>
+      </tr>
+      <tr>
+        <td id="L1026" class="blob-num js-line-number" data-line-number="1026"></td>
+        <td id="LC1026" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            operate on. If not specified, operate on the newest</span></td>
+      </tr>
+      <tr>
+        <td id="L1027" class="blob-num js-line-number" data-line-number="1027"></td>
+        <td id="LC1027" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            version.</span></td>
+      </tr>
+      <tr>
+        <td id="L1028" class="blob-num js-line-number" data-line-number="1028"></td>
+        <td id="LC1028" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1029" class="blob-num js-line-number" data-line-number="1029"></td>
+        <td id="LC1029" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: string</span></td>
+      </tr>
+      <tr>
+        <td id="L1030" class="blob-num js-line-number" data-line-number="1030"></td>
+        <td id="LC1030" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: The value of the subresource.</span></td>
+      </tr>
+      <tr>
+        <td id="L1031" class="blob-num js-line-number" data-line-number="1031"></td>
+        <td id="LC1031" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1032" class="blob-num js-line-number" data-line-number="1032"></td>
+        <td id="LC1032" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> subresource:</td>
+      </tr>
+      <tr>
+        <td id="L1033" class="blob-num js-line-number" data-line-number="1033"></td>
+        <td id="LC1033" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">TypeError</span>(<span class="pl-s"><span class="pl-pds">&#39;</span>get_subresource called with subresource=None<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L1034" class="blob-num js-line-number" data-line-number="1034"></td>
+        <td id="LC1034" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> subresource</td>
+      </tr>
+      <tr>
+        <td id="L1035" class="blob-num js-line-number" data-line-number="1035"></td>
+        <td id="LC1035" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
+      </tr>
+      <tr>
+        <td id="L1036" class="blob-num js-line-number" data-line-number="1036"></td>
+        <td id="LC1036" class="blob-code blob-code-inner js-file-line">            query_args <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id</td>
+      </tr>
+      <tr>
+        <td id="L1037" class="blob-num js-line-number" data-line-number="1037"></td>
+        <td id="LC1037" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
+      </tr>
+      <tr>
+        <td id="L1038" class="blob-num js-line-number" data-line-number="1038"></td>
+        <td id="LC1038" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
+      </tr>
+      <tr>
+        <td id="L1039" class="blob-num js-line-number" data-line-number="1039"></td>
+        <td id="LC1039" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1040" class="blob-num js-line-number" data-line-number="1040"></td>
+        <td id="LC1040" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1041" class="blob-num js-line-number" data-line-number="1041"></td>
+        <td id="LC1041" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1042" class="blob-num js-line-number" data-line-number="1042"></td>
+        <td id="LC1042" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1043" class="blob-num js-line-number" data-line-number="1043"></td>
+        <td id="LC1043" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1044" class="blob-num js-line-number" data-line-number="1044"></td>
+        <td id="LC1044" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> body</td>
+      </tr>
+      <tr>
+        <td id="L1045" class="blob-num js-line-number" data-line-number="1045"></td>
+        <td id="LC1045" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1046" class="blob-num js-line-number" data-line-number="1046"></td>
+        <td id="LC1046" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">make_public</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">recursive</span><span class="pl-k">=</span><span class="pl-c1">False</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1047" class="blob-num js-line-number" data-line-number="1047"></td>
+        <td id="LC1047" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.set_canned_acl(<span class="pl-s"><span class="pl-pds">&#39;</span>public-read<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1048" class="blob-num js-line-number" data-line-number="1048"></td>
+        <td id="LC1048" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> recursive:</td>
+      </tr>
+      <tr>
+        <td id="L1049" class="blob-num js-line-number" data-line-number="1049"></td>
+        <td id="LC1049" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">for</span> key <span class="pl-k">in</span> <span class="pl-c1">self</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1050" class="blob-num js-line-number" data-line-number="1050"></td>
+        <td id="LC1050" class="blob-code blob-code-inner js-file-line">                <span class="pl-c1">self</span>.set_canned_acl(<span class="pl-s"><span class="pl-pds">&#39;</span>public-read<span class="pl-pds">&#39;</span></span>, key.name, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1051" class="blob-num js-line-number" data-line-number="1051"></td>
+        <td id="LC1051" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1052" class="blob-num js-line-number" data-line-number="1052"></td>
+        <td id="LC1052" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">add_email_grant</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">permission</span>, <span class="pl-smi">email_address</span>,</td>
+      </tr>
+      <tr>
+        <td id="L1053" class="blob-num js-line-number" data-line-number="1053"></td>
+        <td id="LC1053" class="blob-code blob-code-inner js-file-line">                        <span class="pl-smi">recursive</span><span class="pl-k">=</span><span class="pl-c1">False</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1054" class="blob-num js-line-number" data-line-number="1054"></td>
+        <td id="LC1054" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1055" class="blob-num js-line-number" data-line-number="1055"></td>
+        <td id="LC1055" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Convenience method that provides a quick way to add an email grant</span></td>
+      </tr>
+      <tr>
+        <td id="L1056" class="blob-num js-line-number" data-line-number="1056"></td>
+        <td id="LC1056" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        to a bucket. This method retrieves the current ACL, creates a new</span></td>
+      </tr>
+      <tr>
+        <td id="L1057" class="blob-num js-line-number" data-line-number="1057"></td>
+        <td id="LC1057" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        grant based on the parameters passed in, adds that grant to the ACL</span></td>
+      </tr>
+      <tr>
+        <td id="L1058" class="blob-num js-line-number" data-line-number="1058"></td>
+        <td id="LC1058" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        and then PUT&#39;s the new ACL back to S3.</span></td>
+      </tr>
+      <tr>
+        <td id="L1059" class="blob-num js-line-number" data-line-number="1059"></td>
+        <td id="LC1059" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1060" class="blob-num js-line-number" data-line-number="1060"></td>
+        <td id="LC1060" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type permission: string</span></td>
+      </tr>
+      <tr>
+        <td id="L1061" class="blob-num js-line-number" data-line-number="1061"></td>
+        <td id="LC1061" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param permission: The permission being granted. Should be one of:</span></td>
+      </tr>
+      <tr>
+        <td id="L1062" class="blob-num js-line-number" data-line-number="1062"></td>
+        <td id="LC1062" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            (READ, WRITE, READ_ACP, WRITE_ACP, FULL_CONTROL).</span></td>
+      </tr>
+      <tr>
+        <td id="L1063" class="blob-num js-line-number" data-line-number="1063"></td>
+        <td id="LC1063" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1064" class="blob-num js-line-number" data-line-number="1064"></td>
+        <td id="LC1064" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type email_address: string</span></td>
+      </tr>
+      <tr>
+        <td id="L1065" class="blob-num js-line-number" data-line-number="1065"></td>
+        <td id="LC1065" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param email_address: The email address associated with the AWS</span></td>
+      </tr>
+      <tr>
+        <td id="L1066" class="blob-num js-line-number" data-line-number="1066"></td>
+        <td id="LC1066" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            account your are granting the permission to.</span></td>
+      </tr>
+      <tr>
+        <td id="L1067" class="blob-num js-line-number" data-line-number="1067"></td>
+        <td id="LC1067" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1068" class="blob-num js-line-number" data-line-number="1068"></td>
+        <td id="LC1068" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type recursive: boolean</span></td>
+      </tr>
+      <tr>
+        <td id="L1069" class="blob-num js-line-number" data-line-number="1069"></td>
+        <td id="LC1069" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param recursive: A boolean value to controls whether the</span></td>
+      </tr>
+      <tr>
+        <td id="L1070" class="blob-num js-line-number" data-line-number="1070"></td>
+        <td id="LC1070" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            command will apply the grant to all keys within the bucket</span></td>
+      </tr>
+      <tr>
+        <td id="L1071" class="blob-num js-line-number" data-line-number="1071"></td>
+        <td id="LC1071" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            or not.  The default value is False.  By passing a True</span></td>
+      </tr>
+      <tr>
+        <td id="L1072" class="blob-num js-line-number" data-line-number="1072"></td>
+        <td id="LC1072" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            value, the call will iterate through all keys in the</span></td>
+      </tr>
+      <tr>
+        <td id="L1073" class="blob-num js-line-number" data-line-number="1073"></td>
+        <td id="LC1073" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            bucket and apply the same grant to each key.  CAUTION: If</span></td>
+      </tr>
+      <tr>
+        <td id="L1074" class="blob-num js-line-number" data-line-number="1074"></td>
+        <td id="LC1074" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            you have a lot of keys, this could take a long time!</span></td>
+      </tr>
+      <tr>
+        <td id="L1075" class="blob-num js-line-number" data-line-number="1075"></td>
+        <td id="LC1075" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1076" class="blob-num js-line-number" data-line-number="1076"></td>
+        <td id="LC1076" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> permission <span class="pl-k">not</span> <span class="pl-k">in</span> S3Permissions:</td>
+      </tr>
+      <tr>
+        <td id="L1077" class="blob-num js-line-number" data-line-number="1077"></td>
+        <td id="LC1077" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_permissions_error(</td>
+      </tr>
+      <tr>
+        <td id="L1078" class="blob-num js-line-number" data-line-number="1078"></td>
+        <td id="LC1078" class="blob-code blob-code-inner js-file-line">                <span class="pl-s"><span class="pl-pds">&#39;</span>Unknown Permission: <span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> permission)</td>
+      </tr>
+      <tr>
+        <td id="L1079" class="blob-num js-line-number" data-line-number="1079"></td>
+        <td id="LC1079" class="blob-code blob-code-inner js-file-line">        policy <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_acl(<span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1080" class="blob-num js-line-number" data-line-number="1080"></td>
+        <td id="LC1080" class="blob-code blob-code-inner js-file-line">        policy.acl.add_email_grant(permission, email_address)</td>
+      </tr>
+      <tr>
+        <td id="L1081" class="blob-num js-line-number" data-line-number="1081"></td>
+        <td id="LC1081" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.set_acl(policy, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1082" class="blob-num js-line-number" data-line-number="1082"></td>
+        <td id="LC1082" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> recursive:</td>
+      </tr>
+      <tr>
+        <td id="L1083" class="blob-num js-line-number" data-line-number="1083"></td>
+        <td id="LC1083" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">for</span> key <span class="pl-k">in</span> <span class="pl-c1">self</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1084" class="blob-num js-line-number" data-line-number="1084"></td>
+        <td id="LC1084" class="blob-code blob-code-inner js-file-line">                key.add_email_grant(permission, email_address, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1085" class="blob-num js-line-number" data-line-number="1085"></td>
+        <td id="LC1085" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1086" class="blob-num js-line-number" data-line-number="1086"></td>
+        <td id="LC1086" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">add_user_grant</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">permission</span>, <span class="pl-smi">user_id</span>, <span class="pl-smi">recursive</span><span class="pl-k">=</span><span class="pl-c1">False</span>,</td>
+      </tr>
+      <tr>
+        <td id="L1087" class="blob-num js-line-number" data-line-number="1087"></td>
+        <td id="LC1087" class="blob-code blob-code-inner js-file-line">                       <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">display_name</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1088" class="blob-num js-line-number" data-line-number="1088"></td>
+        <td id="LC1088" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1089" class="blob-num js-line-number" data-line-number="1089"></td>
+        <td id="LC1089" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Convenience method that provides a quick way to add a canonical</span></td>
+      </tr>
+      <tr>
+        <td id="L1090" class="blob-num js-line-number" data-line-number="1090"></td>
+        <td id="LC1090" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        user grant to a bucket.  This method retrieves the current ACL,</span></td>
+      </tr>
+      <tr>
+        <td id="L1091" class="blob-num js-line-number" data-line-number="1091"></td>
+        <td id="LC1091" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        creates a new grant based on the parameters passed in, adds that</span></td>
+      </tr>
+      <tr>
+        <td id="L1092" class="blob-num js-line-number" data-line-number="1092"></td>
+        <td id="LC1092" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        grant to the ACL and then PUT&#39;s the new ACL back to S3.</span></td>
+      </tr>
+      <tr>
+        <td id="L1093" class="blob-num js-line-number" data-line-number="1093"></td>
+        <td id="LC1093" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1094" class="blob-num js-line-number" data-line-number="1094"></td>
+        <td id="LC1094" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type permission: string</span></td>
+      </tr>
+      <tr>
+        <td id="L1095" class="blob-num js-line-number" data-line-number="1095"></td>
+        <td id="LC1095" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param permission: The permission being granted. Should be one of:</span></td>
+      </tr>
+      <tr>
+        <td id="L1096" class="blob-num js-line-number" data-line-number="1096"></td>
+        <td id="LC1096" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            (READ, WRITE, READ_ACP, WRITE_ACP, FULL_CONTROL).</span></td>
+      </tr>
+      <tr>
+        <td id="L1097" class="blob-num js-line-number" data-line-number="1097"></td>
+        <td id="LC1097" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1098" class="blob-num js-line-number" data-line-number="1098"></td>
+        <td id="LC1098" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type user_id: string</span></td>
+      </tr>
+      <tr>
+        <td id="L1099" class="blob-num js-line-number" data-line-number="1099"></td>
+        <td id="LC1099" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param user_id:     The canonical user id associated with the AWS</span></td>
+      </tr>
+      <tr>
+        <td id="L1100" class="blob-num js-line-number" data-line-number="1100"></td>
+        <td id="LC1100" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            account your are granting the permission to.</span></td>
+      </tr>
+      <tr>
+        <td id="L1101" class="blob-num js-line-number" data-line-number="1101"></td>
+        <td id="LC1101" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1102" class="blob-num js-line-number" data-line-number="1102"></td>
+        <td id="LC1102" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type recursive: boolean</span></td>
+      </tr>
+      <tr>
+        <td id="L1103" class="blob-num js-line-number" data-line-number="1103"></td>
+        <td id="LC1103" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param recursive: A boolean value to controls whether the</span></td>
+      </tr>
+      <tr>
+        <td id="L1104" class="blob-num js-line-number" data-line-number="1104"></td>
+        <td id="LC1104" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            command will apply the grant to all keys within the bucket</span></td>
+      </tr>
+      <tr>
+        <td id="L1105" class="blob-num js-line-number" data-line-number="1105"></td>
+        <td id="LC1105" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            or not.  The default value is False.  By passing a True</span></td>
+      </tr>
+      <tr>
+        <td id="L1106" class="blob-num js-line-number" data-line-number="1106"></td>
+        <td id="LC1106" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            value, the call will iterate through all keys in the</span></td>
+      </tr>
+      <tr>
+        <td id="L1107" class="blob-num js-line-number" data-line-number="1107"></td>
+        <td id="LC1107" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            bucket and apply the same grant to each key.  CAUTION: If</span></td>
+      </tr>
+      <tr>
+        <td id="L1108" class="blob-num js-line-number" data-line-number="1108"></td>
+        <td id="LC1108" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            you have a lot of keys, this could take a long time!</span></td>
+      </tr>
+      <tr>
+        <td id="L1109" class="blob-num js-line-number" data-line-number="1109"></td>
+        <td id="LC1109" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1110" class="blob-num js-line-number" data-line-number="1110"></td>
+        <td id="LC1110" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type display_name: string</span></td>
+      </tr>
+      <tr>
+        <td id="L1111" class="blob-num js-line-number" data-line-number="1111"></td>
+        <td id="LC1111" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param display_name: An option string containing the user&#39;s</span></td>
+      </tr>
+      <tr>
+        <td id="L1112" class="blob-num js-line-number" data-line-number="1112"></td>
+        <td id="LC1112" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Display Name.  Only required on Walrus.</span></td>
+      </tr>
+      <tr>
+        <td id="L1113" class="blob-num js-line-number" data-line-number="1113"></td>
+        <td id="LC1113" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1114" class="blob-num js-line-number" data-line-number="1114"></td>
+        <td id="LC1114" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> permission <span class="pl-k">not</span> <span class="pl-k">in</span> S3Permissions:</td>
+      </tr>
+      <tr>
+        <td id="L1115" class="blob-num js-line-number" data-line-number="1115"></td>
+        <td id="LC1115" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_permissions_error(</td>
+      </tr>
+      <tr>
+        <td id="L1116" class="blob-num js-line-number" data-line-number="1116"></td>
+        <td id="LC1116" class="blob-code blob-code-inner js-file-line">                <span class="pl-s"><span class="pl-pds">&#39;</span>Unknown Permission: <span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> permission)</td>
+      </tr>
+      <tr>
+        <td id="L1117" class="blob-num js-line-number" data-line-number="1117"></td>
+        <td id="LC1117" class="blob-code blob-code-inner js-file-line">        policy <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_acl(<span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1118" class="blob-num js-line-number" data-line-number="1118"></td>
+        <td id="LC1118" class="blob-code blob-code-inner js-file-line">        policy.acl.add_user_grant(permission, user_id,</td>
+      </tr>
+      <tr>
+        <td id="L1119" class="blob-num js-line-number" data-line-number="1119"></td>
+        <td id="LC1119" class="blob-code blob-code-inner js-file-line">                                  <span class="pl-v">display_name</span><span class="pl-k">=</span>display_name)</td>
+      </tr>
+      <tr>
+        <td id="L1120" class="blob-num js-line-number" data-line-number="1120"></td>
+        <td id="LC1120" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.set_acl(policy, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1121" class="blob-num js-line-number" data-line-number="1121"></td>
+        <td id="LC1121" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> recursive:</td>
+      </tr>
+      <tr>
+        <td id="L1122" class="blob-num js-line-number" data-line-number="1122"></td>
+        <td id="LC1122" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">for</span> key <span class="pl-k">in</span> <span class="pl-c1">self</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1123" class="blob-num js-line-number" data-line-number="1123"></td>
+        <td id="LC1123" class="blob-code blob-code-inner js-file-line">                key.add_user_grant(permission, user_id, <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
+      </tr>
+      <tr>
+        <td id="L1124" class="blob-num js-line-number" data-line-number="1124"></td>
+        <td id="LC1124" class="blob-code blob-code-inner js-file-line">                                   <span class="pl-v">display_name</span><span class="pl-k">=</span>display_name)</td>
+      </tr>
+      <tr>
+        <td id="L1125" class="blob-num js-line-number" data-line-number="1125"></td>
+        <td id="LC1125" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1126" class="blob-num js-line-number" data-line-number="1126"></td>
+        <td id="LC1126" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">list_grants</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1127" class="blob-num js-line-number" data-line-number="1127"></td>
+        <td id="LC1127" class="blob-code blob-code-inner js-file-line">        policy <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_acl(<span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1128" class="blob-num js-line-number" data-line-number="1128"></td>
+        <td id="LC1128" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> policy.acl.grants</td>
+      </tr>
+      <tr>
+        <td id="L1129" class="blob-num js-line-number" data-line-number="1129"></td>
+        <td id="LC1129" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1130" class="blob-num js-line-number" data-line-number="1130"></td>
+        <td id="LC1130" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_location</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1131" class="blob-num js-line-number" data-line-number="1131"></td>
+        <td id="LC1131" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1132" class="blob-num js-line-number" data-line-number="1132"></td>
+        <td id="LC1132" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the LocationConstraint for the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1133" class="blob-num js-line-number" data-line-number="1133"></td>
+        <td id="LC1133" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1134" class="blob-num js-line-number" data-line-number="1134"></td>
+        <td id="LC1134" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: str</span></td>
+      </tr>
+      <tr>
+        <td id="L1135" class="blob-num js-line-number" data-line-number="1135"></td>
+        <td id="LC1135" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: The LocationConstraint for the bucket or the empty</span></td>
+      </tr>
+      <tr>
+        <td id="L1136" class="blob-num js-line-number" data-line-number="1136"></td>
+        <td id="LC1136" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            string if no constraint was specified when bucket was created.</span></td>
+      </tr>
+      <tr>
+        <td id="L1137" class="blob-num js-line-number" data-line-number="1137"></td>
+        <td id="LC1137" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1138" class="blob-num js-line-number" data-line-number="1138"></td>
+        <td id="LC1138" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1139" class="blob-num js-line-number" data-line-number="1139"></td>
+        <td id="LC1139" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
+      </tr>
+      <tr>
+        <td id="L1140" class="blob-num js-line-number" data-line-number="1140"></td>
+        <td id="LC1140" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>location<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L1141" class="blob-num js-line-number" data-line-number="1141"></td>
+        <td id="LC1141" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1142" class="blob-num js-line-number" data-line-number="1142"></td>
+        <td id="LC1142" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1143" class="blob-num js-line-number" data-line-number="1143"></td>
+        <td id="LC1143" class="blob-code blob-code-inner js-file-line">            rs <span class="pl-k">=</span> ResultSet(<span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L1144" class="blob-num js-line-number" data-line-number="1144"></td>
+        <td id="LC1144" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(rs, <span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L1145" class="blob-num js-line-number" data-line-number="1145"></td>
+        <td id="LC1145" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1146" class="blob-num js-line-number" data-line-number="1146"></td>
+        <td id="LC1146" class="blob-code blob-code-inner js-file-line">                body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L1147" class="blob-num js-line-number" data-line-number="1147"></td>
+        <td id="LC1147" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
+      </tr>
+      <tr>
+        <td id="L1148" class="blob-num js-line-number" data-line-number="1148"></td>
+        <td id="LC1148" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> rs.LocationConstraint</td>
+      </tr>
+      <tr>
+        <td id="L1149" class="blob-num js-line-number" data-line-number="1149"></td>
+        <td id="LC1149" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1150" class="blob-num js-line-number" data-line-number="1150"></td>
+        <td id="LC1150" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1151" class="blob-num js-line-number" data-line-number="1151"></td>
+        <td id="LC1151" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1152" class="blob-num js-line-number" data-line-number="1152"></td>
+        <td id="LC1152" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1153" class="blob-num js-line-number" data-line-number="1153"></td>
+        <td id="LC1153" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_xml_logging</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">logging_str</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1154" class="blob-num js-line-number" data-line-number="1154"></td>
+        <td id="LC1154" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1155" class="blob-num js-line-number" data-line-number="1155"></td>
+        <td id="LC1155" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Set logging on a bucket directly to the given xml string.</span></td>
+      </tr>
+      <tr>
+        <td id="L1156" class="blob-num js-line-number" data-line-number="1156"></td>
+        <td id="LC1156" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1157" class="blob-num js-line-number" data-line-number="1157"></td>
+        <td id="LC1157" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type logging_str: unicode string</span></td>
+      </tr>
+      <tr>
+        <td id="L1158" class="blob-num js-line-number" data-line-number="1158"></td>
+        <td id="LC1158" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param logging_str: The XML for the bucketloggingstatus which</span></td>
+      </tr>
+      <tr>
+        <td id="L1159" class="blob-num js-line-number" data-line-number="1159"></td>
+        <td id="LC1159" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            will be set.  The string will be converted to utf-8 before</span></td>
+      </tr>
+      <tr>
+        <td id="L1160" class="blob-num js-line-number" data-line-number="1160"></td>
+        <td id="LC1160" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            it is sent.  Usually, you will obtain this XML from the</span></td>
+      </tr>
+      <tr>
+        <td id="L1161" class="blob-num js-line-number" data-line-number="1161"></td>
+        <td id="LC1161" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            BucketLogging object.</span></td>
+      </tr>
+      <tr>
+        <td id="L1162" class="blob-num js-line-number" data-line-number="1162"></td>
+        <td id="LC1162" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1163" class="blob-num js-line-number" data-line-number="1163"></td>
+        <td id="LC1163" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: bool</span></td>
+      </tr>
+      <tr>
+        <td id="L1164" class="blob-num js-line-number" data-line-number="1164"></td>
+        <td id="LC1164" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: True if ok or raises an exception.</span></td>
+      </tr>
+      <tr>
+        <td id="L1165" class="blob-num js-line-number" data-line-number="1165"></td>
+        <td id="LC1165" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1166" class="blob-num js-line-number" data-line-number="1166"></td>
+        <td id="LC1166" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> logging_str</td>
+      </tr>
+      <tr>
+        <td id="L1167" class="blob-num js-line-number" data-line-number="1167"></td>
+        <td id="LC1167" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1168" class="blob-num js-line-number" data-line-number="1168"></td>
+        <td id="LC1168" class="blob-code blob-code-inner js-file-line">            body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L1169" class="blob-num js-line-number" data-line-number="1169"></td>
+        <td id="LC1169" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, <span class="pl-v">data</span><span class="pl-k">=</span>body,</td>
+      </tr>
+      <tr>
+        <td id="L1170" class="blob-num js-line-number" data-line-number="1170"></td>
+        <td id="LC1170" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>logging<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1171" class="blob-num js-line-number" data-line-number="1171"></td>
+        <td id="LC1171" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1172" class="blob-num js-line-number" data-line-number="1172"></td>
+        <td id="LC1172" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1173" class="blob-num js-line-number" data-line-number="1173"></td>
+        <td id="LC1173" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
+      </tr>
+      <tr>
+        <td id="L1174" class="blob-num js-line-number" data-line-number="1174"></td>
+        <td id="LC1174" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1175" class="blob-num js-line-number" data-line-number="1175"></td>
+        <td id="LC1175" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1176" class="blob-num js-line-number" data-line-number="1176"></td>
+        <td id="LC1176" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1177" class="blob-num js-line-number" data-line-number="1177"></td>
+        <td id="LC1177" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1178" class="blob-num js-line-number" data-line-number="1178"></td>
+        <td id="LC1178" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">enable_logging</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">target_bucket</span>, <span class="pl-smi">target_prefix</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L1179" class="blob-num js-line-number" data-line-number="1179"></td>
+        <td id="LC1179" class="blob-code blob-code-inner js-file-line">                       <span class="pl-smi">grants</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1180" class="blob-num js-line-number" data-line-number="1180"></td>
+        <td id="LC1180" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1181" class="blob-num js-line-number" data-line-number="1181"></td>
+        <td id="LC1181" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Enable logging on a bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1182" class="blob-num js-line-number" data-line-number="1182"></td>
+        <td id="LC1182" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1183" class="blob-num js-line-number" data-line-number="1183"></td>
+        <td id="LC1183" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type target_bucket: bucket or string</span></td>
+      </tr>
+      <tr>
+        <td id="L1184" class="blob-num js-line-number" data-line-number="1184"></td>
+        <td id="LC1184" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param target_bucket: The bucket to log to.</span></td>
+      </tr>
+      <tr>
+        <td id="L1185" class="blob-num js-line-number" data-line-number="1185"></td>
+        <td id="LC1185" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1186" class="blob-num js-line-number" data-line-number="1186"></td>
+        <td id="LC1186" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type target_prefix: string</span></td>
+      </tr>
+      <tr>
+        <td id="L1187" class="blob-num js-line-number" data-line-number="1187"></td>
+        <td id="LC1187" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param target_prefix: The prefix which should be prepended to the</span></td>
+      </tr>
+      <tr>
+        <td id="L1188" class="blob-num js-line-number" data-line-number="1188"></td>
+        <td id="LC1188" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            generated log files written to the target_bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1189" class="blob-num js-line-number" data-line-number="1189"></td>
+        <td id="LC1189" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1190" class="blob-num js-line-number" data-line-number="1190"></td>
+        <td id="LC1190" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type grants: list of Grant objects</span></td>
+      </tr>
+      <tr>
+        <td id="L1191" class="blob-num js-line-number" data-line-number="1191"></td>
+        <td id="LC1191" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param grants: A list of extra permissions which will be granted on</span></td>
+      </tr>
+      <tr>
+        <td id="L1192" class="blob-num js-line-number" data-line-number="1192"></td>
+        <td id="LC1192" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the log files which are created.</span></td>
+      </tr>
+      <tr>
+        <td id="L1193" class="blob-num js-line-number" data-line-number="1193"></td>
+        <td id="LC1193" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1194" class="blob-num js-line-number" data-line-number="1194"></td>
+        <td id="LC1194" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: bool</span></td>
+      </tr>
+      <tr>
+        <td id="L1195" class="blob-num js-line-number" data-line-number="1195"></td>
+        <td id="LC1195" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: True if ok or raises an exception.</span></td>
+      </tr>
+      <tr>
+        <td id="L1196" class="blob-num js-line-number" data-line-number="1196"></td>
+        <td id="LC1196" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1197" class="blob-num js-line-number" data-line-number="1197"></td>
+        <td id="LC1197" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-c1">isinstance</span>(target_bucket, Bucket):</td>
+      </tr>
+      <tr>
+        <td id="L1198" class="blob-num js-line-number" data-line-number="1198"></td>
+        <td id="LC1198" class="blob-code blob-code-inner js-file-line">            target_bucket <span class="pl-k">=</span> target_bucket.name</td>
+      </tr>
+      <tr>
+        <td id="L1199" class="blob-num js-line-number" data-line-number="1199"></td>
+        <td id="LC1199" class="blob-code blob-code-inner js-file-line">        blogging <span class="pl-k">=</span> BucketLogging(<span class="pl-v">target</span><span class="pl-k">=</span>target_bucket, <span class="pl-v">prefix</span><span class="pl-k">=</span>target_prefix,</td>
+      </tr>
+      <tr>
+        <td id="L1200" class="blob-num js-line-number" data-line-number="1200"></td>
+        <td id="LC1200" class="blob-code blob-code-inner js-file-line">                                 <span class="pl-v">grants</span><span class="pl-k">=</span>grants)</td>
+      </tr>
+      <tr>
+        <td id="L1201" class="blob-num js-line-number" data-line-number="1201"></td>
+        <td id="LC1201" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.set_xml_logging(blogging.to_xml(), <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1202" class="blob-num js-line-number" data-line-number="1202"></td>
+        <td id="LC1202" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1203" class="blob-num js-line-number" data-line-number="1203"></td>
+        <td id="LC1203" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">disable_logging</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1204" class="blob-num js-line-number" data-line-number="1204"></td>
+        <td id="LC1204" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1205" class="blob-num js-line-number" data-line-number="1205"></td>
+        <td id="LC1205" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Disable logging on a bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1206" class="blob-num js-line-number" data-line-number="1206"></td>
+        <td id="LC1206" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1207" class="blob-num js-line-number" data-line-number="1207"></td>
+        <td id="LC1207" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: bool</span></td>
+      </tr>
+      <tr>
+        <td id="L1208" class="blob-num js-line-number" data-line-number="1208"></td>
+        <td id="LC1208" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: True if ok or raises an exception.</span></td>
+      </tr>
+      <tr>
+        <td id="L1209" class="blob-num js-line-number" data-line-number="1209"></td>
+        <td id="LC1209" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1210" class="blob-num js-line-number" data-line-number="1210"></td>
+        <td id="LC1210" class="blob-code blob-code-inner js-file-line">        blogging <span class="pl-k">=</span> BucketLogging()</td>
+      </tr>
+      <tr>
+        <td id="L1211" class="blob-num js-line-number" data-line-number="1211"></td>
+        <td id="LC1211" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.set_xml_logging(blogging.to_xml(), <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1212" class="blob-num js-line-number" data-line-number="1212"></td>
+        <td id="LC1212" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1213" class="blob-num js-line-number" data-line-number="1213"></td>
+        <td id="LC1213" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_logging_status</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1214" class="blob-num js-line-number" data-line-number="1214"></td>
+        <td id="LC1214" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1215" class="blob-num js-line-number" data-line-number="1215"></td>
+        <td id="LC1215" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Get the logging status for this bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1216" class="blob-num js-line-number" data-line-number="1216"></td>
+        <td id="LC1216" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1217" class="blob-num js-line-number" data-line-number="1217"></td>
+        <td id="LC1217" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.bucketlogging.BucketLogging`</span></td>
+      </tr>
+      <tr>
+        <td id="L1218" class="blob-num js-line-number" data-line-number="1218"></td>
+        <td id="LC1218" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: A BucketLogging object for this bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1219" class="blob-num js-line-number" data-line-number="1219"></td>
+        <td id="LC1219" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1220" class="blob-num js-line-number" data-line-number="1220"></td>
+        <td id="LC1220" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1221" class="blob-num js-line-number" data-line-number="1221"></td>
+        <td id="LC1221" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>logging<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1222" class="blob-num js-line-number" data-line-number="1222"></td>
+        <td id="LC1222" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1223" class="blob-num js-line-number" data-line-number="1223"></td>
+        <td id="LC1223" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1224" class="blob-num js-line-number" data-line-number="1224"></td>
+        <td id="LC1224" class="blob-code blob-code-inner js-file-line">            blogging <span class="pl-k">=</span> BucketLogging()</td>
+      </tr>
+      <tr>
+        <td id="L1225" class="blob-num js-line-number" data-line-number="1225"></td>
+        <td id="LC1225" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(blogging, <span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L1226" class="blob-num js-line-number" data-line-number="1226"></td>
+        <td id="LC1226" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1227" class="blob-num js-line-number" data-line-number="1227"></td>
+        <td id="LC1227" class="blob-code blob-code-inner js-file-line">                body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L1228" class="blob-num js-line-number" data-line-number="1228"></td>
+        <td id="LC1228" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
+      </tr>
+      <tr>
+        <td id="L1229" class="blob-num js-line-number" data-line-number="1229"></td>
+        <td id="LC1229" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> blogging</td>
+      </tr>
+      <tr>
+        <td id="L1230" class="blob-num js-line-number" data-line-number="1230"></td>
+        <td id="LC1230" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1231" class="blob-num js-line-number" data-line-number="1231"></td>
+        <td id="LC1231" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1232" class="blob-num js-line-number" data-line-number="1232"></td>
+        <td id="LC1232" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1233" class="blob-num js-line-number" data-line-number="1233"></td>
+        <td id="LC1233" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1234" class="blob-num js-line-number" data-line-number="1234"></td>
+        <td id="LC1234" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_as_logging_target</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1235" class="blob-num js-line-number" data-line-number="1235"></td>
+        <td id="LC1235" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1236" class="blob-num js-line-number" data-line-number="1236"></td>
+        <td id="LC1236" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Setup the current bucket as a logging target by granting the necessary</span></td>
+      </tr>
+      <tr>
+        <td id="L1237" class="blob-num js-line-number" data-line-number="1237"></td>
+        <td id="LC1237" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        permissions to the LogDelivery group to write log files to this bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1238" class="blob-num js-line-number" data-line-number="1238"></td>
+        <td id="LC1238" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1239" class="blob-num js-line-number" data-line-number="1239"></td>
+        <td id="LC1239" class="blob-code blob-code-inner js-file-line">        policy <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_acl(<span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1240" class="blob-num js-line-number" data-line-number="1240"></td>
+        <td id="LC1240" class="blob-code blob-code-inner js-file-line">        g1 <span class="pl-k">=</span> Grant(<span class="pl-v">permission</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>WRITE<span class="pl-pds">&#39;</span></span>, <span class="pl-v">type</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>Group<span class="pl-pds">&#39;</span></span>, <span class="pl-v">uri</span><span class="pl-k">=</span><span class="pl-c1">self</span>.LoggingGroup)</td>
+      </tr>
+      <tr>
+        <td id="L1241" class="blob-num js-line-number" data-line-number="1241"></td>
+        <td id="LC1241" class="blob-code blob-code-inner js-file-line">        g2 <span class="pl-k">=</span> Grant(<span class="pl-v">permission</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>READ_ACP<span class="pl-pds">&#39;</span></span>, <span class="pl-v">type</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>Group<span class="pl-pds">&#39;</span></span>, <span class="pl-v">uri</span><span class="pl-k">=</span><span class="pl-c1">self</span>.LoggingGroup)</td>
+      </tr>
+      <tr>
+        <td id="L1242" class="blob-num js-line-number" data-line-number="1242"></td>
+        <td id="LC1242" class="blob-code blob-code-inner js-file-line">        policy.acl.add_grant(g1)</td>
+      </tr>
+      <tr>
+        <td id="L1243" class="blob-num js-line-number" data-line-number="1243"></td>
+        <td id="LC1243" class="blob-code blob-code-inner js-file-line">        policy.acl.add_grant(g2)</td>
+      </tr>
+      <tr>
+        <td id="L1244" class="blob-num js-line-number" data-line-number="1244"></td>
+        <td id="LC1244" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.set_acl(policy, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1245" class="blob-num js-line-number" data-line-number="1245"></td>
+        <td id="LC1245" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1246" class="blob-num js-line-number" data-line-number="1246"></td>
+        <td id="LC1246" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_request_payment</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1247" class="blob-num js-line-number" data-line-number="1247"></td>
+        <td id="LC1247" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1248" class="blob-num js-line-number" data-line-number="1248"></td>
+        <td id="LC1248" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>requestPayment<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1249" class="blob-num js-line-number" data-line-number="1249"></td>
+        <td id="LC1249" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1250" class="blob-num js-line-number" data-line-number="1250"></td>
+        <td id="LC1250" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1251" class="blob-num js-line-number" data-line-number="1251"></td>
+        <td id="LC1251" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> body</td>
+      </tr>
+      <tr>
+        <td id="L1252" class="blob-num js-line-number" data-line-number="1252"></td>
+        <td id="LC1252" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1253" class="blob-num js-line-number" data-line-number="1253"></td>
+        <td id="LC1253" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1254" class="blob-num js-line-number" data-line-number="1254"></td>
+        <td id="LC1254" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1255" class="blob-num js-line-number" data-line-number="1255"></td>
+        <td id="LC1255" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1256" class="blob-num js-line-number" data-line-number="1256"></td>
+        <td id="LC1256" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_request_payment</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">payer</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>BucketOwner<span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1257" class="blob-num js-line-number" data-line-number="1257"></td>
+        <td id="LC1257" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> <span class="pl-c1">self</span>.BucketPaymentBody <span class="pl-k">%</span> payer</td>
+      </tr>
+      <tr>
+        <td id="L1258" class="blob-num js-line-number" data-line-number="1258"></td>
+        <td id="LC1258" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, <span class="pl-v">data</span><span class="pl-k">=</span>body,</td>
+      </tr>
+      <tr>
+        <td id="L1259" class="blob-num js-line-number" data-line-number="1259"></td>
+        <td id="LC1259" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>requestPayment<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1260" class="blob-num js-line-number" data-line-number="1260"></td>
+        <td id="LC1260" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1261" class="blob-num js-line-number" data-line-number="1261"></td>
+        <td id="LC1261" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1262" class="blob-num js-line-number" data-line-number="1262"></td>
+        <td id="LC1262" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
+      </tr>
+      <tr>
+        <td id="L1263" class="blob-num js-line-number" data-line-number="1263"></td>
+        <td id="LC1263" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1264" class="blob-num js-line-number" data-line-number="1264"></td>
+        <td id="LC1264" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1265" class="blob-num js-line-number" data-line-number="1265"></td>
+        <td id="LC1265" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1266" class="blob-num js-line-number" data-line-number="1266"></td>
+        <td id="LC1266" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1267" class="blob-num js-line-number" data-line-number="1267"></td>
+        <td id="LC1267" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">configure_versioning</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">versioning</span>, <span class="pl-smi">mfa_delete</span><span class="pl-k">=</span><span class="pl-c1">False</span>,</td>
+      </tr>
+      <tr>
+        <td id="L1268" class="blob-num js-line-number" data-line-number="1268"></td>
+        <td id="LC1268" class="blob-code blob-code-inner js-file-line">                             <span class="pl-smi">mfa_token</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1269" class="blob-num js-line-number" data-line-number="1269"></td>
+        <td id="LC1269" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1270" class="blob-num js-line-number" data-line-number="1270"></td>
+        <td id="LC1270" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Configure versioning for this bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1271" class="blob-num js-line-number" data-line-number="1271"></td>
+        <td id="LC1271" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1272" class="blob-num js-line-number" data-line-number="1272"></td>
+        <td id="LC1272" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        ..note:: This feature is currently in beta.</span></td>
+      </tr>
+      <tr>
+        <td id="L1273" class="blob-num js-line-number" data-line-number="1273"></td>
+        <td id="LC1273" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1274" class="blob-num js-line-number" data-line-number="1274"></td>
+        <td id="LC1274" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type versioning: bool</span></td>
+      </tr>
+      <tr>
+        <td id="L1275" class="blob-num js-line-number" data-line-number="1275"></td>
+        <td id="LC1275" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param versioning: A boolean indicating whether version is</span></td>
+      </tr>
+      <tr>
+        <td id="L1276" class="blob-num js-line-number" data-line-number="1276"></td>
+        <td id="LC1276" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            enabled (True) or disabled (False).</span></td>
+      </tr>
+      <tr>
+        <td id="L1277" class="blob-num js-line-number" data-line-number="1277"></td>
+        <td id="LC1277" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1278" class="blob-num js-line-number" data-line-number="1278"></td>
+        <td id="LC1278" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type mfa_delete: bool</span></td>
+      </tr>
+      <tr>
+        <td id="L1279" class="blob-num js-line-number" data-line-number="1279"></td>
+        <td id="LC1279" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param mfa_delete: A boolean indicating whether the</span></td>
+      </tr>
+      <tr>
+        <td id="L1280" class="blob-num js-line-number" data-line-number="1280"></td>
+        <td id="LC1280" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Multi-Factor Authentication Delete feature is enabled</span></td>
+      </tr>
+      <tr>
+        <td id="L1281" class="blob-num js-line-number" data-line-number="1281"></td>
+        <td id="LC1281" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            (True) or disabled (False).  If mfa_delete is enabled then</span></td>
+      </tr>
+      <tr>
+        <td id="L1282" class="blob-num js-line-number" data-line-number="1282"></td>
+        <td id="LC1282" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            all Delete operations will require the token from your MFA</span></td>
+      </tr>
+      <tr>
+        <td id="L1283" class="blob-num js-line-number" data-line-number="1283"></td>
+        <td id="LC1283" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            device to be passed in the request.</span></td>
+      </tr>
+      <tr>
+        <td id="L1284" class="blob-num js-line-number" data-line-number="1284"></td>
+        <td id="LC1284" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1285" class="blob-num js-line-number" data-line-number="1285"></td>
+        <td id="LC1285" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type mfa_token: tuple or list of strings</span></td>
+      </tr>
+      <tr>
+        <td id="L1286" class="blob-num js-line-number" data-line-number="1286"></td>
+        <td id="LC1286" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param mfa_token: A tuple or list consisting of the serial</span></td>
+      </tr>
+      <tr>
+        <td id="L1287" class="blob-num js-line-number" data-line-number="1287"></td>
+        <td id="LC1287" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            number from the MFA device and the current value of the</span></td>
+      </tr>
+      <tr>
+        <td id="L1288" class="blob-num js-line-number" data-line-number="1288"></td>
+        <td id="LC1288" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            six-digit token associated with the device.  This value is</span></td>
+      </tr>
+      <tr>
+        <td id="L1289" class="blob-num js-line-number" data-line-number="1289"></td>
+        <td id="LC1289" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            required when you are changing the status of the MfaDelete</span></td>
+      </tr>
+      <tr>
+        <td id="L1290" class="blob-num js-line-number" data-line-number="1290"></td>
+        <td id="LC1290" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            property of the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1291" class="blob-num js-line-number" data-line-number="1291"></td>
+        <td id="LC1291" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1292" class="blob-num js-line-number" data-line-number="1292"></td>
+        <td id="LC1292" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> versioning:</td>
+      </tr>
+      <tr>
+        <td id="L1293" class="blob-num js-line-number" data-line-number="1293"></td>
+        <td id="LC1293" class="blob-code blob-code-inner js-file-line">            ver <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>Enabled<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1294" class="blob-num js-line-number" data-line-number="1294"></td>
+        <td id="LC1294" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1295" class="blob-num js-line-number" data-line-number="1295"></td>
+        <td id="LC1295" class="blob-code blob-code-inner js-file-line">            ver <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>Suspended<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1296" class="blob-num js-line-number" data-line-number="1296"></td>
+        <td id="LC1296" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> mfa_delete:</td>
+      </tr>
+      <tr>
+        <td id="L1297" class="blob-num js-line-number" data-line-number="1297"></td>
+        <td id="LC1297" class="blob-code blob-code-inner js-file-line">            mfa <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>Enabled<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1298" class="blob-num js-line-number" data-line-number="1298"></td>
+        <td id="LC1298" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1299" class="blob-num js-line-number" data-line-number="1299"></td>
+        <td id="LC1299" class="blob-code blob-code-inner js-file-line">            mfa <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>Disabled<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1300" class="blob-num js-line-number" data-line-number="1300"></td>
+        <td id="LC1300" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> <span class="pl-c1">self</span>.VersioningBody <span class="pl-k">%</span> (ver, mfa)</td>
+      </tr>
+      <tr>
+        <td id="L1301" class="blob-num js-line-number" data-line-number="1301"></td>
+        <td id="LC1301" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> mfa_token:</td>
+      </tr>
+      <tr>
+        <td id="L1302" class="blob-num js-line-number" data-line-number="1302"></td>
+        <td id="LC1302" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> headers:</td>
+      </tr>
+      <tr>
+        <td id="L1303" class="blob-num js-line-number" data-line-number="1303"></td>
+        <td id="LC1303" class="blob-code blob-code-inner js-file-line">                headers <span class="pl-k">=</span> {}</td>
+      </tr>
+      <tr>
+        <td id="L1304" class="blob-num js-line-number" data-line-number="1304"></td>
+        <td id="LC1304" class="blob-code blob-code-inner js-file-line">            provider <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.provider</td>
+      </tr>
+      <tr>
+        <td id="L1305" class="blob-num js-line-number" data-line-number="1305"></td>
+        <td id="LC1305" class="blob-code blob-code-inner js-file-line">            headers[provider.mfa_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span> <span class="pl-pds">&#39;</span></span>.join(mfa_token)</td>
+      </tr>
+      <tr>
+        <td id="L1306" class="blob-num js-line-number" data-line-number="1306"></td>
+        <td id="LC1306" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, <span class="pl-v">data</span><span class="pl-k">=</span>body,</td>
+      </tr>
+      <tr>
+        <td id="L1307" class="blob-num js-line-number" data-line-number="1307"></td>
+        <td id="LC1307" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>versioning<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1308" class="blob-num js-line-number" data-line-number="1308"></td>
+        <td id="LC1308" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1309" class="blob-num js-line-number" data-line-number="1309"></td>
+        <td id="LC1309" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1310" class="blob-num js-line-number" data-line-number="1310"></td>
+        <td id="LC1310" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
+      </tr>
+      <tr>
+        <td id="L1311" class="blob-num js-line-number" data-line-number="1311"></td>
+        <td id="LC1311" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1312" class="blob-num js-line-number" data-line-number="1312"></td>
+        <td id="LC1312" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1313" class="blob-num js-line-number" data-line-number="1313"></td>
+        <td id="LC1313" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1314" class="blob-num js-line-number" data-line-number="1314"></td>
+        <td id="LC1314" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1315" class="blob-num js-line-number" data-line-number="1315"></td>
+        <td id="LC1315" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_versioning_status</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1316" class="blob-num js-line-number" data-line-number="1316"></td>
+        <td id="LC1316" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1317" class="blob-num js-line-number" data-line-number="1317"></td>
+        <td id="LC1317" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the current status of versioning on the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1318" class="blob-num js-line-number" data-line-number="1318"></td>
+        <td id="LC1318" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1319" class="blob-num js-line-number" data-line-number="1319"></td>
+        <td id="LC1319" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: dict</span></td>
+      </tr>
+      <tr>
+        <td id="L1320" class="blob-num js-line-number" data-line-number="1320"></td>
+        <td id="LC1320" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: A dictionary containing a key named &#39;Versioning&#39;</span></td>
+      </tr>
+      <tr>
+        <td id="L1321" class="blob-num js-line-number" data-line-number="1321"></td>
+        <td id="LC1321" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            that can have a value of either Enabled, Disabled, or</span></td>
+      </tr>
+      <tr>
+        <td id="L1322" class="blob-num js-line-number" data-line-number="1322"></td>
+        <td id="LC1322" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Suspended. Also, if MFADelete has ever been enabled on the</span></td>
+      </tr>
+      <tr>
+        <td id="L1323" class="blob-num js-line-number" data-line-number="1323"></td>
+        <td id="LC1323" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            bucket, the dictionary will contain a key named</span></td>
+      </tr>
+      <tr>
+        <td id="L1324" class="blob-num js-line-number" data-line-number="1324"></td>
+        <td id="LC1324" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            &#39;MFADelete&#39; which will have a value of either Enabled or</span></td>
+      </tr>
+      <tr>
+        <td id="L1325" class="blob-num js-line-number" data-line-number="1325"></td>
+        <td id="LC1325" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Suspended.</span></td>
+      </tr>
+      <tr>
+        <td id="L1326" class="blob-num js-line-number" data-line-number="1326"></td>
+        <td id="LC1326" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1327" class="blob-num js-line-number" data-line-number="1327"></td>
+        <td id="LC1327" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1328" class="blob-num js-line-number" data-line-number="1328"></td>
+        <td id="LC1328" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>versioning<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1329" class="blob-num js-line-number" data-line-number="1329"></td>
+        <td id="LC1329" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1330" class="blob-num js-line-number" data-line-number="1330"></td>
+        <td id="LC1330" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, six.string_types):</td>
+      </tr>
+      <tr>
+        <td id="L1331" class="blob-num js-line-number" data-line-number="1331"></td>
+        <td id="LC1331" class="blob-code blob-code-inner js-file-line">            body <span class="pl-k">=</span> body.decode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L1332" class="blob-num js-line-number" data-line-number="1332"></td>
+        <td id="LC1332" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
+      </tr>
+      <tr>
+        <td id="L1333" class="blob-num js-line-number" data-line-number="1333"></td>
+        <td id="LC1333" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1334" class="blob-num js-line-number" data-line-number="1334"></td>
+        <td id="LC1334" class="blob-code blob-code-inner js-file-line">            d <span class="pl-k">=</span> {}</td>
+      </tr>
+      <tr>
+        <td id="L1335" class="blob-num js-line-number" data-line-number="1335"></td>
+        <td id="LC1335" class="blob-code blob-code-inner js-file-line">            ver <span class="pl-k">=</span> re.search(<span class="pl-c1">self</span>.VersionRE, body)</td>
+      </tr>
+      <tr>
+        <td id="L1336" class="blob-num js-line-number" data-line-number="1336"></td>
+        <td id="LC1336" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> ver:</td>
+      </tr>
+      <tr>
+        <td id="L1337" class="blob-num js-line-number" data-line-number="1337"></td>
+        <td id="LC1337" class="blob-code blob-code-inner js-file-line">                d[<span class="pl-s"><span class="pl-pds">&#39;</span>Versioning<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> ver.group(<span class="pl-c1">1</span>)</td>
+      </tr>
+      <tr>
+        <td id="L1338" class="blob-num js-line-number" data-line-number="1338"></td>
+        <td id="LC1338" class="blob-code blob-code-inner js-file-line">            mfa <span class="pl-k">=</span> re.search(<span class="pl-c1">self</span>.MFADeleteRE, body)</td>
+      </tr>
+      <tr>
+        <td id="L1339" class="blob-num js-line-number" data-line-number="1339"></td>
+        <td id="LC1339" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> mfa:</td>
+      </tr>
+      <tr>
+        <td id="L1340" class="blob-num js-line-number" data-line-number="1340"></td>
+        <td id="LC1340" class="blob-code blob-code-inner js-file-line">                d[<span class="pl-s"><span class="pl-pds">&#39;</span>MfaDelete<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> mfa.group(<span class="pl-c1">1</span>)</td>
+      </tr>
+      <tr>
+        <td id="L1341" class="blob-num js-line-number" data-line-number="1341"></td>
+        <td id="LC1341" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> d</td>
+      </tr>
+      <tr>
+        <td id="L1342" class="blob-num js-line-number" data-line-number="1342"></td>
+        <td id="LC1342" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1343" class="blob-num js-line-number" data-line-number="1343"></td>
+        <td id="LC1343" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1344" class="blob-num js-line-number" data-line-number="1344"></td>
+        <td id="LC1344" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1345" class="blob-num js-line-number" data-line-number="1345"></td>
+        <td id="LC1345" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1346" class="blob-num js-line-number" data-line-number="1346"></td>
+        <td id="LC1346" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">configure_lifecycle</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">lifecycle_config</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1347" class="blob-num js-line-number" data-line-number="1347"></td>
+        <td id="LC1347" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1348" class="blob-num js-line-number" data-line-number="1348"></td>
+        <td id="LC1348" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Configure lifecycle for this bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1349" class="blob-num js-line-number" data-line-number="1349"></td>
+        <td id="LC1349" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1350" class="blob-num js-line-number" data-line-number="1350"></td>
+        <td id="LC1350" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type lifecycle_config: :class:`boto.s3.lifecycle.Lifecycle`</span></td>
+      </tr>
+      <tr>
+        <td id="L1351" class="blob-num js-line-number" data-line-number="1351"></td>
+        <td id="LC1351" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param lifecycle_config: The lifecycle configuration you want</span></td>
+      </tr>
+      <tr>
+        <td id="L1352" class="blob-num js-line-number" data-line-number="1352"></td>
+        <td id="LC1352" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            to configure for this bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1353" class="blob-num js-line-number" data-line-number="1353"></td>
+        <td id="LC1353" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1354" class="blob-num js-line-number" data-line-number="1354"></td>
+        <td id="LC1354" class="blob-code blob-code-inner js-file-line">        xml <span class="pl-k">=</span> lifecycle_config.to_xml()</td>
+      </tr>
+      <tr>
+        <td id="L1355" class="blob-num js-line-number" data-line-number="1355"></td>
+        <td id="LC1355" class="blob-code blob-code-inner js-file-line">        <span class="pl-c"><span class="pl-c">#</span>xml = xml.encode(&#39;utf-8&#39;)</span></td>
+      </tr>
+      <tr>
+        <td id="L1356" class="blob-num js-line-number" data-line-number="1356"></td>
+        <td id="LC1356" class="blob-code blob-code-inner js-file-line">        fp <span class="pl-k">=</span> StringIO(xml)</td>
+      </tr>
+      <tr>
+        <td id="L1357" class="blob-num js-line-number" data-line-number="1357"></td>
+        <td id="LC1357" class="blob-code blob-code-inner js-file-line">        md5 <span class="pl-k">=</span> boto.utils.compute_md5(fp)</td>
+      </tr>
+      <tr>
+        <td id="L1358" class="blob-num js-line-number" data-line-number="1358"></td>
+        <td id="LC1358" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> headers <span class="pl-k">is</span> <span class="pl-c1">None</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1359" class="blob-num js-line-number" data-line-number="1359"></td>
+        <td id="LC1359" class="blob-code blob-code-inner js-file-line">            headers <span class="pl-k">=</span> {}</td>
+      </tr>
+      <tr>
+        <td id="L1360" class="blob-num js-line-number" data-line-number="1360"></td>
+        <td id="LC1360" class="blob-code blob-code-inner js-file-line">        headers[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-MD5<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> md5[<span class="pl-c1">1</span>]</td>
+      </tr>
+      <tr>
+        <td id="L1361" class="blob-num js-line-number" data-line-number="1361"></td>
+        <td id="LC1361" class="blob-code blob-code-inner js-file-line">        headers[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-Type<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>text/xml<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1362" class="blob-num js-line-number" data-line-number="1362"></td>
+        <td id="LC1362" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1363" class="blob-num js-line-number" data-line-number="1363"></td>
+        <td id="LC1363" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">data</span><span class="pl-k">=</span>fp.getvalue(),</td>
+      </tr>
+      <tr>
+        <td id="L1364" class="blob-num js-line-number" data-line-number="1364"></td>
+        <td id="LC1364" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>lifecycle<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L1365" class="blob-num js-line-number" data-line-number="1365"></td>
+        <td id="LC1365" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1366" class="blob-num js-line-number" data-line-number="1366"></td>
+        <td id="LC1366" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1367" class="blob-num js-line-number" data-line-number="1367"></td>
+        <td id="LC1367" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1368" class="blob-num js-line-number" data-line-number="1368"></td>
+        <td id="LC1368" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
+      </tr>
+      <tr>
+        <td id="L1369" class="blob-num js-line-number" data-line-number="1369"></td>
+        <td id="LC1369" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1370" class="blob-num js-line-number" data-line-number="1370"></td>
+        <td id="LC1370" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1371" class="blob-num js-line-number" data-line-number="1371"></td>
+        <td id="LC1371" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1372" class="blob-num js-line-number" data-line-number="1372"></td>
+        <td id="LC1372" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1373" class="blob-num js-line-number" data-line-number="1373"></td>
+        <td id="LC1373" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_lifecycle_config</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1374" class="blob-num js-line-number" data-line-number="1374"></td>
+        <td id="LC1374" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1375" class="blob-num js-line-number" data-line-number="1375"></td>
+        <td id="LC1375" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the current lifecycle configuration on the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1376" class="blob-num js-line-number" data-line-number="1376"></td>
+        <td id="LC1376" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1377" class="blob-num js-line-number" data-line-number="1377"></td>
+        <td id="LC1377" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.lifecycle.Lifecycle`</span></td>
+      </tr>
+      <tr>
+        <td id="L1378" class="blob-num js-line-number" data-line-number="1378"></td>
+        <td id="LC1378" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: A LifecycleConfig object that describes all current</span></td>
+      </tr>
+      <tr>
+        <td id="L1379" class="blob-num js-line-number" data-line-number="1379"></td>
+        <td id="LC1379" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            lifecycle rules in effect for the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1380" class="blob-num js-line-number" data-line-number="1380"></td>
+        <td id="LC1380" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1381" class="blob-num js-line-number" data-line-number="1381"></td>
+        <td id="LC1381" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1382" class="blob-num js-line-number" data-line-number="1382"></td>
+        <td id="LC1382" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>lifecycle<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1383" class="blob-num js-line-number" data-line-number="1383"></td>
+        <td id="LC1383" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1384" class="blob-num js-line-number" data-line-number="1384"></td>
+        <td id="LC1384" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
+      </tr>
+      <tr>
+        <td id="L1385" class="blob-num js-line-number" data-line-number="1385"></td>
+        <td id="LC1385" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1386" class="blob-num js-line-number" data-line-number="1386"></td>
+        <td id="LC1386" class="blob-code blob-code-inner js-file-line">            lifecycle <span class="pl-k">=</span> Lifecycle()</td>
+      </tr>
+      <tr>
+        <td id="L1387" class="blob-num js-line-number" data-line-number="1387"></td>
+        <td id="LC1387" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(lifecycle, <span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L1388" class="blob-num js-line-number" data-line-number="1388"></td>
+        <td id="LC1388" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1389" class="blob-num js-line-number" data-line-number="1389"></td>
+        <td id="LC1389" class="blob-code blob-code-inner js-file-line">                body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L1390" class="blob-num js-line-number" data-line-number="1390"></td>
+        <td id="LC1390" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
+      </tr>
+      <tr>
+        <td id="L1391" class="blob-num js-line-number" data-line-number="1391"></td>
+        <td id="LC1391" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> lifecycle</td>
+      </tr>
+      <tr>
+        <td id="L1392" class="blob-num js-line-number" data-line-number="1392"></td>
+        <td id="LC1392" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1393" class="blob-num js-line-number" data-line-number="1393"></td>
+        <td id="LC1393" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1394" class="blob-num js-line-number" data-line-number="1394"></td>
+        <td id="LC1394" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1395" class="blob-num js-line-number" data-line-number="1395"></td>
+        <td id="LC1395" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1396" class="blob-num js-line-number" data-line-number="1396"></td>
+        <td id="LC1396" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete_lifecycle_configuration</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1397" class="blob-num js-line-number" data-line-number="1397"></td>
+        <td id="LC1397" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1398" class="blob-num js-line-number" data-line-number="1398"></td>
+        <td id="LC1398" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Removes all lifecycle configuration from the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1399" class="blob-num js-line-number" data-line-number="1399"></td>
+        <td id="LC1399" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1400" class="blob-num js-line-number" data-line-number="1400"></td>
+        <td id="LC1400" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>DELETE<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1401" class="blob-num js-line-number" data-line-number="1401"></td>
+        <td id="LC1401" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>lifecycle<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L1402" class="blob-num js-line-number" data-line-number="1402"></td>
+        <td id="LC1402" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1403" class="blob-num js-line-number" data-line-number="1403"></td>
+        <td id="LC1403" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1404" class="blob-num js-line-number" data-line-number="1404"></td>
+        <td id="LC1404" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
+      </tr>
+      <tr>
+        <td id="L1405" class="blob-num js-line-number" data-line-number="1405"></td>
+        <td id="LC1405" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">204</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1406" class="blob-num js-line-number" data-line-number="1406"></td>
+        <td id="LC1406" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
+      </tr>
+      <tr>
+        <td id="L1407" class="blob-num js-line-number" data-line-number="1407"></td>
+        <td id="LC1407" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1408" class="blob-num js-line-number" data-line-number="1408"></td>
+        <td id="LC1408" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1409" class="blob-num js-line-number" data-line-number="1409"></td>
+        <td id="LC1409" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1410" class="blob-num js-line-number" data-line-number="1410"></td>
+        <td id="LC1410" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1411" class="blob-num js-line-number" data-line-number="1411"></td>
+        <td id="LC1411" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">configure_website</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">suffix</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">error_key</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
+      </tr>
+      <tr>
+        <td id="L1412" class="blob-num js-line-number" data-line-number="1412"></td>
+        <td id="LC1412" class="blob-code blob-code-inner js-file-line">                          <span class="pl-smi">redirect_all_requests_to</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
+      </tr>
+      <tr>
+        <td id="L1413" class="blob-num js-line-number" data-line-number="1413"></td>
+        <td id="LC1413" class="blob-code blob-code-inner js-file-line">                          <span class="pl-smi">routing_rules</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
+      </tr>
+      <tr>
+        <td id="L1414" class="blob-num js-line-number" data-line-number="1414"></td>
+        <td id="LC1414" class="blob-code blob-code-inner js-file-line">                          <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1415" class="blob-num js-line-number" data-line-number="1415"></td>
+        <td id="LC1415" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1416" class="blob-num js-line-number" data-line-number="1416"></td>
+        <td id="LC1416" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Configure this bucket to act as a website</span></td>
+      </tr>
+      <tr>
+        <td id="L1417" class="blob-num js-line-number" data-line-number="1417"></td>
+        <td id="LC1417" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1418" class="blob-num js-line-number" data-line-number="1418"></td>
+        <td id="LC1418" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type suffix: str</span></td>
+      </tr>
+      <tr>
+        <td id="L1419" class="blob-num js-line-number" data-line-number="1419"></td>
+        <td id="LC1419" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param suffix: Suffix that is appended to a request that is for a</span></td>
+      </tr>
+      <tr>
+        <td id="L1420" class="blob-num js-line-number" data-line-number="1420"></td>
+        <td id="LC1420" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            &quot;directory&quot; on the website endpoint (e.g. if the suffix is</span></td>
+      </tr>
+      <tr>
+        <td id="L1421" class="blob-num js-line-number" data-line-number="1421"></td>
+        <td id="LC1421" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            index.html and you make a request to samplebucket/images/</span></td>
+      </tr>
+      <tr>
+        <td id="L1422" class="blob-num js-line-number" data-line-number="1422"></td>
+        <td id="LC1422" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the data that is returned will be for the object with the</span></td>
+      </tr>
+      <tr>
+        <td id="L1423" class="blob-num js-line-number" data-line-number="1423"></td>
+        <td id="LC1423" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            key name images/index.html).  The suffix must not be empty</span></td>
+      </tr>
+      <tr>
+        <td id="L1424" class="blob-num js-line-number" data-line-number="1424"></td>
+        <td id="LC1424" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            and must not include a slash character.</span></td>
+      </tr>
+      <tr>
+        <td id="L1425" class="blob-num js-line-number" data-line-number="1425"></td>
+        <td id="LC1425" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1426" class="blob-num js-line-number" data-line-number="1426"></td>
+        <td id="LC1426" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type error_key: str</span></td>
+      </tr>
+      <tr>
+        <td id="L1427" class="blob-num js-line-number" data-line-number="1427"></td>
+        <td id="LC1427" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param error_key: The object key name to use when a 4XX class</span></td>
+      </tr>
+      <tr>
+        <td id="L1428" class="blob-num js-line-number" data-line-number="1428"></td>
+        <td id="LC1428" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            error occurs.  This is optional.</span></td>
+      </tr>
+      <tr>
+        <td id="L1429" class="blob-num js-line-number" data-line-number="1429"></td>
+        <td id="LC1429" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1430" class="blob-num js-line-number" data-line-number="1430"></td>
+        <td id="LC1430" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type redirect_all_requests_to: :class:`boto.s3.website.RedirectLocation`</span></td>
+      </tr>
+      <tr>
+        <td id="L1431" class="blob-num js-line-number" data-line-number="1431"></td>
+        <td id="LC1431" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param redirect_all_requests_to: Describes the redirect behavior for</span></td>
+      </tr>
+      <tr>
+        <td id="L1432" class="blob-num js-line-number" data-line-number="1432"></td>
+        <td id="LC1432" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            every request to this bucket&#39;s website endpoint. If this value is</span></td>
+      </tr>
+      <tr>
+        <td id="L1433" class="blob-num js-line-number" data-line-number="1433"></td>
+        <td id="LC1433" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            non None, no other values are considered when configuring the</span></td>
+      </tr>
+      <tr>
+        <td id="L1434" class="blob-num js-line-number" data-line-number="1434"></td>
+        <td id="LC1434" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            website configuration for the bucket. This is an instance of</span></td>
+      </tr>
+      <tr>
+        <td id="L1435" class="blob-num js-line-number" data-line-number="1435"></td>
+        <td id="LC1435" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ``RedirectLocation``.</span></td>
+      </tr>
+      <tr>
+        <td id="L1436" class="blob-num js-line-number" data-line-number="1436"></td>
+        <td id="LC1436" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1437" class="blob-num js-line-number" data-line-number="1437"></td>
+        <td id="LC1437" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type routing_rules: :class:`boto.s3.website.RoutingRules`</span></td>
+      </tr>
+      <tr>
+        <td id="L1438" class="blob-num js-line-number" data-line-number="1438"></td>
+        <td id="LC1438" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param routing_rules: Object which specifies conditions</span></td>
+      </tr>
+      <tr>
+        <td id="L1439" class="blob-num js-line-number" data-line-number="1439"></td>
+        <td id="LC1439" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            and redirects that apply when the conditions are met.</span></td>
+      </tr>
+      <tr>
+        <td id="L1440" class="blob-num js-line-number" data-line-number="1440"></td>
+        <td id="LC1440" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1441" class="blob-num js-line-number" data-line-number="1441"></td>
+        <td id="LC1441" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1442" class="blob-num js-line-number" data-line-number="1442"></td>
+        <td id="LC1442" class="blob-code blob-code-inner js-file-line">        config <span class="pl-k">=</span> website.WebsiteConfiguration(</td>
+      </tr>
+      <tr>
+        <td id="L1443" class="blob-num js-line-number" data-line-number="1443"></td>
+        <td id="LC1443" class="blob-code blob-code-inner js-file-line">                suffix, error_key, redirect_all_requests_to,</td>
+      </tr>
+      <tr>
+        <td id="L1444" class="blob-num js-line-number" data-line-number="1444"></td>
+        <td id="LC1444" class="blob-code blob-code-inner js-file-line">                routing_rules)</td>
+      </tr>
+      <tr>
+        <td id="L1445" class="blob-num js-line-number" data-line-number="1445"></td>
+        <td id="LC1445" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.set_website_configuration(config, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1446" class="blob-num js-line-number" data-line-number="1446"></td>
+        <td id="LC1446" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1447" class="blob-num js-line-number" data-line-number="1447"></td>
+        <td id="LC1447" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_website_configuration</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">config</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1448" class="blob-num js-line-number" data-line-number="1448"></td>
+        <td id="LC1448" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1449" class="blob-num js-line-number" data-line-number="1449"></td>
+        <td id="LC1449" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type config: boto.s3.website.WebsiteConfiguration</span></td>
+      </tr>
+      <tr>
+        <td id="L1450" class="blob-num js-line-number" data-line-number="1450"></td>
+        <td id="LC1450" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param config: Configuration data</span></td>
+      </tr>
+      <tr>
+        <td id="L1451" class="blob-num js-line-number" data-line-number="1451"></td>
+        <td id="LC1451" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1452" class="blob-num js-line-number" data-line-number="1452"></td>
+        <td id="LC1452" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.set_website_configuration_xml(config.to_xml(),</td>
+      </tr>
+      <tr>
+        <td id="L1453" class="blob-num js-line-number" data-line-number="1453"></td>
+        <td id="LC1453" class="blob-code blob-code-inner js-file-line">          <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1454" class="blob-num js-line-number" data-line-number="1454"></td>
+        <td id="LC1454" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1455" class="blob-num js-line-number" data-line-number="1455"></td>
+        <td id="LC1455" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1456" class="blob-num js-line-number" data-line-number="1456"></td>
+        <td id="LC1456" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_website_configuration_xml</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">xml</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1457" class="blob-num js-line-number" data-line-number="1457"></td>
+        <td id="LC1457" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span>Upload xml website configuration<span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1458" class="blob-num js-line-number" data-line-number="1458"></td>
+        <td id="LC1458" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, <span class="pl-v">data</span><span class="pl-k">=</span>xml,</td>
+      </tr>
+      <tr>
+        <td id="L1459" class="blob-num js-line-number" data-line-number="1459"></td>
+        <td id="LC1459" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>website<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L1460" class="blob-num js-line-number" data-line-number="1460"></td>
+        <td id="LC1460" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1461" class="blob-num js-line-number" data-line-number="1461"></td>
+        <td id="LC1461" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1462" class="blob-num js-line-number" data-line-number="1462"></td>
+        <td id="LC1462" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1463" class="blob-num js-line-number" data-line-number="1463"></td>
+        <td id="LC1463" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
+      </tr>
+      <tr>
+        <td id="L1464" class="blob-num js-line-number" data-line-number="1464"></td>
+        <td id="LC1464" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1465" class="blob-num js-line-number" data-line-number="1465"></td>
+        <td id="LC1465" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1466" class="blob-num js-line-number" data-line-number="1466"></td>
+        <td id="LC1466" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1467" class="blob-num js-line-number" data-line-number="1467"></td>
+        <td id="LC1467" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1468" class="blob-num js-line-number" data-line-number="1468"></td>
+        <td id="LC1468" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_website_configuration</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1469" class="blob-num js-line-number" data-line-number="1469"></td>
+        <td id="LC1469" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1470" class="blob-num js-line-number" data-line-number="1470"></td>
+        <td id="LC1470" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the current status of website configuration on the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1471" class="blob-num js-line-number" data-line-number="1471"></td>
+        <td id="LC1471" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1472" class="blob-num js-line-number" data-line-number="1472"></td>
+        <td id="LC1472" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: dict</span></td>
+      </tr>
+      <tr>
+        <td id="L1473" class="blob-num js-line-number" data-line-number="1473"></td>
+        <td id="LC1473" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: A dictionary containing a Python representation</span></td>
+      </tr>
+      <tr>
+        <td id="L1474" class="blob-num js-line-number" data-line-number="1474"></td>
+        <td id="LC1474" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            of the XML response from S3. The overall structure is:</span></td>
+      </tr>
+      <tr>
+        <td id="L1475" class="blob-num js-line-number" data-line-number="1475"></td>
+        <td id="LC1475" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1476" class="blob-num js-line-number" data-line-number="1476"></td>
+        <td id="LC1476" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        * WebsiteConfiguration</span></td>
+      </tr>
+      <tr>
+        <td id="L1477" class="blob-num js-line-number" data-line-number="1477"></td>
+        <td id="LC1477" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1478" class="blob-num js-line-number" data-line-number="1478"></td>
+        <td id="LC1478" class="blob-code blob-code-inner js-file-line"><span class="pl-s">          * IndexDocument</span></td>
+      </tr>
+      <tr>
+        <td id="L1479" class="blob-num js-line-number" data-line-number="1479"></td>
+        <td id="LC1479" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1480" class="blob-num js-line-number" data-line-number="1480"></td>
+        <td id="LC1480" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            * Suffix : suffix that is appended to request that</span></td>
+      </tr>
+      <tr>
+        <td id="L1481" class="blob-num js-line-number" data-line-number="1481"></td>
+        <td id="LC1481" class="blob-code blob-code-inner js-file-line"><span class="pl-s">              is for a &quot;directory&quot; on the website endpoint</span></td>
+      </tr>
+      <tr>
+        <td id="L1482" class="blob-num js-line-number" data-line-number="1482"></td>
+        <td id="LC1482" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            * ErrorDocument</span></td>
+      </tr>
+      <tr>
+        <td id="L1483" class="blob-num js-line-number" data-line-number="1483"></td>
+        <td id="LC1483" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1484" class="blob-num js-line-number" data-line-number="1484"></td>
+        <td id="LC1484" class="blob-code blob-code-inner js-file-line"><span class="pl-s">              * Key : name of object to serve when an error occurs</span></td>
+      </tr>
+      <tr>
+        <td id="L1485" class="blob-num js-line-number" data-line-number="1485"></td>
+        <td id="LC1485" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1486" class="blob-num js-line-number" data-line-number="1486"></td>
+        <td id="LC1486" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1487" class="blob-num js-line-number" data-line-number="1487"></td>
+        <td id="LC1487" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.get_website_configuration_with_xml(headers)[<span class="pl-c1">0</span>]</td>
+      </tr>
+      <tr>
+        <td id="L1488" class="blob-num js-line-number" data-line-number="1488"></td>
+        <td id="LC1488" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1489" class="blob-num js-line-number" data-line-number="1489"></td>
+        <td id="LC1489" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_website_configuration_obj</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1490" class="blob-num js-line-number" data-line-number="1490"></td>
+        <td id="LC1490" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span>Get the website configuration as a</span></td>
+      </tr>
+      <tr>
+        <td id="L1491" class="blob-num js-line-number" data-line-number="1491"></td>
+        <td id="LC1491" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :class:`boto.s3.website.WebsiteConfiguration` object.</span></td>
+      </tr>
+      <tr>
+        <td id="L1492" class="blob-num js-line-number" data-line-number="1492"></td>
+        <td id="LC1492" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1493" class="blob-num js-line-number" data-line-number="1493"></td>
+        <td id="LC1493" class="blob-code blob-code-inner js-file-line">        config_xml <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_website_configuration_xml(<span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1494" class="blob-num js-line-number" data-line-number="1494"></td>
+        <td id="LC1494" class="blob-code blob-code-inner js-file-line">        config <span class="pl-k">=</span> website.WebsiteConfiguration()</td>
+      </tr>
+      <tr>
+        <td id="L1495" class="blob-num js-line-number" data-line-number="1495"></td>
+        <td id="LC1495" class="blob-code blob-code-inner js-file-line">        h <span class="pl-k">=</span> handler.XmlHandler(config, <span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L1496" class="blob-num js-line-number" data-line-number="1496"></td>
+        <td id="LC1496" class="blob-code blob-code-inner js-file-line">        xml.sax.parseString(config_xml, h)</td>
+      </tr>
+      <tr>
+        <td id="L1497" class="blob-num js-line-number" data-line-number="1497"></td>
+        <td id="LC1497" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> config</td>
+      </tr>
+      <tr>
+        <td id="L1498" class="blob-num js-line-number" data-line-number="1498"></td>
+        <td id="LC1498" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1499" class="blob-num js-line-number" data-line-number="1499"></td>
+        <td id="LC1499" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_website_configuration_with_xml</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1500" class="blob-num js-line-number" data-line-number="1500"></td>
+        <td id="LC1500" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1501" class="blob-num js-line-number" data-line-number="1501"></td>
+        <td id="LC1501" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the current status of website configuration on the bucket as</span></td>
+      </tr>
+      <tr>
+        <td id="L1502" class="blob-num js-line-number" data-line-number="1502"></td>
+        <td id="LC1502" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        unparsed XML.</span></td>
+      </tr>
+      <tr>
+        <td id="L1503" class="blob-num js-line-number" data-line-number="1503"></td>
+        <td id="LC1503" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1504" class="blob-num js-line-number" data-line-number="1504"></td>
+        <td id="LC1504" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: 2-Tuple</span></td>
+      </tr>
+      <tr>
+        <td id="L1505" class="blob-num js-line-number" data-line-number="1505"></td>
+        <td id="LC1505" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: 2-tuple containing:</span></td>
+      </tr>
+      <tr>
+        <td id="L1506" class="blob-num js-line-number" data-line-number="1506"></td>
+        <td id="LC1506" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1507" class="blob-num js-line-number" data-line-number="1507"></td>
+        <td id="LC1507" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            1) A dictionary containing a Python representation <span class="pl-c1">\</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1508" class="blob-num js-line-number" data-line-number="1508"></td>
+        <td id="LC1508" class="blob-code blob-code-inner js-file-line"><span class="pl-s">                of the XML response. The overall structure is:</span></td>
+      </tr>
+      <tr>
+        <td id="L1509" class="blob-num js-line-number" data-line-number="1509"></td>
+        <td id="LC1509" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1510" class="blob-num js-line-number" data-line-number="1510"></td>
+        <td id="LC1510" class="blob-code blob-code-inner js-file-line"><span class="pl-s">              * WebsiteConfiguration</span></td>
+      </tr>
+      <tr>
+        <td id="L1511" class="blob-num js-line-number" data-line-number="1511"></td>
+        <td id="LC1511" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1512" class="blob-num js-line-number" data-line-number="1512"></td>
+        <td id="LC1512" class="blob-code blob-code-inner js-file-line"><span class="pl-s">                * IndexDocument</span></td>
+      </tr>
+      <tr>
+        <td id="L1513" class="blob-num js-line-number" data-line-number="1513"></td>
+        <td id="LC1513" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1514" class="blob-num js-line-number" data-line-number="1514"></td>
+        <td id="LC1514" class="blob-code blob-code-inner js-file-line"><span class="pl-s">                  * Suffix : suffix that is appended to request that <span class="pl-c1">\</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1515" class="blob-num js-line-number" data-line-number="1515"></td>
+        <td id="LC1515" class="blob-code blob-code-inner js-file-line"><span class="pl-s">                    is for a &quot;directory&quot; on the website endpoint</span></td>
+      </tr>
+      <tr>
+        <td id="L1516" class="blob-num js-line-number" data-line-number="1516"></td>
+        <td id="LC1516" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1517" class="blob-num js-line-number" data-line-number="1517"></td>
+        <td id="LC1517" class="blob-code blob-code-inner js-file-line"><span class="pl-s">                  * ErrorDocument</span></td>
+      </tr>
+      <tr>
+        <td id="L1518" class="blob-num js-line-number" data-line-number="1518"></td>
+        <td id="LC1518" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1519" class="blob-num js-line-number" data-line-number="1519"></td>
+        <td id="LC1519" class="blob-code blob-code-inner js-file-line"><span class="pl-s">                    * Key : name of object to serve when an error occurs</span></td>
+      </tr>
+      <tr>
+        <td id="L1520" class="blob-num js-line-number" data-line-number="1520"></td>
+        <td id="LC1520" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1521" class="blob-num js-line-number" data-line-number="1521"></td>
+        <td id="LC1521" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1522" class="blob-num js-line-number" data-line-number="1522"></td>
+        <td id="LC1522" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            2) unparsed XML describing the bucket&#39;s website configuration</span></td>
+      </tr>
+      <tr>
+        <td id="L1523" class="blob-num js-line-number" data-line-number="1523"></td>
+        <td id="LC1523" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1524" class="blob-num js-line-number" data-line-number="1524"></td>
+        <td id="LC1524" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1525" class="blob-num js-line-number" data-line-number="1525"></td>
+        <td id="LC1525" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1526" class="blob-num js-line-number" data-line-number="1526"></td>
+        <td id="LC1526" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_website_configuration_xml(<span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1527" class="blob-num js-line-number" data-line-number="1527"></td>
+        <td id="LC1527" class="blob-code blob-code-inner js-file-line">        e <span class="pl-k">=</span> boto.jsonresponse.Element()</td>
+      </tr>
+      <tr>
+        <td id="L1528" class="blob-num js-line-number" data-line-number="1528"></td>
+        <td id="LC1528" class="blob-code blob-code-inner js-file-line">        h <span class="pl-k">=</span> boto.jsonresponse.XmlHandler(e, <span class="pl-c1">None</span>)</td>
+      </tr>
+      <tr>
+        <td id="L1529" class="blob-num js-line-number" data-line-number="1529"></td>
+        <td id="LC1529" class="blob-code blob-code-inner js-file-line">        h.parse(body)</td>
+      </tr>
+      <tr>
+        <td id="L1530" class="blob-num js-line-number" data-line-number="1530"></td>
+        <td id="LC1530" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> e, body</td>
+      </tr>
+      <tr>
+        <td id="L1531" class="blob-num js-line-number" data-line-number="1531"></td>
+        <td id="LC1531" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1532" class="blob-num js-line-number" data-line-number="1532"></td>
+        <td id="LC1532" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_website_configuration_xml</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1533" class="blob-num js-line-number" data-line-number="1533"></td>
+        <td id="LC1533" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span>Get raw website configuration xml<span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1534" class="blob-num js-line-number" data-line-number="1534"></td>
+        <td id="LC1534" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1535" class="blob-num js-line-number" data-line-number="1535"></td>
+        <td id="LC1535" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>website<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1536" class="blob-num js-line-number" data-line-number="1536"></td>
+        <td id="LC1536" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read().decode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L1537" class="blob-num js-line-number" data-line-number="1537"></td>
+        <td id="LC1537" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
+      </tr>
+      <tr>
+        <td id="L1538" class="blob-num js-line-number" data-line-number="1538"></td>
+        <td id="LC1538" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1539" class="blob-num js-line-number" data-line-number="1539"></td>
+        <td id="LC1539" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1540" class="blob-num js-line-number" data-line-number="1540"></td>
+        <td id="LC1540" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1541" class="blob-num js-line-number" data-line-number="1541"></td>
+        <td id="LC1541" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1542" class="blob-num js-line-number" data-line-number="1542"></td>
+        <td id="LC1542" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> body</td>
+      </tr>
+      <tr>
+        <td id="L1543" class="blob-num js-line-number" data-line-number="1543"></td>
+        <td id="LC1543" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1544" class="blob-num js-line-number" data-line-number="1544"></td>
+        <td id="LC1544" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete_website_configuration</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1545" class="blob-num js-line-number" data-line-number="1545"></td>
+        <td id="LC1545" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1546" class="blob-num js-line-number" data-line-number="1546"></td>
+        <td id="LC1546" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Removes all website configuration from the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1547" class="blob-num js-line-number" data-line-number="1547"></td>
+        <td id="LC1547" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1548" class="blob-num js-line-number" data-line-number="1548"></td>
+        <td id="LC1548" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>DELETE<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1549" class="blob-num js-line-number" data-line-number="1549"></td>
+        <td id="LC1549" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>website<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1550" class="blob-num js-line-number" data-line-number="1550"></td>
+        <td id="LC1550" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1551" class="blob-num js-line-number" data-line-number="1551"></td>
+        <td id="LC1551" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
+      </tr>
+      <tr>
+        <td id="L1552" class="blob-num js-line-number" data-line-number="1552"></td>
+        <td id="LC1552" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">204</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1553" class="blob-num js-line-number" data-line-number="1553"></td>
+        <td id="LC1553" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
+      </tr>
+      <tr>
+        <td id="L1554" class="blob-num js-line-number" data-line-number="1554"></td>
+        <td id="LC1554" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1555" class="blob-num js-line-number" data-line-number="1555"></td>
+        <td id="LC1555" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1556" class="blob-num js-line-number" data-line-number="1556"></td>
+        <td id="LC1556" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1557" class="blob-num js-line-number" data-line-number="1557"></td>
+        <td id="LC1557" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1558" class="blob-num js-line-number" data-line-number="1558"></td>
+        <td id="LC1558" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_website_endpoint</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>):</td>
+      </tr>
+      <tr>
+        <td id="L1559" class="blob-num js-line-number" data-line-number="1559"></td>
+        <td id="LC1559" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1560" class="blob-num js-line-number" data-line-number="1560"></td>
+        <td id="LC1560" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the fully qualified hostname to use is you want to access this</span></td>
+      </tr>
+      <tr>
+        <td id="L1561" class="blob-num js-line-number" data-line-number="1561"></td>
+        <td id="LC1561" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        bucket as a website.  This doesn&#39;t validate whether the bucket has</span></td>
+      </tr>
+      <tr>
+        <td id="L1562" class="blob-num js-line-number" data-line-number="1562"></td>
+        <td id="LC1562" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        been correctly configured as a website or not.</span></td>
+      </tr>
+      <tr>
+        <td id="L1563" class="blob-num js-line-number" data-line-number="1563"></td>
+        <td id="LC1563" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1564" class="blob-num js-line-number" data-line-number="1564"></td>
+        <td id="LC1564" class="blob-code blob-code-inner js-file-line">        l <span class="pl-k">=</span> [<span class="pl-c1">self</span>.name]</td>
+      </tr>
+      <tr>
+        <td id="L1565" class="blob-num js-line-number" data-line-number="1565"></td>
+        <td id="LC1565" class="blob-code blob-code-inner js-file-line">        l.append(S3WebsiteEndpointTranslate.translate_region(<span class="pl-c1">self</span>.get_location()))</td>
+      </tr>
+      <tr>
+        <td id="L1566" class="blob-num js-line-number" data-line-number="1566"></td>
+        <td id="LC1566" class="blob-code blob-code-inner js-file-line">        l.append(<span class="pl-s"><span class="pl-pds">&#39;</span>.<span class="pl-pds">&#39;</span></span>.join(<span class="pl-c1">self</span>.connection.host.split(<span class="pl-s"><span class="pl-pds">&#39;</span>.<span class="pl-pds">&#39;</span></span>)[<span class="pl-k">-</span><span class="pl-c1">2</span>:]))</td>
+      </tr>
+      <tr>
+        <td id="L1567" class="blob-num js-line-number" data-line-number="1567"></td>
+        <td id="LC1567" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-s"><span class="pl-pds">&#39;</span>.<span class="pl-pds">&#39;</span></span>.join(l)</td>
+      </tr>
+      <tr>
+        <td id="L1568" class="blob-num js-line-number" data-line-number="1568"></td>
+        <td id="LC1568" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1569" class="blob-num js-line-number" data-line-number="1569"></td>
+        <td id="LC1569" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_policy</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1570" class="blob-num js-line-number" data-line-number="1570"></td>
+        <td id="LC1570" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1571" class="blob-num js-line-number" data-line-number="1571"></td>
+        <td id="LC1571" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the JSON policy associated with the bucket.  The policy</span></td>
+      </tr>
+      <tr>
+        <td id="L1572" class="blob-num js-line-number" data-line-number="1572"></td>
+        <td id="LC1572" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        is returned as an uninterpreted JSON string.</span></td>
+      </tr>
+      <tr>
+        <td id="L1573" class="blob-num js-line-number" data-line-number="1573"></td>
+        <td id="LC1573" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1574" class="blob-num js-line-number" data-line-number="1574"></td>
+        <td id="LC1574" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1575" class="blob-num js-line-number" data-line-number="1575"></td>
+        <td id="LC1575" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>policy<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1576" class="blob-num js-line-number" data-line-number="1576"></td>
+        <td id="LC1576" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1577" class="blob-num js-line-number" data-line-number="1577"></td>
+        <td id="LC1577" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1578" class="blob-num js-line-number" data-line-number="1578"></td>
+        <td id="LC1578" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> body</td>
+      </tr>
+      <tr>
+        <td id="L1579" class="blob-num js-line-number" data-line-number="1579"></td>
+        <td id="LC1579" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1580" class="blob-num js-line-number" data-line-number="1580"></td>
+        <td id="LC1580" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1581" class="blob-num js-line-number" data-line-number="1581"></td>
+        <td id="LC1581" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1582" class="blob-num js-line-number" data-line-number="1582"></td>
+        <td id="LC1582" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1583" class="blob-num js-line-number" data-line-number="1583"></td>
+        <td id="LC1583" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_policy</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">policy</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1584" class="blob-num js-line-number" data-line-number="1584"></td>
+        <td id="LC1584" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1585" class="blob-num js-line-number" data-line-number="1585"></td>
+        <td id="LC1585" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Add or replace the JSON policy associated with the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1586" class="blob-num js-line-number" data-line-number="1586"></td>
+        <td id="LC1586" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1587" class="blob-num js-line-number" data-line-number="1587"></td>
+        <td id="LC1587" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type policy: str</span></td>
+      </tr>
+      <tr>
+        <td id="L1588" class="blob-num js-line-number" data-line-number="1588"></td>
+        <td id="LC1588" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param policy: The JSON policy as a string.</span></td>
+      </tr>
+      <tr>
+        <td id="L1589" class="blob-num js-line-number" data-line-number="1589"></td>
+        <td id="LC1589" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1590" class="blob-num js-line-number" data-line-number="1590"></td>
+        <td id="LC1590" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1591" class="blob-num js-line-number" data-line-number="1591"></td>
+        <td id="LC1591" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">data</span><span class="pl-k">=</span>policy,</td>
+      </tr>
+      <tr>
+        <td id="L1592" class="blob-num js-line-number" data-line-number="1592"></td>
+        <td id="LC1592" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>policy<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L1593" class="blob-num js-line-number" data-line-number="1593"></td>
+        <td id="LC1593" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1594" class="blob-num js-line-number" data-line-number="1594"></td>
+        <td id="LC1594" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1595" class="blob-num js-line-number" data-line-number="1595"></td>
+        <td id="LC1595" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">&gt;=</span> <span class="pl-c1">200</span> <span class="pl-k">and</span> response.status <span class="pl-k">&lt;=</span> <span class="pl-c1">204</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1596" class="blob-num js-line-number" data-line-number="1596"></td>
+        <td id="LC1596" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
+      </tr>
+      <tr>
+        <td id="L1597" class="blob-num js-line-number" data-line-number="1597"></td>
+        <td id="LC1597" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1598" class="blob-num js-line-number" data-line-number="1598"></td>
+        <td id="LC1598" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1599" class="blob-num js-line-number" data-line-number="1599"></td>
+        <td id="LC1599" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1600" class="blob-num js-line-number" data-line-number="1600"></td>
+        <td id="LC1600" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1601" class="blob-num js-line-number" data-line-number="1601"></td>
+        <td id="LC1601" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete_policy</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1602" class="blob-num js-line-number" data-line-number="1602"></td>
+        <td id="LC1602" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>DELETE<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1603" class="blob-num js-line-number" data-line-number="1603"></td>
+        <td id="LC1603" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">data</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>/?policy<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L1604" class="blob-num js-line-number" data-line-number="1604"></td>
+        <td id="LC1604" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>policy<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L1605" class="blob-num js-line-number" data-line-number="1605"></td>
+        <td id="LC1605" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1606" class="blob-num js-line-number" data-line-number="1606"></td>
+        <td id="LC1606" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1607" class="blob-num js-line-number" data-line-number="1607"></td>
+        <td id="LC1607" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">&gt;=</span> <span class="pl-c1">200</span> <span class="pl-k">and</span> response.status <span class="pl-k">&lt;=</span> <span class="pl-c1">204</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1608" class="blob-num js-line-number" data-line-number="1608"></td>
+        <td id="LC1608" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
+      </tr>
+      <tr>
+        <td id="L1609" class="blob-num js-line-number" data-line-number="1609"></td>
+        <td id="LC1609" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1610" class="blob-num js-line-number" data-line-number="1610"></td>
+        <td id="LC1610" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1611" class="blob-num js-line-number" data-line-number="1611"></td>
+        <td id="LC1611" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1612" class="blob-num js-line-number" data-line-number="1612"></td>
+        <td id="LC1612" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1613" class="blob-num js-line-number" data-line-number="1613"></td>
+        <td id="LC1613" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_cors_xml</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">cors_xml</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1614" class="blob-num js-line-number" data-line-number="1614"></td>
+        <td id="LC1614" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1615" class="blob-num js-line-number" data-line-number="1615"></td>
+        <td id="LC1615" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Set the CORS (Cross-Origin Resource Sharing) for a bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1616" class="blob-num js-line-number" data-line-number="1616"></td>
+        <td id="LC1616" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1617" class="blob-num js-line-number" data-line-number="1617"></td>
+        <td id="LC1617" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type cors_xml: str</span></td>
+      </tr>
+      <tr>
+        <td id="L1618" class="blob-num js-line-number" data-line-number="1618"></td>
+        <td id="LC1618" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param cors_xml: The XML document describing your desired</span></td>
+      </tr>
+      <tr>
+        <td id="L1619" class="blob-num js-line-number" data-line-number="1619"></td>
+        <td id="LC1619" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            CORS configuration.  See the S3 documentation for details</span></td>
+      </tr>
+      <tr>
+        <td id="L1620" class="blob-num js-line-number" data-line-number="1620"></td>
+        <td id="LC1620" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            of the exact syntax required.</span></td>
+      </tr>
+      <tr>
+        <td id="L1621" class="blob-num js-line-number" data-line-number="1621"></td>
+        <td id="LC1621" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1622" class="blob-num js-line-number" data-line-number="1622"></td>
+        <td id="LC1622" class="blob-code blob-code-inner js-file-line">        fp <span class="pl-k">=</span> StringIO(cors_xml)</td>
+      </tr>
+      <tr>
+        <td id="L1623" class="blob-num js-line-number" data-line-number="1623"></td>
+        <td id="LC1623" class="blob-code blob-code-inner js-file-line">        md5 <span class="pl-k">=</span> boto.utils.compute_md5(fp)</td>
+      </tr>
+      <tr>
+        <td id="L1624" class="blob-num js-line-number" data-line-number="1624"></td>
+        <td id="LC1624" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> headers <span class="pl-k">is</span> <span class="pl-c1">None</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1625" class="blob-num js-line-number" data-line-number="1625"></td>
+        <td id="LC1625" class="blob-code blob-code-inner js-file-line">            headers <span class="pl-k">=</span> {}</td>
+      </tr>
+      <tr>
+        <td id="L1626" class="blob-num js-line-number" data-line-number="1626"></td>
+        <td id="LC1626" class="blob-code blob-code-inner js-file-line">        headers[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-MD5<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> md5[<span class="pl-c1">1</span>]</td>
+      </tr>
+      <tr>
+        <td id="L1627" class="blob-num js-line-number" data-line-number="1627"></td>
+        <td id="LC1627" class="blob-code blob-code-inner js-file-line">        headers[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-Type<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>text/xml<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1628" class="blob-num js-line-number" data-line-number="1628"></td>
+        <td id="LC1628" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1629" class="blob-num js-line-number" data-line-number="1629"></td>
+        <td id="LC1629" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">data</span><span class="pl-k">=</span>fp.getvalue(),</td>
+      </tr>
+      <tr>
+        <td id="L1630" class="blob-num js-line-number" data-line-number="1630"></td>
+        <td id="LC1630" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>cors<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L1631" class="blob-num js-line-number" data-line-number="1631"></td>
+        <td id="LC1631" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1632" class="blob-num js-line-number" data-line-number="1632"></td>
+        <td id="LC1632" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1633" class="blob-num js-line-number" data-line-number="1633"></td>
+        <td id="LC1633" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1634" class="blob-num js-line-number" data-line-number="1634"></td>
+        <td id="LC1634" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
+      </tr>
+      <tr>
+        <td id="L1635" class="blob-num js-line-number" data-line-number="1635"></td>
+        <td id="LC1635" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1636" class="blob-num js-line-number" data-line-number="1636"></td>
+        <td id="LC1636" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1637" class="blob-num js-line-number" data-line-number="1637"></td>
+        <td id="LC1637" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1638" class="blob-num js-line-number" data-line-number="1638"></td>
+        <td id="LC1638" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1639" class="blob-num js-line-number" data-line-number="1639"></td>
+        <td id="LC1639" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_cors</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">cors_config</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1640" class="blob-num js-line-number" data-line-number="1640"></td>
+        <td id="LC1640" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1641" class="blob-num js-line-number" data-line-number="1641"></td>
+        <td id="LC1641" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Set the CORS for this bucket given a boto CORSConfiguration</span></td>
+      </tr>
+      <tr>
+        <td id="L1642" class="blob-num js-line-number" data-line-number="1642"></td>
+        <td id="LC1642" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        object.</span></td>
+      </tr>
+      <tr>
+        <td id="L1643" class="blob-num js-line-number" data-line-number="1643"></td>
+        <td id="LC1643" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1644" class="blob-num js-line-number" data-line-number="1644"></td>
+        <td id="LC1644" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type cors_config: :class:`boto.s3.cors.CORSConfiguration`</span></td>
+      </tr>
+      <tr>
+        <td id="L1645" class="blob-num js-line-number" data-line-number="1645"></td>
+        <td id="LC1645" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param cors_config: The CORS configuration you want</span></td>
+      </tr>
+      <tr>
+        <td id="L1646" class="blob-num js-line-number" data-line-number="1646"></td>
+        <td id="LC1646" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            to configure for this bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1647" class="blob-num js-line-number" data-line-number="1647"></td>
+        <td id="LC1647" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1648" class="blob-num js-line-number" data-line-number="1648"></td>
+        <td id="LC1648" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.set_cors_xml(cors_config.to_xml())</td>
+      </tr>
+      <tr>
+        <td id="L1649" class="blob-num js-line-number" data-line-number="1649"></td>
+        <td id="LC1649" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1650" class="blob-num js-line-number" data-line-number="1650"></td>
+        <td id="LC1650" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_cors_xml</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1651" class="blob-num js-line-number" data-line-number="1651"></td>
+        <td id="LC1651" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1652" class="blob-num js-line-number" data-line-number="1652"></td>
+        <td id="LC1652" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the current CORS configuration on the bucket as an</span></td>
+      </tr>
+      <tr>
+        <td id="L1653" class="blob-num js-line-number" data-line-number="1653"></td>
+        <td id="LC1653" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        XML document.</span></td>
+      </tr>
+      <tr>
+        <td id="L1654" class="blob-num js-line-number" data-line-number="1654"></td>
+        <td id="LC1654" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1655" class="blob-num js-line-number" data-line-number="1655"></td>
+        <td id="LC1655" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1656" class="blob-num js-line-number" data-line-number="1656"></td>
+        <td id="LC1656" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>cors<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1657" class="blob-num js-line-number" data-line-number="1657"></td>
+        <td id="LC1657" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1658" class="blob-num js-line-number" data-line-number="1658"></td>
+        <td id="LC1658" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
+      </tr>
+      <tr>
+        <td id="L1659" class="blob-num js-line-number" data-line-number="1659"></td>
+        <td id="LC1659" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1660" class="blob-num js-line-number" data-line-number="1660"></td>
+        <td id="LC1660" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> body</td>
+      </tr>
+      <tr>
+        <td id="L1661" class="blob-num js-line-number" data-line-number="1661"></td>
+        <td id="LC1661" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1662" class="blob-num js-line-number" data-line-number="1662"></td>
+        <td id="LC1662" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1663" class="blob-num js-line-number" data-line-number="1663"></td>
+        <td id="LC1663" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1664" class="blob-num js-line-number" data-line-number="1664"></td>
+        <td id="LC1664" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1665" class="blob-num js-line-number" data-line-number="1665"></td>
+        <td id="LC1665" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_cors</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1666" class="blob-num js-line-number" data-line-number="1666"></td>
+        <td id="LC1666" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1667" class="blob-num js-line-number" data-line-number="1667"></td>
+        <td id="LC1667" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the current CORS configuration on the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1668" class="blob-num js-line-number" data-line-number="1668"></td>
+        <td id="LC1668" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1669" class="blob-num js-line-number" data-line-number="1669"></td>
+        <td id="LC1669" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.cors.CORSConfiguration`</span></td>
+      </tr>
+      <tr>
+        <td id="L1670" class="blob-num js-line-number" data-line-number="1670"></td>
+        <td id="LC1670" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: A CORSConfiguration object that describes all current</span></td>
+      </tr>
+      <tr>
+        <td id="L1671" class="blob-num js-line-number" data-line-number="1671"></td>
+        <td id="LC1671" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            CORS rules in effect for the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1672" class="blob-num js-line-number" data-line-number="1672"></td>
+        <td id="LC1672" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1673" class="blob-num js-line-number" data-line-number="1673"></td>
+        <td id="LC1673" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_cors_xml(headers)</td>
+      </tr>
+      <tr>
+        <td id="L1674" class="blob-num js-line-number" data-line-number="1674"></td>
+        <td id="LC1674" class="blob-code blob-code-inner js-file-line">        cors <span class="pl-k">=</span> CORSConfiguration()</td>
+      </tr>
+      <tr>
+        <td id="L1675" class="blob-num js-line-number" data-line-number="1675"></td>
+        <td id="LC1675" class="blob-code blob-code-inner js-file-line">        h <span class="pl-k">=</span> handler.XmlHandler(cors, <span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L1676" class="blob-num js-line-number" data-line-number="1676"></td>
+        <td id="LC1676" class="blob-code blob-code-inner js-file-line">        xml.sax.parseString(body, h)</td>
+      </tr>
+      <tr>
+        <td id="L1677" class="blob-num js-line-number" data-line-number="1677"></td>
+        <td id="LC1677" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> cors</td>
+      </tr>
+      <tr>
+        <td id="L1678" class="blob-num js-line-number" data-line-number="1678"></td>
+        <td id="LC1678" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1679" class="blob-num js-line-number" data-line-number="1679"></td>
+        <td id="LC1679" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete_cors</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1680" class="blob-num js-line-number" data-line-number="1680"></td>
+        <td id="LC1680" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1681" class="blob-num js-line-number" data-line-number="1681"></td>
+        <td id="LC1681" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Removes all CORS configuration from the bucket.</span></td>
+      </tr>
+      <tr>
+        <td id="L1682" class="blob-num js-line-number" data-line-number="1682"></td>
+        <td id="LC1682" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1683" class="blob-num js-line-number" data-line-number="1683"></td>
+        <td id="LC1683" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>DELETE<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1684" class="blob-num js-line-number" data-line-number="1684"></td>
+        <td id="LC1684" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>cors<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L1685" class="blob-num js-line-number" data-line-number="1685"></td>
+        <td id="LC1685" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1686" class="blob-num js-line-number" data-line-number="1686"></td>
+        <td id="LC1686" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1687" class="blob-num js-line-number" data-line-number="1687"></td>
+        <td id="LC1687" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
+      </tr>
+      <tr>
+        <td id="L1688" class="blob-num js-line-number" data-line-number="1688"></td>
+        <td id="LC1688" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">204</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1689" class="blob-num js-line-number" data-line-number="1689"></td>
+        <td id="LC1689" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
+      </tr>
+      <tr>
+        <td id="L1690" class="blob-num js-line-number" data-line-number="1690"></td>
+        <td id="LC1690" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1691" class="blob-num js-line-number" data-line-number="1691"></td>
+        <td id="LC1691" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1692" class="blob-num js-line-number" data-line-number="1692"></td>
+        <td id="LC1692" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1693" class="blob-num js-line-number" data-line-number="1693"></td>
+        <td id="LC1693" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1694" class="blob-num js-line-number" data-line-number="1694"></td>
+        <td id="LC1694" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">initiate_multipart_upload</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
+      </tr>
+      <tr>
+        <td id="L1695" class="blob-num js-line-number" data-line-number="1695"></td>
+        <td id="LC1695" class="blob-code blob-code-inner js-file-line">                                  <span class="pl-smi">reduced_redundancy</span><span class="pl-k">=</span><span class="pl-c1">False</span>,</td>
+      </tr>
+      <tr>
+        <td id="L1696" class="blob-num js-line-number" data-line-number="1696"></td>
+        <td id="LC1696" class="blob-code blob-code-inner js-file-line">                                  <span class="pl-smi">metadata</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">encrypt_key</span><span class="pl-k">=</span><span class="pl-c1">False</span>,</td>
+      </tr>
+      <tr>
+        <td id="L1697" class="blob-num js-line-number" data-line-number="1697"></td>
+        <td id="LC1697" class="blob-code blob-code-inner js-file-line">                                  <span class="pl-smi">policy</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1698" class="blob-num js-line-number" data-line-number="1698"></td>
+        <td id="LC1698" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1699" class="blob-num js-line-number" data-line-number="1699"></td>
+        <td id="LC1699" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Start a multipart upload operation.</span></td>
+      </tr>
+      <tr>
+        <td id="L1700" class="blob-num js-line-number" data-line-number="1700"></td>
+        <td id="LC1700" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1701" class="blob-num js-line-number" data-line-number="1701"></td>
+        <td id="LC1701" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        .. note::</span></td>
+      </tr>
+      <tr>
+        <td id="L1702" class="blob-num js-line-number" data-line-number="1702"></td>
+        <td id="LC1702" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1703" class="blob-num js-line-number" data-line-number="1703"></td>
+        <td id="LC1703" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Note: After you initiate multipart upload and upload one or more</span></td>
+      </tr>
+      <tr>
+        <td id="L1704" class="blob-num js-line-number" data-line-number="1704"></td>
+        <td id="LC1704" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parts, you must either complete or abort multipart upload in order</span></td>
+      </tr>
+      <tr>
+        <td id="L1705" class="blob-num js-line-number" data-line-number="1705"></td>
+        <td id="LC1705" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            to stop getting charged for storage of the uploaded parts. Only</span></td>
+      </tr>
+      <tr>
+        <td id="L1706" class="blob-num js-line-number" data-line-number="1706"></td>
+        <td id="LC1706" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            after you either complete or abort multipart upload, Amazon S3</span></td>
+      </tr>
+      <tr>
+        <td id="L1707" class="blob-num js-line-number" data-line-number="1707"></td>
+        <td id="LC1707" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            frees up the parts storage and stops charging you for the parts</span></td>
+      </tr>
+      <tr>
+        <td id="L1708" class="blob-num js-line-number" data-line-number="1708"></td>
+        <td id="LC1708" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            storage.</span></td>
+      </tr>
+      <tr>
+        <td id="L1709" class="blob-num js-line-number" data-line-number="1709"></td>
+        <td id="LC1709" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1710" class="blob-num js-line-number" data-line-number="1710"></td>
+        <td id="LC1710" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_name: string</span></td>
+      </tr>
+      <tr>
+        <td id="L1711" class="blob-num js-line-number" data-line-number="1711"></td>
+        <td id="LC1711" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_name: The name of the key that will ultimately</span></td>
+      </tr>
+      <tr>
+        <td id="L1712" class="blob-num js-line-number" data-line-number="1712"></td>
+        <td id="LC1712" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            result from this multipart upload operation.  This will be</span></td>
+      </tr>
+      <tr>
+        <td id="L1713" class="blob-num js-line-number" data-line-number="1713"></td>
+        <td id="LC1713" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            exactly as the key appears in the bucket after the upload</span></td>
+      </tr>
+      <tr>
+        <td id="L1714" class="blob-num js-line-number" data-line-number="1714"></td>
+        <td id="LC1714" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            process has been completed.</span></td>
+      </tr>
+      <tr>
+        <td id="L1715" class="blob-num js-line-number" data-line-number="1715"></td>
+        <td id="LC1715" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1716" class="blob-num js-line-number" data-line-number="1716"></td>
+        <td id="LC1716" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type headers: dict</span></td>
+      </tr>
+      <tr>
+        <td id="L1717" class="blob-num js-line-number" data-line-number="1717"></td>
+        <td id="LC1717" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param headers: Additional HTTP headers to send and store with the</span></td>
+      </tr>
+      <tr>
+        <td id="L1718" class="blob-num js-line-number" data-line-number="1718"></td>
+        <td id="LC1718" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            resulting key in S3.</span></td>
+      </tr>
+      <tr>
+        <td id="L1719" class="blob-num js-line-number" data-line-number="1719"></td>
+        <td id="LC1719" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1720" class="blob-num js-line-number" data-line-number="1720"></td>
+        <td id="LC1720" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type reduced_redundancy: boolean</span></td>
+      </tr>
+      <tr>
+        <td id="L1721" class="blob-num js-line-number" data-line-number="1721"></td>
+        <td id="LC1721" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param reduced_redundancy: In multipart uploads, the storage</span></td>
+      </tr>
+      <tr>
+        <td id="L1722" class="blob-num js-line-number" data-line-number="1722"></td>
+        <td id="LC1722" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            class is specified when initiating the upload, not when</span></td>
+      </tr>
+      <tr>
+        <td id="L1723" class="blob-num js-line-number" data-line-number="1723"></td>
+        <td id="LC1723" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            uploading individual parts.  So if you want the resulting</span></td>
+      </tr>
+      <tr>
+        <td id="L1724" class="blob-num js-line-number" data-line-number="1724"></td>
+        <td id="LC1724" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            key to use the reduced redundancy storage class set this</span></td>
+      </tr>
+      <tr>
+        <td id="L1725" class="blob-num js-line-number" data-line-number="1725"></td>
+        <td id="LC1725" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            flag when you initiate the upload.</span></td>
+      </tr>
+      <tr>
+        <td id="L1726" class="blob-num js-line-number" data-line-number="1726"></td>
+        <td id="LC1726" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1727" class="blob-num js-line-number" data-line-number="1727"></td>
+        <td id="LC1727" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type metadata: dict</span></td>
+      </tr>
+      <tr>
+        <td id="L1728" class="blob-num js-line-number" data-line-number="1728"></td>
+        <td id="LC1728" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param metadata: Any metadata that you would like to set on the key</span></td>
+      </tr>
+      <tr>
+        <td id="L1729" class="blob-num js-line-number" data-line-number="1729"></td>
+        <td id="LC1729" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            that results from the multipart upload.</span></td>
+      </tr>
+      <tr>
+        <td id="L1730" class="blob-num js-line-number" data-line-number="1730"></td>
+        <td id="LC1730" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1731" class="blob-num js-line-number" data-line-number="1731"></td>
+        <td id="LC1731" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encrypt_key: bool</span></td>
+      </tr>
+      <tr>
+        <td id="L1732" class="blob-num js-line-number" data-line-number="1732"></td>
+        <td id="LC1732" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encrypt_key: If True, the new copy of the object will</span></td>
+      </tr>
+      <tr>
+        <td id="L1733" class="blob-num js-line-number" data-line-number="1733"></td>
+        <td id="LC1733" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            be encrypted on the server-side by S3 and will be stored</span></td>
+      </tr>
+      <tr>
+        <td id="L1734" class="blob-num js-line-number" data-line-number="1734"></td>
+        <td id="LC1734" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            in an encrypted form while at rest in S3.</span></td>
+      </tr>
+      <tr>
+        <td id="L1735" class="blob-num js-line-number" data-line-number="1735"></td>
+        <td id="LC1735" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
+      </tr>
+      <tr>
+        <td id="L1736" class="blob-num js-line-number" data-line-number="1736"></td>
+        <td id="LC1736" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type policy: :class:`boto.s3.acl.CannedACLStrings`</span></td>
+      </tr>
+      <tr>
+        <td id="L1737" class="blob-num js-line-number" data-line-number="1737"></td>
+        <td id="LC1737" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param policy: A canned ACL policy that will be applied to the</span></td>
+      </tr>
+      <tr>
+        <td id="L1738" class="blob-num js-line-number" data-line-number="1738"></td>
+        <td id="LC1738" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            new key (once completed) in S3.</span></td>
+      </tr>
+      <tr>
+        <td id="L1739" class="blob-num js-line-number" data-line-number="1739"></td>
+        <td id="LC1739" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1740" class="blob-num js-line-number" data-line-number="1740"></td>
+        <td id="LC1740" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>uploads<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1741" class="blob-num js-line-number" data-line-number="1741"></td>
+        <td id="LC1741" class="blob-code blob-code-inner js-file-line">        provider <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.provider</td>
+      </tr>
+      <tr>
+        <td id="L1742" class="blob-num js-line-number" data-line-number="1742"></td>
+        <td id="LC1742" class="blob-code blob-code-inner js-file-line">        headers <span class="pl-k">=</span> headers <span class="pl-k">or</span> {}</td>
+      </tr>
+      <tr>
+        <td id="L1743" class="blob-num js-line-number" data-line-number="1743"></td>
+        <td id="LC1743" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> policy:</td>
+      </tr>
+      <tr>
+        <td id="L1744" class="blob-num js-line-number" data-line-number="1744"></td>
+        <td id="LC1744" class="blob-code blob-code-inner js-file-line">            headers[provider.acl_header] <span class="pl-k">=</span> policy</td>
+      </tr>
+      <tr>
+        <td id="L1745" class="blob-num js-line-number" data-line-number="1745"></td>
+        <td id="LC1745" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> reduced_redundancy:</td>
+      </tr>
+      <tr>
+        <td id="L1746" class="blob-num js-line-number" data-line-number="1746"></td>
+        <td id="LC1746" class="blob-code blob-code-inner js-file-line">            storage_class_header <span class="pl-k">=</span> provider.storage_class_header</td>
+      </tr>
+      <tr>
+        <td id="L1747" class="blob-num js-line-number" data-line-number="1747"></td>
+        <td id="LC1747" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> storage_class_header:</td>
+      </tr>
+      <tr>
+        <td id="L1748" class="blob-num js-line-number" data-line-number="1748"></td>
+        <td id="LC1748" class="blob-code blob-code-inner js-file-line">                headers[storage_class_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>REDUCED_REDUNDANCY<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1749" class="blob-num js-line-number" data-line-number="1749"></td>
+        <td id="LC1749" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> <span class="pl-k">TODO</span>: what if the provider doesn&#39;t support reduced redundancy?</span></td>
+      </tr>
+      <tr>
+        <td id="L1750" class="blob-num js-line-number" data-line-number="1750"></td>
+        <td id="LC1750" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> (see boto.s3.key.Key.set_contents_from_file)</span></td>
+      </tr>
+      <tr>
+        <td id="L1751" class="blob-num js-line-number" data-line-number="1751"></td>
+        <td id="LC1751" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> encrypt_key:</td>
+      </tr>
+      <tr>
+        <td id="L1752" class="blob-num js-line-number" data-line-number="1752"></td>
+        <td id="LC1752" class="blob-code blob-code-inner js-file-line">            headers[provider.server_side_encryption_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>AES256<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1753" class="blob-num js-line-number" data-line-number="1753"></td>
+        <td id="LC1753" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> metadata <span class="pl-k">is</span> <span class="pl-c1">None</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1754" class="blob-num js-line-number" data-line-number="1754"></td>
+        <td id="LC1754" class="blob-code blob-code-inner js-file-line">            metadata <span class="pl-k">=</span> {}</td>
+      </tr>
+      <tr>
+        <td id="L1755" class="blob-num js-line-number" data-line-number="1755"></td>
+        <td id="LC1755" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1756" class="blob-num js-line-number" data-line-number="1756"></td>
+        <td id="LC1756" class="blob-code blob-code-inner js-file-line">        headers <span class="pl-k">=</span> boto.utils.merge_meta(headers, metadata,</td>
+      </tr>
+      <tr>
+        <td id="L1757" class="blob-num js-line-number" data-line-number="1757"></td>
+        <td id="LC1757" class="blob-code blob-code-inner js-file-line">                <span class="pl-c1">self</span>.connection.provider)</td>
+      </tr>
+      <tr>
+        <td id="L1758" class="blob-num js-line-number" data-line-number="1758"></td>
+        <td id="LC1758" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>POST<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
+      </tr>
+      <tr>
+        <td id="L1759" class="blob-num js-line-number" data-line-number="1759"></td>
+        <td id="LC1759" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
+      </tr>
+      <tr>
+        <td id="L1760" class="blob-num js-line-number" data-line-number="1760"></td>
+        <td id="LC1760" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1761" class="blob-num js-line-number" data-line-number="1761"></td>
+        <td id="LC1761" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1762" class="blob-num js-line-number" data-line-number="1762"></td>
+        <td id="LC1762" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
+      </tr>
+      <tr>
+        <td id="L1763" class="blob-num js-line-number" data-line-number="1763"></td>
+        <td id="LC1763" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1764" class="blob-num js-line-number" data-line-number="1764"></td>
+        <td id="LC1764" class="blob-code blob-code-inner js-file-line">            resp <span class="pl-k">=</span> MultiPartUpload(<span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L1765" class="blob-num js-line-number" data-line-number="1765"></td>
+        <td id="LC1765" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(resp, <span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L1766" class="blob-num js-line-number" data-line-number="1766"></td>
+        <td id="LC1766" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1767" class="blob-num js-line-number" data-line-number="1767"></td>
+        <td id="LC1767" class="blob-code blob-code-inner js-file-line">                body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L1768" class="blob-num js-line-number" data-line-number="1768"></td>
+        <td id="LC1768" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
+      </tr>
+      <tr>
+        <td id="L1769" class="blob-num js-line-number" data-line-number="1769"></td>
+        <td id="LC1769" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> resp</td>
+      </tr>
+      <tr>
+        <td id="L1770" class="blob-num js-line-number" data-line-number="1770"></td>
+        <td id="LC1770" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1771" class="blob-num js-line-number" data-line-number="1771"></td>
+        <td id="LC1771" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1772" class="blob-num js-line-number" data-line-number="1772"></td>
+        <td id="LC1772" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1773" class="blob-num js-line-number" data-line-number="1773"></td>
+        <td id="LC1773" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1774" class="blob-num js-line-number" data-line-number="1774"></td>
+        <td id="LC1774" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">complete_multipart_upload</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">upload_id</span>,</td>
+      </tr>
+      <tr>
+        <td id="L1775" class="blob-num js-line-number" data-line-number="1775"></td>
+        <td id="LC1775" class="blob-code blob-code-inner js-file-line">                                  <span class="pl-smi">xml_body</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1776" class="blob-num js-line-number" data-line-number="1776"></td>
+        <td id="LC1776" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1777" class="blob-num js-line-number" data-line-number="1777"></td>
+        <td id="LC1777" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Complete a multipart upload operation.</span></td>
+      </tr>
+      <tr>
+        <td id="L1778" class="blob-num js-line-number" data-line-number="1778"></td>
+        <td id="LC1778" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1779" class="blob-num js-line-number" data-line-number="1779"></td>
+        <td id="LC1779" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>uploadId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> upload_id</td>
+      </tr>
+      <tr>
+        <td id="L1780" class="blob-num js-line-number" data-line-number="1780"></td>
+        <td id="LC1780" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> headers <span class="pl-k">is</span> <span class="pl-c1">None</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1781" class="blob-num js-line-number" data-line-number="1781"></td>
+        <td id="LC1781" class="blob-code blob-code-inner js-file-line">            headers <span class="pl-k">=</span> {}</td>
+      </tr>
+      <tr>
+        <td id="L1782" class="blob-num js-line-number" data-line-number="1782"></td>
+        <td id="LC1782" class="blob-code blob-code-inner js-file-line">        headers[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-Type<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>text/xml<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1783" class="blob-num js-line-number" data-line-number="1783"></td>
+        <td id="LC1783" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>POST<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
+      </tr>
+      <tr>
+        <td id="L1784" class="blob-num js-line-number" data-line-number="1784"></td>
+        <td id="LC1784" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
+      </tr>
+      <tr>
+        <td id="L1785" class="blob-num js-line-number" data-line-number="1785"></td>
+        <td id="LC1785" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers, <span class="pl-v">data</span><span class="pl-k">=</span>xml_body)</td>
+      </tr>
+      <tr>
+        <td id="L1786" class="blob-num js-line-number" data-line-number="1786"></td>
+        <td id="LC1786" class="blob-code blob-code-inner js-file-line">        contains_error <span class="pl-k">=</span> <span class="pl-c1">False</span></td>
+      </tr>
+      <tr>
+        <td id="L1787" class="blob-num js-line-number" data-line-number="1787"></td>
+        <td id="LC1787" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read().decode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L1788" class="blob-num js-line-number" data-line-number="1788"></td>
+        <td id="LC1788" class="blob-code blob-code-inner js-file-line">        <span class="pl-c"><span class="pl-c">#</span> Some errors will be reported in the body of the response</span></td>
+      </tr>
+      <tr>
+        <td id="L1789" class="blob-num js-line-number" data-line-number="1789"></td>
+        <td id="LC1789" class="blob-code blob-code-inner js-file-line">        <span class="pl-c"><span class="pl-c">#</span> even though the HTTP response code is 200.  This check</span></td>
+      </tr>
+      <tr>
+        <td id="L1790" class="blob-num js-line-number" data-line-number="1790"></td>
+        <td id="LC1790" class="blob-code blob-code-inner js-file-line">        <span class="pl-c"><span class="pl-c">#</span> does a quick and dirty peek in the body for an error element.</span></td>
+      </tr>
+      <tr>
+        <td id="L1791" class="blob-num js-line-number" data-line-number="1791"></td>
+        <td id="LC1791" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> body.find(<span class="pl-s"><span class="pl-pds">&#39;</span>&lt;Error&gt;<span class="pl-pds">&#39;</span></span>) <span class="pl-k">&gt;</span> <span class="pl-c1">0</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1792" class="blob-num js-line-number" data-line-number="1792"></td>
+        <td id="LC1792" class="blob-code blob-code-inner js-file-line">            contains_error <span class="pl-k">=</span> <span class="pl-c1">True</span></td>
+      </tr>
+      <tr>
+        <td id="L1793" class="blob-num js-line-number" data-line-number="1793"></td>
+        <td id="LC1793" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
+      </tr>
+      <tr>
+        <td id="L1794" class="blob-num js-line-number" data-line-number="1794"></td>
+        <td id="LC1794" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span> <span class="pl-k">and</span> <span class="pl-k">not</span> contains_error:</td>
+      </tr>
+      <tr>
+        <td id="L1795" class="blob-num js-line-number" data-line-number="1795"></td>
+        <td id="LC1795" class="blob-code blob-code-inner js-file-line">            resp <span class="pl-k">=</span> CompleteMultiPartUpload(<span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L1796" class="blob-num js-line-number" data-line-number="1796"></td>
+        <td id="LC1796" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(resp, <span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L1797" class="blob-num js-line-number" data-line-number="1797"></td>
+        <td id="LC1797" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1798" class="blob-num js-line-number" data-line-number="1798"></td>
+        <td id="LC1798" class="blob-code blob-code-inner js-file-line">                body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L1799" class="blob-num js-line-number" data-line-number="1799"></td>
+        <td id="LC1799" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
+      </tr>
+      <tr>
+        <td id="L1800" class="blob-num js-line-number" data-line-number="1800"></td>
+        <td id="LC1800" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> Use a dummy key to parse various response headers</span></td>
+      </tr>
+      <tr>
+        <td id="L1801" class="blob-num js-line-number" data-line-number="1801"></td>
+        <td id="LC1801" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> for versioning, encryption info and then explicitly</span></td>
+      </tr>
+      <tr>
+        <td id="L1802" class="blob-num js-line-number" data-line-number="1802"></td>
+        <td id="LC1802" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> set the completed MPU object values from key.</span></td>
+      </tr>
+      <tr>
+        <td id="L1803" class="blob-num js-line-number" data-line-number="1803"></td>
+        <td id="LC1803" class="blob-code blob-code-inner js-file-line">            k <span class="pl-k">=</span> <span class="pl-c1">self</span>.key_class(<span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L1804" class="blob-num js-line-number" data-line-number="1804"></td>
+        <td id="LC1804" class="blob-code blob-code-inner js-file-line">            k.handle_version_headers(response)</td>
+      </tr>
+      <tr>
+        <td id="L1805" class="blob-num js-line-number" data-line-number="1805"></td>
+        <td id="LC1805" class="blob-code blob-code-inner js-file-line">            k.handle_encryption_headers(response)</td>
+      </tr>
+      <tr>
+        <td id="L1806" class="blob-num js-line-number" data-line-number="1806"></td>
+        <td id="LC1806" class="blob-code blob-code-inner js-file-line">            resp.version_id <span class="pl-k">=</span> k.version_id</td>
+      </tr>
+      <tr>
+        <td id="L1807" class="blob-num js-line-number" data-line-number="1807"></td>
+        <td id="LC1807" class="blob-code blob-code-inner js-file-line">            resp.encrypted <span class="pl-k">=</span> k.encrypted</td>
+      </tr>
+      <tr>
+        <td id="L1808" class="blob-num js-line-number" data-line-number="1808"></td>
+        <td id="LC1808" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> resp</td>
+      </tr>
+      <tr>
+        <td id="L1809" class="blob-num js-line-number" data-line-number="1809"></td>
+        <td id="LC1809" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1810" class="blob-num js-line-number" data-line-number="1810"></td>
+        <td id="LC1810" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1811" class="blob-num js-line-number" data-line-number="1811"></td>
+        <td id="LC1811" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1812" class="blob-num js-line-number" data-line-number="1812"></td>
+        <td id="LC1812" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1813" class="blob-num js-line-number" data-line-number="1813"></td>
+        <td id="LC1813" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">cancel_multipart_upload</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">upload_id</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1814" class="blob-num js-line-number" data-line-number="1814"></td>
+        <td id="LC1814" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1815" class="blob-num js-line-number" data-line-number="1815"></td>
+        <td id="LC1815" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        To verify that all parts have been removed, so you don&#39;t get charged</span></td>
+      </tr>
+      <tr>
+        <td id="L1816" class="blob-num js-line-number" data-line-number="1816"></td>
+        <td id="LC1816" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        for the part storage, you should call the List Parts operation and</span></td>
+      </tr>
+      <tr>
+        <td id="L1817" class="blob-num js-line-number" data-line-number="1817"></td>
+        <td id="LC1817" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        ensure the parts list is empty.</span></td>
+      </tr>
+      <tr>
+        <td id="L1818" class="blob-num js-line-number" data-line-number="1818"></td>
+        <td id="LC1818" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1819" class="blob-num js-line-number" data-line-number="1819"></td>
+        <td id="LC1819" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>uploadId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> upload_id</td>
+      </tr>
+      <tr>
+        <td id="L1820" class="blob-num js-line-number" data-line-number="1820"></td>
+        <td id="LC1820" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>DELETE<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
+      </tr>
+      <tr>
+        <td id="L1821" class="blob-num js-line-number" data-line-number="1821"></td>
+        <td id="LC1821" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
+      </tr>
+      <tr>
+        <td id="L1822" class="blob-num js-line-number" data-line-number="1822"></td>
+        <td id="LC1822" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1823" class="blob-num js-line-number" data-line-number="1823"></td>
+        <td id="LC1823" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1824" class="blob-num js-line-number" data-line-number="1824"></td>
+        <td id="LC1824" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
+      </tr>
+      <tr>
+        <td id="L1825" class="blob-num js-line-number" data-line-number="1825"></td>
+        <td id="LC1825" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">204</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1826" class="blob-num js-line-number" data-line-number="1826"></td>
+        <td id="LC1826" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1827" class="blob-num js-line-number" data-line-number="1827"></td>
+        <td id="LC1827" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1828" class="blob-num js-line-number" data-line-number="1828"></td>
+        <td id="LC1828" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1829" class="blob-num js-line-number" data-line-number="1829"></td>
+        <td id="LC1829" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1830" class="blob-num js-line-number" data-line-number="1830"></td>
+        <td id="LC1830" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.connection.delete_bucket(<span class="pl-c1">self</span>.name, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1831" class="blob-num js-line-number" data-line-number="1831"></td>
+        <td id="LC1831" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1832" class="blob-num js-line-number" data-line-number="1832"></td>
+        <td id="LC1832" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_tags</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1833" class="blob-num js-line-number" data-line-number="1833"></td>
+        <td id="LC1833" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_xml_tags(headers)</td>
+      </tr>
+      <tr>
+        <td id="L1834" class="blob-num js-line-number" data-line-number="1834"></td>
+        <td id="LC1834" class="blob-code blob-code-inner js-file-line">        tags <span class="pl-k">=</span> Tags()</td>
+      </tr>
+      <tr>
+        <td id="L1835" class="blob-num js-line-number" data-line-number="1835"></td>
+        <td id="LC1835" class="blob-code blob-code-inner js-file-line">        h <span class="pl-k">=</span> handler.XmlHandler(tags, <span class="pl-c1">self</span>)</td>
+      </tr>
+      <tr>
+        <td id="L1836" class="blob-num js-line-number" data-line-number="1836"></td>
+        <td id="LC1836" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(response, <span class="pl-c1">bytes</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1837" class="blob-num js-line-number" data-line-number="1837"></td>
+        <td id="LC1837" class="blob-code blob-code-inner js-file-line">            response <span class="pl-k">=</span> response.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L1838" class="blob-num js-line-number" data-line-number="1838"></td>
+        <td id="LC1838" class="blob-code blob-code-inner js-file-line">        xml.sax.parseString(response, h)</td>
+      </tr>
+      <tr>
+        <td id="L1839" class="blob-num js-line-number" data-line-number="1839"></td>
+        <td id="LC1839" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> tags</td>
+      </tr>
+      <tr>
+        <td id="L1840" class="blob-num js-line-number" data-line-number="1840"></td>
+        <td id="LC1840" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1841" class="blob-num js-line-number" data-line-number="1841"></td>
+        <td id="LC1841" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_xml_tags</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1842" class="blob-num js-line-number" data-line-number="1842"></td>
+        <td id="LC1842" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1843" class="blob-num js-line-number" data-line-number="1843"></td>
+        <td id="LC1843" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>tagging<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L1844" class="blob-num js-line-number" data-line-number="1844"></td>
+        <td id="LC1844" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1845" class="blob-num js-line-number" data-line-number="1845"></td>
+        <td id="LC1845" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1846" class="blob-num js-line-number" data-line-number="1846"></td>
+        <td id="LC1846" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1847" class="blob-num js-line-number" data-line-number="1847"></td>
+        <td id="LC1847" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> body</td>
+      </tr>
+      <tr>
+        <td id="L1848" class="blob-num js-line-number" data-line-number="1848"></td>
+        <td id="LC1848" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1849" class="blob-num js-line-number" data-line-number="1849"></td>
+        <td id="LC1849" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1850" class="blob-num js-line-number" data-line-number="1850"></td>
+        <td id="LC1850" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1851" class="blob-num js-line-number" data-line-number="1851"></td>
+        <td id="LC1851" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1852" class="blob-num js-line-number" data-line-number="1852"></td>
+        <td id="LC1852" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_xml_tags</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">tag_str</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>tagging<span class="pl-pds">&#39;</span></span>):</td>
+      </tr>
+      <tr>
+        <td id="L1853" class="blob-num js-line-number" data-line-number="1853"></td>
+        <td id="LC1853" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> headers <span class="pl-k">is</span> <span class="pl-c1">None</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1854" class="blob-num js-line-number" data-line-number="1854"></td>
+        <td id="LC1854" class="blob-code blob-code-inner js-file-line">            headers <span class="pl-k">=</span> {}</td>
+      </tr>
+      <tr>
+        <td id="L1855" class="blob-num js-line-number" data-line-number="1855"></td>
+        <td id="LC1855" class="blob-code blob-code-inner js-file-line">        md5 <span class="pl-k">=</span> boto.utils.compute_md5(StringIO(tag_str))</td>
+      </tr>
+      <tr>
+        <td id="L1856" class="blob-num js-line-number" data-line-number="1856"></td>
+        <td id="LC1856" class="blob-code blob-code-inner js-file-line">        headers[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-MD5<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> md5[<span class="pl-c1">1</span>]</td>
+      </tr>
+      <tr>
+        <td id="L1857" class="blob-num js-line-number" data-line-number="1857"></td>
+        <td id="LC1857" class="blob-code blob-code-inner js-file-line">        headers[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-Type<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>text/xml<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L1858" class="blob-num js-line-number" data-line-number="1858"></td>
+        <td id="LC1858" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(tag_str, <span class="pl-c1">bytes</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1859" class="blob-num js-line-number" data-line-number="1859"></td>
+        <td id="LC1859" class="blob-code blob-code-inner js-file-line">            tag_str <span class="pl-k">=</span> tag_str.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
+      </tr>
+      <tr>
+        <td id="L1860" class="blob-num js-line-number" data-line-number="1860"></td>
+        <td id="LC1860" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1861" class="blob-num js-line-number" data-line-number="1861"></td>
+        <td id="LC1861" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">data</span><span class="pl-k">=</span>tag_str,</td>
+      </tr>
+      <tr>
+        <td id="L1862" class="blob-num js-line-number" data-line-number="1862"></td>
+        <td id="LC1862" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
+      </tr>
+      <tr>
+        <td id="L1863" class="blob-num js-line-number" data-line-number="1863"></td>
+        <td id="LC1863" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1864" class="blob-num js-line-number" data-line-number="1864"></td>
+        <td id="LC1864" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1865" class="blob-num js-line-number" data-line-number="1865"></td>
+        <td id="LC1865" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">204</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1866" class="blob-num js-line-number" data-line-number="1866"></td>
+        <td id="LC1866" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1867" class="blob-num js-line-number" data-line-number="1867"></td>
+        <td id="LC1867" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+      <tr>
+        <td id="L1868" class="blob-num js-line-number" data-line-number="1868"></td>
+        <td id="LC1868" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
+      </tr>
+      <tr>
+        <td id="L1869" class="blob-num js-line-number" data-line-number="1869"></td>
+        <td id="LC1869" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1870" class="blob-num js-line-number" data-line-number="1870"></td>
+        <td id="LC1870" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_tags</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">tags</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1871" class="blob-num js-line-number" data-line-number="1871"></td>
+        <td id="LC1871" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.set_xml_tags(tags.to_xml(), <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1872" class="blob-num js-line-number" data-line-number="1872"></td>
+        <td id="LC1872" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1873" class="blob-num js-line-number" data-line-number="1873"></td>
+        <td id="LC1873" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete_tags</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
+      </tr>
+      <tr>
+        <td id="L1874" class="blob-num js-line-number" data-line-number="1874"></td>
+        <td id="LC1874" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>DELETE<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
+      </tr>
+      <tr>
+        <td id="L1875" class="blob-num js-line-number" data-line-number="1875"></td>
+        <td id="LC1875" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>tagging<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L1876" class="blob-num js-line-number" data-line-number="1876"></td>
+        <td id="LC1876" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
+      </tr>
+      <tr>
+        <td id="L1877" class="blob-num js-line-number" data-line-number="1877"></td>
+        <td id="LC1877" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
+      </tr>
+      <tr>
+        <td id="L1878" class="blob-num js-line-number" data-line-number="1878"></td>
+        <td id="LC1878" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
+      </tr>
+      <tr>
+        <td id="L1879" class="blob-num js-line-number" data-line-number="1879"></td>
+        <td id="LC1879" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">204</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1880" class="blob-num js-line-number" data-line-number="1880"></td>
+        <td id="LC1880" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
+      </tr>
+      <tr>
+        <td id="L1881" class="blob-num js-line-number" data-line-number="1881"></td>
+        <td id="LC1881" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
+      </tr>
+      <tr>
+        <td id="L1882" class="blob-num js-line-number" data-line-number="1882"></td>
+        <td id="LC1882" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
+      </tr>
+      <tr>
+        <td id="L1883" class="blob-num js-line-number" data-line-number="1883"></td>
+        <td id="LC1883" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
+      </tr>
+</table>
+
+  <details class="details-reset details-overlay BlobToolbar position-absolute js-file-line-actions dropdown d-none" aria-hidden="true">
+    <summary class="btn-octicon ml-0 px-2 p-0 bg-white border border-gray-dark rounded-1" aria-label="Inline file action toolbar">
+      <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/></svg>
+    </summary>
+    <details-menu>
+      <ul class="BlobToolbar-dropdown dropdown-menu dropdown-menu-se mt-2" style="width:185px">
+        <li><clipboard-copy role="menuitem" class="dropdown-item" id="js-copy-lines" style="cursor:pointer;" data-original-text="Copy lines">Copy lines</clipboard-copy></li>
+        <li><clipboard-copy role="menuitem" class="dropdown-item" id="js-copy-permalink" style="cursor:pointer;" data-original-text="Copy permalink">Copy permalink</clipboard-copy></li>
+        <li><a class="dropdown-item js-update-url-with-hash" id="js-view-git-blame" role="menuitem" href="/boto/boto/blame/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py">View git blame</a></li>
+          <li><a class="dropdown-item" id="js-new-issue" role="menuitem" href="/boto/boto/issues/new">Reference in new issue</a></li>
+      </ul>
+    </details-menu>
+  </details>
+
+  </div>
+
+    </div>
+
+  
+
+  <details class="details-reset details-overlay details-overlay-dark">
+    <summary data-hotkey="l" aria-label="Jump to line"></summary>
+    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast linejump" aria-label="Jump to line">
+      <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-jump-to-line-form Box-body d-flex" action="" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <input class="form-control flex-auto mr-3 linejump-input js-jump-to-line-field" type="text" placeholder="Jump to line&hellip;" aria-label="Jump to line" autofocus>
+        <button type="submit" class="btn" data-close-dialog>Go</button>
+</form>    </details-dialog>
+  </details>
+
+
+
+  </div>
+  <div class="modal-backdrop js-touch-events"></div>
+</div>
+
+    </main>
+  </div>
+  
+
+  </div>
+
+        
+<div class="footer container-lg width-full px-3" role="contentinfo">
+  <div class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light ">
+    <ul class="list-style-none d-flex flex-wrap ">
+      <li class="mr-3">&copy; 2019 <span title="0.20016s from unicorn-6fd48d577-fmjln">GitHub</span>, Inc.</li>
+        <li class="mr-3"><a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms">Terms</a></li>
+        <li class="mr-3"><a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy">Privacy</a></li>
+        <li class="mr-3"><a data-ga-click="Footer, go to security, text:security" href="https://github.com/security">Security</a></li>
+        <li class="mr-3"><a href="https://githubstatus.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
+        <li><a data-ga-click="Footer, go to help, text:help" href="https://help.github.com">Help</a></li>
+    </ul>
+
+    <a aria-label="Homepage" title="GitHub" class="footer-octicon mx-lg-4" href="https://github.com">
+      <svg height="24" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+</a>
+   <ul class="list-style-none d-flex flex-wrap ">
+        <li class="mr-3"><a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact">Contact GitHub</a></li>
+        <li class="mr-3"><a href="https://github.com/pricing" data-ga-click="Footer, go to Pricing, text:Pricing">Pricing</a></li>
+      <li class="mr-3"><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
+      <li class="mr-3"><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
+        <li class="mr-3"><a href="https://github.blog" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
+        <li><a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a></li>
+
+    </ul>
+  </div>
+  <div class="d-flex flex-justify-center pb-6">
+    <span class="f6 text-gray-light"></span>
+  </div>
+</div>
+
+
+
+  <div id="ajax-error-message" class="ajax-error-message flash flash-error">
+    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>
+    <button type="button" class="flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
+      <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+    </button>
+    You can’t perform that action at this time.
+  </div>
+
+
+    <script crossorigin="anonymous" integrity="sha512-jFuNBkwlIX73xJbI2nTCs01W/xjwP+Ccc0gEdkD4d/tQBv4xIZx4dZLnkYhzawWhnxjJbvkHsxSXQffNs0Ce4Q==" type="application/javascript" src="https://github.githubassets.com/assets/compat-bootstrap-8102d067.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-HjenL0te0b2HT4WuEaue96gj0ht0TK52tVMNn4UDKQUIzoS8xbMBkyLnLudpSjJTb9sQUx6NZyVnwtb+d7zZjA==" type="application/javascript" src="https://github.githubassets.com/assets/frameworks-440b8182.js"></script>
+    
+    <script crossorigin="anonymous" async="async" integrity="sha512-VGEzKV4XNZ4Y48OsUH9YpmW7epTsL5aOvJGwrISO+G5jW7CxCsiUX6PzFS5AIf02bGVBUuHCMMWNGDqpssrX4g==" type="application/javascript" src="https://github.githubassets.com/assets/github-bootstrap-827e2f91.js"></script>
+    
+    
+    
+  <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner" hidden
+    >
+    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>
+    <span class="signed-in-tab-flash">You signed in with another tab or window. <a href="">Reload</a> to refresh your session.</span>
+    <span class="signed-out-tab-flash">You signed out in another tab or window. <a href="">Reload</a> to refresh your session.</span>
+  </div>
+  <template id="site-details-dialog">
+  <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark" open>
+    <summary aria-haspopup="dialog" aria-label="Close dialog"></summary>
+    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast">
+      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
+        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+      </button>
+      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
+    </details-dialog>
+  </details>
+</template>
+
+  <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
+  <div class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large" style="width:360px;">
+  </div>
+</div>
+
+  <div aria-live="polite" class="js-global-screen-reader-notice sr-only"></div>
+
+  </body>
+</html>
+

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -1,8640 +1,1883 @@
-
-
-
-
-
-
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-  <link rel="dns-prefetch" href="https://github.githubassets.com">
-  <link rel="dns-prefetch" href="https://avatars0.githubusercontent.com">
-  <link rel="dns-prefetch" href="https://avatars1.githubusercontent.com">
-  <link rel="dns-prefetch" href="https://avatars2.githubusercontent.com">
-  <link rel="dns-prefetch" href="https://avatars3.githubusercontent.com">
-  <link rel="dns-prefetch" href="https://github-cloud.s3.amazonaws.com">
-  <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/">
-
-
-
-  <link crossorigin="anonymous" media="all" integrity="sha512-A9QuENBx7wdV7lzJMZ1WVk18pXDoNo9VPaUEtN5LeRZAScCPV2mZygJnUxGXxcGRBofXTEc3cHqTkCjloOlPMQ==" rel="stylesheet" href="https://github.githubassets.com/assets/frameworks-574e79274f191ff598834554443b5a1c.css" />
-  <link crossorigin="anonymous" media="all" integrity="sha512-5LDBQ/DhsFq/ry7aepdbc1FV0mW/0lPqH6GlYFfzzd5wo8MBz9Rb67LigKe0uKM8kK5QrA/QsJCpsE1+hOLF6w==" rel="stylesheet" href="https://github.githubassets.com/assets/site-0e25450ff46c1fbf61d504f9ffc4d784.css" />
-    <link crossorigin="anonymous" media="all" integrity="sha512-kPMIIv3a9n5JTf0DJfMtBPuVVHi89vH20wKiIYYZpeOhLIz6d+hq+LzjaqOrBSAJGfMt5vHNmRP5ToA0jp8R+Q==" rel="stylesheet" href="https://github.githubassets.com/assets/github-bc91cc1784c152eec5801a21221639a5.css" />
-    
-    
-    
-    
-
-  <meta name="viewport" content="width=device-width">
-  
-  <title>boto/bucket.py at 603d3ce3f3f3ee9ecf452772814a7231f9ef81e3 · boto/boto · GitHub</title>
-    <meta name="description" content="For the latest version of boto, see https://github.com/boto/boto3 -- Python interface to Amazon Web Services - boto/boto">
-    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
-  <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
-  <meta property="fb:app_id" content="1401488693436528">
-
-    
-    <meta property="og:image" content="https://avatars2.githubusercontent.com/u/327752?s=400&amp;v=4" /><meta property="og:site_name" content="GitHub" /><meta property="og:type" content="object" /><meta property="og:title" content="boto/boto" /><meta property="og:url" content="https://github.com/boto/boto" /><meta property="og:description" content="For the latest version of boto, see https://github.com/boto/boto3 -- Python interface to Amazon Web Services - boto/boto" />
-
-  <link rel="assets" href="https://github.githubassets.com/">
-  
-  <meta name="pjax-timeout" content="1000">
-  
-  <meta name="request-id" content="B6D0:79EE:8BA70:10FF37:5C92A6B9" data-pjax-transient>
-
-
-  
-
-  <meta name="selected-link" value="repo_source" data-pjax-transient>
-
-      <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
-    <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
-    <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
-
-  <meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="B6D0:79EE:8BA70:10FF37:5C92A6B9" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
-<meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/blob/show" data-pjax-transient="true" />
-
-
-
-    <meta name="google-analytics" content="UA-3769691-2">
-
-
-<meta class="js-ga-set" name="dimension1" content="Logged Out">
-
-
-
-  
-
-      <meta name="hostname" content="github.com">
-    <meta name="user-login" content="">
-
-      <meta name="expected-hostname" content="github.com">
-    <meta name="js-proxy-site-detection-payload" content="NjIwODY0MDljNTAwMjY1NmUyNWNiOTNmYzc2MTA1OGNiMjUwYTU3ZTE2ZWI5YmJhYjlhYTI1YTg1NTljMTA2MXx7InJlbW90ZV9hZGRyZXNzIjoiMTA0LjEzMi4xNTQuNzkiLCJyZXF1ZXN0X2lkIjoiQjZEMDo3OUVFOjhCQTcwOjEwRkYzNzo1QzkyQTZCOSIsInRpbWVzdGFtcCI6MTU1MzExNDgxMCwiaG9zdCI6ImdpdGh1Yi5jb20ifQ==">
-
-    <meta name="enabled-features" content="UNIVERSE_BANNER,MARKETPLACE_SOCIAL_PROOF,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_PLAN_RESTRICTION_EDITOR">
-
-  <meta name="html-safe-nonce" content="0d3b32bd8fea979e7ff71ca4c7753bdd4cf1ab63">
-
-  <meta http-equiv="x-pjax-version" content="261b4aeef5636e7d9ed3d5697012184b">
-  
-
-      <link href="https://github.com/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3.atom" rel="alternate" title="Recent Commits to boto:603d3ce3f3f3ee9ecf452772814a7231f9ef81e3" type="application/atom+xml">
-
-  <meta name="go-import" content="github.com/boto/boto git https://github.com/boto/boto.git">
-
-  <meta name="octolytics-dimension-user_id" content="327752" /><meta name="octolytics-dimension-user_login" content="boto" /><meta name="octolytics-dimension-repository_id" content="771016" /><meta name="octolytics-dimension-repository_nwo" content="boto/boto" /><meta name="octolytics-dimension-repository_public" content="true" /><meta name="octolytics-dimension-repository_is_fork" content="false" /><meta name="octolytics-dimension-repository_network_root_id" content="771016" /><meta name="octolytics-dimension-repository_network_root_nwo" content="boto/boto" /><meta name="octolytics-dimension-repository_explore_github_marketplace_ci_cta_shown" content="false" />
-
-
-    <link rel="canonical" href="https://github.com/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py" data-pjax-transient>
-
-
-  <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats">
-
-  <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
-
-  <link rel="mask-icon" href="https://github.githubassets.com/pinned-octocat.svg" color="#000000">
-  <link rel="icon" type="image/x-icon" class="js-site-favicon" href="https://github.githubassets.com/favicon.ico">
-
-<meta name="theme-color" content="#1e2327">
-
-
-
-
-  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
-
-  </head>
-
-  <body class="logged-out env-production page-blob">
-    
-
-  <div class="position-relative js-header-wrapper ">
-    <a href="#start-of-content" tabindex="1" class="px-2 py-4 bg-blue text-white show-on-focus js-skip-to-content">Skip to content</a>
-    <div id="js-pjax-loader-bar" class="pjax-loader-bar"><div class="progress"></div></div>
-
-    
-    
-    
-
-
-        
-<header class="Header-old header-logged-out  position-relative f4 py-3" role="banner">
-  <div class="container-lg d-flex px-3">
-    <div class="d-flex flex-justify-between flex-items-center">
-        <a class="mr-4" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark">
-          <svg height="32" class="octicon octicon-mark-github text-white" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
-        </a>
-    </div>
-
-    <div class="HeaderMenu HeaderMenu--logged-out d-flex flex-justify-between flex-items-center flex-auto">
-      <div class="d-none">
-        <button class="btn-link js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
-          <svg height="24" class="octicon octicon-x text-gray" viewBox="0 0 12 16" version="1.1" width="18" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
-        </button>
-      </div>
-
-        <nav class="mt-0" aria-label="Global">
-          <ul class="d-flex list-style-none">
-              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
-                <details class="HeaderMenu-details details-overlay details-reset width-full">
-                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
-                    Why GitHub?
-                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
-                      <path d="M1,1l6.2,6L13,1"></path>
-                    </svg>
-                  </summary>
-                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 mt-0  p-4 left-n4 position-absolute">
-                    <a href="/features" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Features <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
-                    <ul class="list-style-none f5 pb-3">
-                      <li class="edge-item-fix"><a href="/features/code-review/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code review">Code review</a></li>
-                      <li class="edge-item-fix"><a href="/features/project-management/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Project management">Project management</a></li>
-                      <li class="edge-item-fix"><a href="/features/integrations" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Integrations">Integrations</a></li>
-                      <li class="edge-item-fix"><a href="/features/actions" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Actions">Actions</a>
-                      <li class="edge-item-fix"><a href="/features#team-management" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team management">Team management</a></li>
-                      <li class="edge-item-fix"><a href="/features#social-coding" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Social coding">Social coding</a></li>
-                      <li class="edge-item-fix"><a href="/features#documentation" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Documentation">Documentation</a></li>
-                      <li class="edge-item-fix"><a href="/features#code-hosting" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code hosting">Code hosting</a></li>
-                    </ul>
-
-                    <ul class="list-style-none mb-0 border-lg-top pt-lg-3">
-                      <li class="edge-item-fix"><a href="/case-studies" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Customer stories">Customer stories <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
-                      <li class="edge-item-fix"><a href="/security" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Security">Security <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
-                    </ul>
-                  </div>
-                </details>
-              </li>
-              <li class=" mr-3 mr-lg-3">
-                <a href="/enterprise" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, click, go to Enterprise">Enterprise</a>
-              </li>
-
-              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
-                <details class="HeaderMenu-details details-overlay details-reset width-full">
-                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
-                    Explore
-                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
-                      <path d="M1,1l6.2,6L13,1"></path>
-                    </svg>
-                  </summary>
-
-                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-0 mt-0  p-4 left-n4 position-absolute">
-                    <ul class="list-style-none mb-3">
-                      <li class="edge-item-fix"><a href="/explore" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Explore GitHub <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
-                    </ul>
-
-                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Learn &amp; contribute</h4>
-                    <ul class="list-style-none mb-3">
-                      <li class="edge-item-fix"><a href="/topics" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Topics">Topics</a></li>
-                        <li class="edge-item-fix"><a href="/collections" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Collections">Collections</a></li>
-                      <li class="edge-item-fix"><a href="/trending" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Trending">Trending</a></li>
-                      <li class="edge-item-fix"><a href="https://lab.github.com/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Learning lab">Learning Lab</a></li>
-                      <li class="edge-item-fix"><a href="https://opensource.guide" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Open source guides">Open source guides</a></li>
-                    </ul>
-
-                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Connect with others</h4>
-                    <ul class="list-style-none mb-0">
-                      <li class="edge-item-fix"><a href="https://github.com/events" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Events">Events</a></li>
-                      <li class="edge-item-fix"><a href="https://github.community" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Community forum">Community forum</a></li>
-                      <li class="edge-item-fix"><a href="https://education.github.com" class="py-2 pb-0 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to GitHub Education">GitHub Education</a></li>
-                    </ul>
-                  </div>
-                </details>
-              </li>
-
-              <li class=" mr-3 mr-lg-3">
-                <a href="/marketplace" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Marketplace">Marketplace</a>
-              </li>
-
-              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
-                <details class="HeaderMenu-details details-overlay details-reset width-full">
-                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
-                    Pricing
-                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
-                       <path d="M1,1l6.2,6L13,1"></path>
-                    </svg>
-                  </summary>
-
-                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-4 mt-0  p-4 left-n4 position-absolute">
-                    <a href="/pricing" class="pb-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Pricing">Plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
-
-                    <ul class="list-style-none mb-3">
-                      <li class="edge-item-fix"><a href="/pricing#feature-comparison" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Compare features">Compare plans</a></li>
-                      <li class="edge-item-fix"><a href="https://enterprise.github.com/contact" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Compare features">Contact Sales</a></li>
-                    </ul>
-
-                    <ul class="list-style-none mb-0  border-top pt-3">
-                      <li class="edge-item-fix"><a href="/nonprofit" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Nonprofits">Nonprofit <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
-                      <li class="edge-item-fix"><a href="https://education.github.com" class="py-2 pb-0 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover"  data-ga-click="(Logged out) Header, go to Education">Education <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
-                    </ul>
-                  </div>
-                </details>
-              </li>
-          </ul>
-        </nav>
-
-      <div class="d-flex flex-items-center px-0 text-center text-left">
-          <div class="d-lg-flex ">
-            <div class="header-search mr-3 scoped-search site-scoped-search js-site-search position-relative js-jump-to"
-  role="combobox"
-  aria-owns="jump-to-results"
-  aria-label="Search or jump to"
-  aria-haspopup="listbox"
-  aria-expanded="false"
->
-  <div class="position-relative">
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-site-search-form" role="search" aria-label="Site" data-scope-type="Repository" data-scope-id="771016" data-scoped-search-url="/boto/boto/search" data-unscoped-search-url="/search" action="/boto/boto/search" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
-      <label class="form-control input-sm header-search-wrapper p-0 header-search-wrapper-jump-to position-relative d-flex flex-justify-between flex-items-center js-chromeless-input-container">
-        <input type="text"
-          class="form-control input-sm header-search-input jump-to-field js-jump-to-field js-site-search-focus js-site-search-field is-clearable"
-          data-hotkey="s,/"
-          name="q"
-          value=""
-          placeholder="Search"
-          data-unscoped-placeholder="Search GitHub"
-          data-scoped-placeholder="Search"
-          autocapitalize="off"
-          aria-autocomplete="list"
-          aria-controls="jump-to-results"
-          aria-label="Search"
-          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=OaRezg0C1tqJZjjFMMLjhetRkLI5vcwf1SuNQ44Twj5Cg/L1Hw/CSU50cz6g+YMbt5ueIiNyzscHxgrbHtVqOA=="
-          spellcheck="false"
-          autocomplete="off"
-          >
-          <input type="hidden" class="js-site-search-type-field" name="type" >
-            <img src="https://github.githubassets.com/images/search-key-slash.svg" alt="" class="mr-2 header-search-key-slash">
-
-            <div class="Box position-absolute overflow-hidden d-none jump-to-suggestions js-jump-to-suggestions-container">
-              
-<ul class="d-none js-jump-to-suggestions-template-container">
-  
-
-<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-suggestion" role="option">
-  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
-    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
-      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
-    </div>
-
-    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
-
-    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
-    </div>
-
-    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
-      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
-        In this repository
-      </span>
-      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
-        All GitHub
-      </span>
-      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-
-    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
-      Jump to
-      <span class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-  </a>
-</li>
-
-</ul>
-
-<ul class="d-none js-jump-to-no-results-template-container">
-  <li class="d-flex flex-justify-center flex-items-center f5 d-none js-jump-to-suggestion p-2">
-    <span class="text-gray">No suggested jump to results</span>
-  </li>
-</ul>
-
-<ul id="jump-to-results" role="listbox" class="p-0 m-0 js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container">
-  
-
-<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-scoped-search d-none" role="option">
-  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
-    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
-      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
-    </div>
-
-    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
-
-    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
-    </div>
-
-    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
-      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
-        In this repository
-      </span>
-      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
-        All GitHub
-      </span>
-      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-
-    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
-      Jump to
-      <span class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-  </a>
-</li>
-
-  
-
-<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-global-search d-none" role="option">
-  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
-    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
-      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
-    </div>
-
-    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
-
-    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
-    </div>
-
-    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
-      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
-        In this repository
-      </span>
-      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
-        All GitHub
-      </span>
-      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-
-    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
-      Jump to
-      <span class="d-inline-block ml-1 v-align-middle">↵</span>
-    </div>
-  </a>
-</li>
-
-
-</ul>
-
-            </div>
-      </label>
-</form>  </div>
-</div>
-
-          </div>
-
-        <a class="HeaderMenu-link no-underline mr-3" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;B6D0:79EE:8BA70:10FF37:5C92A6B9&quot;,&quot;originating_url&quot;:&quot;https://github.com/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="a57fcf380641741a5fc493468f26d55cd923568fe9746e42d289c57779fac3e0" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in" href="/login?return_to=%2Fboto%2Fboto%2Fblob%2F603d3ce3f3f3ee9ecf452772814a7231f9ef81e3%2Fboto%2Fs3%2Fbucket.py">
-          Sign&nbsp;in
-</a>          <a class="HeaderMenu-link d-inline-block no-underline border border-gray-dark rounded-1 px-2 py-1" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;B6D0:79EE:8BA70:10FF37:5C92A6B9&quot;,&quot;originating_url&quot;:&quot;https://github.com/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="1361130f02b3e4b5a14444b3b165edc18214250c45088e7576f16c1ecc24667e" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up" href="/join">
-            Sign&nbsp;up
-</a>      </div>
-    </div>
-  </div>
-</header>
-
-  </div>
-
-  <div id="start-of-content" class="show-on-focus"></div>
-
-    <div id="js-flash-container">
-
-</div>
-
-
-
-  <div class="application-main " data-commit-hovercards-enabled>
-        <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
-    <main id="js-repo-pjax-container" data-pjax-container >
-      
-
-
-  
-
-
-
-  
-
-
-
-
-  <div class="pagehead repohead instapaper_ignore readability-menu experiment-repo-nav  ">
-    <div class="repohead-details-container clearfix container">
-
-      <ul class="pagehead-actions">
-
-
-
-  <li>
-      <a class="btn btn-sm btn-with-count tooltipped tooltipped-s" aria-label="You must be signed in to watch a repository" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;notification subscription menu watch&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;B6D0:79EE:8BA70:10FF37:5C92A6B9&quot;,&quot;originating_url&quot;:&quot;https://github.com/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="6f4efd2d86b503c38487375bc9de82eab4776b3d7220641f573b10e961e0cc8f" href="/login?return_to=%2Fboto%2Fboto">
-    <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
-    Watch
-</a>  <a class="social-count" href="/boto/boto/watchers"
-     aria-label="311 users are watching this repository">
-    311
-  </a>
-
-  </li>
-
-  <li>
-        <a class="btn btn-sm btn-with-count tooltipped tooltipped-s" aria-label="You must be signed in to star a repository" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;star button&quot;,&quot;repository_id&quot;:771016,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;B6D0:79EE:8BA70:10FF37:5C92A6B9&quot;,&quot;originating_url&quot;:&quot;https://github.com/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="0fadc398996d2b684b5ef96adcfb735d7f94ef05e9457337de7ca3eb498a91f2" href="/login?return_to=%2Fboto%2Fboto">
-      <svg class="octicon octicon-star v-align-text-bottom" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
-      Star
-</a>
-    <a class="social-count js-social-count" href="/boto/boto/stargazers"
-      aria-label="6291 users starred this repository">
-      6,291
-    </a>
-
-  </li>
-
-  <li>
-      <a class="btn btn-sm btn-with-count tooltipped tooltipped-s" aria-label="You must be signed in to fork a repository" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;repo details fork button&quot;,&quot;repository_id&quot;:771016,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;B6D0:79EE:8BA70:10FF37:5C92A6B9&quot;,&quot;originating_url&quot;:&quot;https://github.com/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="cbb74df12f53c4feead762469ebab7d5969d0f1fafd1ce03345af813dbb80386" href="/login?return_to=%2Fboto%2Fboto">
-        <svg class="octicon octicon-repo-forked v-align-text-bottom" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
-        Fork
-</a>
-    <a href="/boto/boto/network/members" class="social-count"
-       aria-label="2279 users forked this repository">
-      2,279
-    </a>
-  </li>
-</ul>
-
-      <h1 class="public ">
-  <svg class="octicon octicon-repo" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-  <span class="author" itemprop="author"><a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/boto/hovercard" href="/boto">boto</a></span><!--
---><span class="path-divider">/</span><!--
---><strong itemprop="name"><a data-pjax="#js-repo-pjax-container" href="/boto/boto">boto</a></strong>
-
-</h1>
-
-    </div>
-    
-<nav class="reponav js-repo-nav js-sidenav-container-pjax container"
-     itemscope
-     itemtype="http://schema.org/BreadcrumbList"
-    aria-label="Repository"
-     data-pjax="#js-repo-pjax-container">
-
-  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-    <a class="js-selected-navigation-item selected reponav-item" itemprop="url" data-hotkey="g c" aria-current="page" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /boto/boto" href="/boto/boto">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"/></svg>
-      <span itemprop="name">Code</span>
-      <meta itemprop="position" content="1">
-</a>  </span>
-
-    <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-      <a itemprop="url" data-hotkey="g i" class="js-selected-navigation-item reponav-item" data-selected-links="repo_issues repo_labels repo_milestones /boto/boto/issues" href="/boto/boto/issues">
-        <svg class="octicon octicon-issue-opened" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"/></svg>
-        <span itemprop="name">Issues</span>
-        <span class="Counter">785</span>
-        <meta itemprop="position" content="2">
-</a>    </span>
-
-  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-    <a data-hotkey="g p" itemprop="url" class="js-selected-navigation-item reponav-item" data-selected-links="repo_pulls checks /boto/boto/pulls" href="/boto/boto/pulls">
-      <svg class="octicon octicon-git-pull-request" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
-      <span itemprop="name">Pull requests</span>
-      <span class="Counter">381</span>
-      <meta itemprop="position" content="3">
-</a>  </span>
-
-
-    <a data-hotkey="g b" class="js-selected-navigation-item reponav-item" data-selected-links="repo_projects new_repo_project repo_project /boto/boto/projects" href="/boto/boto/projects">
-      <svg class="octicon octicon-project" viewBox="0 0 15 16" version="1.1" width="15" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-      Projects
-      <span class="Counter" >0</span>
-</a>
-
-
-    <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse alerts security people /boto/boto/pulse" href="/boto/boto/pulse">
-      <svg class="octicon octicon-graph" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"/></svg>
-      Insights
-</a>
-
-</nav>
-
-
-  </div>
-<div class="container new-discussion-timeline experiment-repo-nav  ">
-  <div class="repository-content ">
-
-    
-    
-
-
-
-  
-    <a class="d-none js-permalink-shortcut" data-hotkey="y" href="/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py">Permalink</a>
-
-    <!-- blob contrib key: blob_contributors:v21:87ce23e7050062f662206e6cbdf01f0e -->
-
-        <div class="signup-prompt-bg rounded-1">
-      <div class="signup-prompt p-4 text-center mb-4 rounded-1">
-        <div class="position-relative">
-          <!-- '"` --><!-- </textarea></xmp> --></option></form><form action="/site/dismiss_signup_prompt" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="A2DvcViUixkdGT7+sSgg5mP3MqDVb9awMStWKlYj/39cAhPr9wf8xV+lcuskDzUcKtXl1vtilUAfjbnfuzDLew==" />
-            <button type="submit" class="position-absolute top-0 right-0 btn-link link-gray" data-ga-click="(Logged out) Sign up prompt, clicked Dismiss, text:dismiss">
-              Dismiss
-            </button>
-</form>          <h3 class="pt-2">Join GitHub today</h3>
-          <p class="col-6 mx-auto">GitHub is home to over 31 million developers working together to host and review code, manage projects, and build software together.</p>
-          <a class="btn btn-primary" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;files signup prompt&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;B6D0:79EE:8BA70:10FF37:5C92A6B9&quot;,&quot;originating_url&quot;:&quot;https://github.com/boto/boto/blob/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="f62270455eaf0a8f6d376afbad7becaf71d4c78d86aeaf874a3904b4f014aa3a" data-ga-click="(Logged out) Sign up prompt, clicked Sign up, text:sign-up" href="/join?source=prompt-blob-show">Sign up</a>
-        </div>
-      </div>
-    </div>
-
-
-    <div class="d-flex flex-shrink-0 flex-items-center mb-3">
-      
-<details class="details-reset details-overlay select-menu branch-select-menu">
-  <summary class="btn btn-sm select-menu-button css-truncate"
-           data-hotkey="w"
-           
-           title="Switch branches or tags">
-    <i>Tree:</i>
-    <span class="css-truncate-target">603d3ce3f3</span>
-  </summary>
-
-  <details-menu class="select-menu-modal position-absolute" style="z-index: 99;" src="/boto/boto/ref-list/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?source_action=show&amp;source_controller=blob" preload>
-    <include-fragment class="select-menu-loading-overlay anim-pulse">
-      <svg height="32" class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"/></svg>
-    </include-fragment>
-  </details-menu>
-</details>
-
-      <div id="blob-path" class="breadcrumb flex-auto ml-2">
-        <span class="js-repo-root text-bold"><span class="js-path-segment"><a data-pjax="true" rel="nofollow" href="/boto/boto/tree/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3"><span>boto</span></a></span></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" rel="nofollow" href="/boto/boto/tree/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto"><span>boto</span></a></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" rel="nofollow" href="/boto/boto/tree/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3"><span>s3</span></a></span><span class="separator">/</span><strong class="final-path">bucket.py</strong>
-      </div>
-      <div class="BtnGroup">
-        <a href="/boto/boto/find/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3"
-              class="js-pjax-capture-input btn btn-sm BtnGroup-item"
-              data-pjax
-              data-hotkey="t">
-          Find file
-        </a>
-        <clipboard-copy for="blob-path" class="btn btn-sm BtnGroup-item">
-          Copy path
-        </clipboard-copy>
-      </div>
-    </div>
-
-
-
-    
-  <div class="Box Box--condensed d-flex flex-column flex-shrink-0">
-      <div class="Box-body d-flex flex-justify-between bg-blue-light flex-items-center">
-        <span class="pr-md-4 f6">
-          <a rel="contributor" data-skip-pjax="true" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=43632885" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/catleeball"><img class="avatar" src="https://avatars1.githubusercontent.com/u/43632885?s=40&amp;v=4" width="20" height="20" alt="@catleeball" /></a>
-          <a class="text-bold link-gray-dark lh-default v-align-middle" rel="contributor" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=43632885" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/catleeball">catleeball</a>
-            <span class="lh-default v-align-middle">
-              <a data-pjax="true" title="Adding the rest of Ed&#39;s boto changes" class="link-gray" href="/boto/boto/commit/9cb3ef473d08a4b65515e8750ef05e21ca1f3984">Adding the rest of Ed's boto changes</a>
-            </span>
-        </span>
-        <span class="d-inline-block flex-shrink-0 v-align-bottom f6">
-          <a class="pr-2 text-mono link-gray" href="/boto/boto/commit/9cb3ef473d08a4b65515e8750ef05e21ca1f3984" data-pjax>
-            9cb3ef4
-          </a>
-          <relative-time datetime="2019-01-09T23:40:46Z">Jan 9, 2019</relative-time>
-        </span>
-      </div>
-
-    <div class="Box-body d-flex flex-items-center flex-auto f6 border-bottom-0" >
-      
-<details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark float-left mr-2" id="blob_contributors_box">
-  <summary
-      class="btn-link"
-      aria-haspopup="dialog"
-      
-      
-      >
-    
-    <span><strong>49</strong> contributors</span>
-  </summary>
-  <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast " aria-label="Users who have contributed to this file">
-    <div class="Box-header">
-      <button class="Box-btn-octicon btn-octicon float-right" type="button" aria-label="Close dialog" data-close-dialog>
-        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
-      </button>
-      <h3 class="Box-title">Users who have contributed to this file</h3>
-    </div>
-    
-        <ul class="list-style-none overflow-auto">
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/garnaat">
-                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/2056?s=40&amp;v=4" width="20" height="20" />
-                garnaat
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/toastdriven">
-                <img class="avatar mr-1" alt="" src="https://avatars0.githubusercontent.com/u/2449?s=40&amp;v=4" width="20" height="20" />
-                toastdriven
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/danielgtaylor">
-                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/106826?s=40&amp;v=4" width="20" height="20" />
-                danielgtaylor
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/mfschwartz">
-                <img class="avatar mr-1" alt="" src="https://avatars3.githubusercontent.com/u/333551?s=40&amp;v=4" width="20" height="20" />
-                mfschwartz
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/jamesls">
-                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/368057?s=40&amp;v=4" width="20" height="20" />
-                jamesls
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/marcacohen">
-                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/658327?s=40&amp;v=4" width="20" height="20" />
-                marcacohen
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/tpodowd">
-                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/235524?s=40&amp;v=4" width="20" height="20" />
-                tpodowd
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/sievlev">
-                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/241111?s=40&amp;v=4" width="20" height="20" />
-                sievlev
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/kouk">
-                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/456007?s=40&amp;v=4" width="20" height="20" />
-                kouk
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/yovadia">
-                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/1914389?s=40&amp;v=4" width="20" height="20" />
-                yovadia
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/fabiant7t">
-                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/81570?s=40&amp;v=4" width="20" height="20" />
-                fabiant7t
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/davbo">
-                <img class="avatar mr-1" alt="" src="https://avatars3.githubusercontent.com/u/330135?s=40&amp;v=4" width="20" height="20" />
-                davbo
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/catleeball">
-                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/43632885?s=40&amp;v=4" width="20" height="20" />
-                catleeball
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/zwilt">
-                <img class="avatar mr-1" alt="" src="https://avatars0.githubusercontent.com/u/3579806?s=40&amp;v=4" width="20" height="20" />
-                zwilt
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/tobiaspal">
-                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/297953?s=40&amp;v=4" width="20" height="20" />
-                tobiaspal
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/tmclane">
-                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/511975?s=40&amp;v=4" width="20" height="20" />
-                tmclane
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/krallin">
-                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/1737686?s=40&amp;v=4" width="20" height="20" />
-                krallin
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/showard">
-                <img class="avatar mr-1" alt="" src="https://avatars0.githubusercontent.com/u/445027?s=40&amp;v=4" width="20" height="20" />
-                showard
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/pasc">
-                <img class="avatar mr-1" alt="" src="https://avatars3.githubusercontent.com/u/56096?s=40&amp;v=4" width="20" height="20" />
-                pasc
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/opottone">
-                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/8319326?s=40&amp;v=4" width="20" height="20" />
-                opottone
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/najeira">
-                <img class="avatar mr-1" alt="" src="https://avatars3.githubusercontent.com/u/1098127?s=40&amp;v=4" width="20" height="20" />
-                najeira
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/markhjelm">
-                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/24922726?s=40&amp;v=4" width="20" height="20" />
-                markhjelm
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/marascio">
-                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/53063?s=40&amp;v=4" width="20" height="20" />
-                marascio
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/kyleknap">
-                <img class="avatar mr-1" alt="" src="https://avatars0.githubusercontent.com/u/4605355?s=40&amp;v=4" width="20" height="20" />
-                kyleknap
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/jtriley">
-                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/46910?s=40&amp;v=4" width="20" height="20" />
-                jtriley
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/jianli">
-                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/1527821?s=40&amp;v=4" width="20" height="20" />
-                jianli
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/houglum">
-                <img class="avatar mr-1" alt="" src="https://avatars1.githubusercontent.com/u/14894525?s=40&amp;v=4" width="20" height="20" />
-                houglum
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/gleicon">
-                <img class="avatar mr-1" alt="" src="https://avatars0.githubusercontent.com/u/38321?s=40&amp;v=4" width="20" height="20" />
-                gleicon
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/gholms">
-                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/92943?s=40&amp;v=4" width="20" height="20" />
-                gholms
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/daviddpark">
-                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/383789?s=40&amp;v=4" width="20" height="20" />
-                daviddpark
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/callahad">
-                <img class="avatar mr-1" alt="" src="https://avatars3.githubusercontent.com/u/24193?s=40&amp;v=4" width="20" height="20" />
-                callahad
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/brimcfadden">
-                <img class="avatar mr-1" alt="" src="https://avatars3.githubusercontent.com/u/276142?s=40&amp;v=4" width="20" height="20" />
-                brimcfadden
-</a>            </li>
-            <li class="Box-row">
-              <a class="link-gray-dark no-underline" href="/JJC1138">
-                <img class="avatar mr-1" alt="" src="https://avatars2.githubusercontent.com/u/428774?s=40&amp;v=4" width="20" height="20" />
-                JJC1138
-</a>            </li>
-        </ul>
-
-  </details-dialog>
-</details>
-          <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=2056" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=garnaat">
-      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/2056?s=40&amp;v=4" width="20" height="20" alt="@garnaat" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=2449" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=toastdriven">
-      <img class="avatar mr-1" src="https://avatars0.githubusercontent.com/u/2449?s=40&amp;v=4" width="20" height="20" alt="@toastdriven" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=106826" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=danielgtaylor">
-      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/106826?s=40&amp;v=4" width="20" height="20" alt="@danielgtaylor" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=333551" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=mfschwartz">
-      <img class="avatar mr-1" src="https://avatars3.githubusercontent.com/u/333551?s=40&amp;v=4" width="20" height="20" alt="@mfschwartz" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=368057" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=jamesls">
-      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/368057?s=40&amp;v=4" width="20" height="20" alt="@jamesls" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=658327" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=marcacohen">
-      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/658327?s=40&amp;v=4" width="20" height="20" alt="@marcacohen" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=235524" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=tpodowd">
-      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/235524?s=40&amp;v=4" width="20" height="20" alt="@tpodowd" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=241111" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=sievlev">
-      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/241111?s=40&amp;v=4" width="20" height="20" alt="@sievlev" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=456007" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=kouk">
-      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/456007?s=40&amp;v=4" width="20" height="20" alt="@kouk" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1914389" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=yovadia">
-      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/1914389?s=40&amp;v=4" width="20" height="20" alt="@yovadia" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=81570" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=fabiant7t">
-      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/81570?s=40&amp;v=4" width="20" height="20" alt="@fabiant7t" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=330135" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=davbo">
-      <img class="avatar mr-1" src="https://avatars3.githubusercontent.com/u/330135?s=40&amp;v=4" width="20" height="20" alt="@davbo" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=43632885" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=catleeball">
-      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/43632885?s=40&amp;v=4" width="20" height="20" alt="@catleeball" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=3579806" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=zwilt">
-      <img class="avatar mr-1" src="https://avatars0.githubusercontent.com/u/3579806?s=40&amp;v=4" width="20" height="20" alt="@zwilt" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=297953" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=tobiaspal">
-      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/297953?s=40&amp;v=4" width="20" height="20" alt="@tobiaspal" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=511975" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=tmclane">
-      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/511975?s=40&amp;v=4" width="20" height="20" alt="@tmclane" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1737686" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=krallin">
-      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/1737686?s=40&amp;v=4" width="20" height="20" alt="@krallin" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=445027" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=showard">
-      <img class="avatar mr-1" src="https://avatars0.githubusercontent.com/u/445027?s=40&amp;v=4" width="20" height="20" alt="@showard" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=56096" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=pasc">
-      <img class="avatar mr-1" src="https://avatars3.githubusercontent.com/u/56096?s=40&amp;v=4" width="20" height="20" alt="@pasc" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=8319326" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=opottone">
-      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/8319326?s=40&amp;v=4" width="20" height="20" alt="@opottone" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1098127" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=najeira">
-      <img class="avatar mr-1" src="https://avatars3.githubusercontent.com/u/1098127?s=40&amp;v=4" width="20" height="20" alt="@najeira" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=24922726" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=markhjelm">
-      <img class="avatar mr-1" src="https://avatars1.githubusercontent.com/u/24922726?s=40&amp;v=4" width="20" height="20" alt="@markhjelm" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=53063" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=marascio">
-      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/53063?s=40&amp;v=4" width="20" height="20" alt="@marascio" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=4605355" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=kyleknap">
-      <img class="avatar mr-1" src="https://avatars0.githubusercontent.com/u/4605355?s=40&amp;v=4" width="20" height="20" alt="@kyleknap" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=46910" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=jtriley">
-      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/46910?s=40&amp;v=4" width="20" height="20" alt="@jtriley" /> 
-</a>    <a class="avatar-link" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1527821" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py?author=jianli">
-      <img class="avatar mr-1" src="https://avatars2.githubusercontent.com/u/1527821?s=40&amp;v=4" width="20" height="20" alt="@jianli" /> 
-</a>
-    <button type="button" class="btn-link lh-default" data-toggle-for="blob_contributors_box">and others</button>
-
-    </div>
-  </div>
-
-
-
-
-
-    <div class="Box mt-3 position-relative">
-      
-<div class="Box-header py-2 d-flex flex-justify-between flex-items-center">
-
-  <div class="text-mono f6">
-      1884 lines (1628 sloc)
-      <span class="file-info-divider"></span>
-    77.9 KB
-  </div>
-
-  <div class="d-flex">
-
-    <div class="BtnGroup">
-      <a id="raw-url" class="btn btn-sm BtnGroup-item" href="/boto/boto/raw/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py">Raw</a>
-        <a class="btn btn-sm js-update-url-with-hash BtnGroup-item" data-hotkey="b" href="/boto/boto/blame/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py">Blame</a>
-      <a rel="nofollow" class="btn btn-sm BtnGroup-item" href="/boto/boto/commits/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py">History</a>
-    </div>
-
-
-    <div>
-
-          <button type="button" class="btn-octicon disabled tooltipped tooltipped-nw"
-            aria-label="You must be signed in to make or propose changes">
-            <svg class="octicon octicon-pencil" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"/></svg>
-          </button>
-          <button type="button" class="btn-octicon btn-octicon-danger disabled tooltipped tooltipped-nw"
-            aria-label="You must be signed in to make or propose changes">
-            <svg class="octicon octicon-trashcan" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"/></svg>
-          </button>
-    </div>
-  </div>
-</div>
-
-      
-
-  <div itemprop="text" class="Box-body px-0 blob-wrapper data type-python ">
-      
-<table class="highlight tab-size js-file-line-container" data-tab-size="8">
-      <tr>
-        <td id="L1" class="blob-num js-line-number" data-line-number="1"></td>
-        <td id="LC1" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> Copyright (c) 2006-2010 Mitch Garnaat http://garnaat.org/</span></td>
-      </tr>
-      <tr>
-        <td id="L2" class="blob-num js-line-number" data-line-number="2"></td>
-        <td id="LC2" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> Copyright (c) 2010, Eucalyptus Systems, Inc.</span></td>
-      </tr>
-      <tr>
-        <td id="L3" class="blob-num js-line-number" data-line-number="3"></td>
-        <td id="LC3" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> All rights reserved.</span></td>
-      </tr>
-      <tr>
-        <td id="L4" class="blob-num js-line-number" data-line-number="4"></td>
-        <td id="LC4" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span></span></td>
-      </tr>
-      <tr>
-        <td id="L5" class="blob-num js-line-number" data-line-number="5"></td>
-        <td id="LC5" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> Permission is hereby granted, free of charge, to any person obtaining a</span></td>
-      </tr>
-      <tr>
-        <td id="L6" class="blob-num js-line-number" data-line-number="6"></td>
-        <td id="LC6" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> copy of this software and associated documentation files (the</span></td>
-      </tr>
-      <tr>
-        <td id="L7" class="blob-num js-line-number" data-line-number="7"></td>
-        <td id="LC7" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> &quot;Software&quot;), to deal in the Software without restriction, including</span></td>
-      </tr>
-      <tr>
-        <td id="L8" class="blob-num js-line-number" data-line-number="8"></td>
-        <td id="LC8" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> without limitation the rights to use, copy, modify, merge, publish, dis-</span></td>
-      </tr>
-      <tr>
-        <td id="L9" class="blob-num js-line-number" data-line-number="9"></td>
-        <td id="LC9" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> tribute, sublicense, and/or sell copies of the Software, and to permit</span></td>
-      </tr>
-      <tr>
-        <td id="L10" class="blob-num js-line-number" data-line-number="10"></td>
-        <td id="LC10" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> persons to whom the Software is furnished to do so, subject to the fol-</span></td>
-      </tr>
-      <tr>
-        <td id="L11" class="blob-num js-line-number" data-line-number="11"></td>
-        <td id="LC11" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> lowing conditions:</span></td>
-      </tr>
-      <tr>
-        <td id="L12" class="blob-num js-line-number" data-line-number="12"></td>
-        <td id="LC12" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span></span></td>
-      </tr>
-      <tr>
-        <td id="L13" class="blob-num js-line-number" data-line-number="13"></td>
-        <td id="LC13" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> The above copyright notice and this permission notice shall be included</span></td>
-      </tr>
-      <tr>
-        <td id="L14" class="blob-num js-line-number" data-line-number="14"></td>
-        <td id="LC14" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> in all copies or substantial portions of the Software.</span></td>
-      </tr>
-      <tr>
-        <td id="L15" class="blob-num js-line-number" data-line-number="15"></td>
-        <td id="LC15" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span></span></td>
-      </tr>
-      <tr>
-        <td id="L16" class="blob-num js-line-number" data-line-number="16"></td>
-        <td id="LC16" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS</span></td>
-      </tr>
-      <tr>
-        <td id="L17" class="blob-num js-line-number" data-line-number="17"></td>
-        <td id="LC17" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-</span></td>
-      </tr>
-      <tr>
-        <td id="L18" class="blob-num js-line-number" data-line-number="18"></td>
-        <td id="LC18" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT</span></td>
-      </tr>
-      <tr>
-        <td id="L19" class="blob-num js-line-number" data-line-number="19"></td>
-        <td id="LC19" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,</span></td>
-      </tr>
-      <tr>
-        <td id="L20" class="blob-num js-line-number" data-line-number="20"></td>
-        <td id="LC20" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,</span></td>
-      </tr>
-      <tr>
-        <td id="L21" class="blob-num js-line-number" data-line-number="21"></td>
-        <td id="LC21" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS</span></td>
-      </tr>
-      <tr>
-        <td id="L22" class="blob-num js-line-number" data-line-number="22"></td>
-        <td id="LC22" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> IN THE SOFTWARE.</span></td>
-      </tr>
-      <tr>
-        <td id="L23" class="blob-num js-line-number" data-line-number="23"></td>
-        <td id="LC23" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L24" class="blob-num js-line-number" data-line-number="24"></td>
-        <td id="LC24" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> <span class="pl-c1">__future__</span> <span class="pl-k">import</span> division</td>
-      </tr>
-      <tr>
-        <td id="L25" class="blob-num js-line-number" data-line-number="25"></td>
-        <td id="LC25" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L26" class="blob-num js-line-number" data-line-number="26"></td>
-        <td id="LC26" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> boto</td>
-      </tr>
-      <tr>
-        <td id="L27" class="blob-num js-line-number" data-line-number="27"></td>
-        <td id="LC27" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto <span class="pl-k">import</span> handler</td>
-      </tr>
-      <tr>
-        <td id="L28" class="blob-num js-line-number" data-line-number="28"></td>
-        <td id="LC28" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.resultset <span class="pl-k">import</span> ResultSet</td>
-      </tr>
-      <tr>
-        <td id="L29" class="blob-num js-line-number" data-line-number="29"></td>
-        <td id="LC29" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.exception <span class="pl-k">import</span> BotoClientError</td>
-      </tr>
-      <tr>
-        <td id="L30" class="blob-num js-line-number" data-line-number="30"></td>
-        <td id="LC30" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.acl <span class="pl-k">import</span> Policy, CannedACLStrings, Grant</td>
-      </tr>
-      <tr>
-        <td id="L31" class="blob-num js-line-number" data-line-number="31"></td>
-        <td id="LC31" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.key <span class="pl-k">import</span> Key</td>
-      </tr>
-      <tr>
-        <td id="L32" class="blob-num js-line-number" data-line-number="32"></td>
-        <td id="LC32" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.prefix <span class="pl-k">import</span> Prefix</td>
-      </tr>
-      <tr>
-        <td id="L33" class="blob-num js-line-number" data-line-number="33"></td>
-        <td id="LC33" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.deletemarker <span class="pl-k">import</span> DeleteMarker</td>
-      </tr>
-      <tr>
-        <td id="L34" class="blob-num js-line-number" data-line-number="34"></td>
-        <td id="LC34" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.multipart <span class="pl-k">import</span> MultiPartUpload</td>
-      </tr>
-      <tr>
-        <td id="L35" class="blob-num js-line-number" data-line-number="35"></td>
-        <td id="LC35" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.multipart <span class="pl-k">import</span> CompleteMultiPartUpload</td>
-      </tr>
-      <tr>
-        <td id="L36" class="blob-num js-line-number" data-line-number="36"></td>
-        <td id="LC36" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.multidelete <span class="pl-k">import</span> MultiDeleteResult</td>
-      </tr>
-      <tr>
-        <td id="L37" class="blob-num js-line-number" data-line-number="37"></td>
-        <td id="LC37" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.multidelete <span class="pl-k">import</span> Error</td>
-      </tr>
-      <tr>
-        <td id="L38" class="blob-num js-line-number" data-line-number="38"></td>
-        <td id="LC38" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.bucketlistresultset <span class="pl-k">import</span> BucketListResultSet</td>
-      </tr>
-      <tr>
-        <td id="L39" class="blob-num js-line-number" data-line-number="39"></td>
-        <td id="LC39" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.bucketlistresultset <span class="pl-k">import</span> VersionedBucketListResultSet</td>
-      </tr>
-      <tr>
-        <td id="L40" class="blob-num js-line-number" data-line-number="40"></td>
-        <td id="LC40" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.bucketlistresultset <span class="pl-k">import</span> MultiPartUploadListResultSet</td>
-      </tr>
-      <tr>
-        <td id="L41" class="blob-num js-line-number" data-line-number="41"></td>
-        <td id="LC41" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.lifecycle <span class="pl-k">import</span> Lifecycle</td>
-      </tr>
-      <tr>
-        <td id="L42" class="blob-num js-line-number" data-line-number="42"></td>
-        <td id="LC42" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.tagging <span class="pl-k">import</span> Tags</td>
-      </tr>
-      <tr>
-        <td id="L43" class="blob-num js-line-number" data-line-number="43"></td>
-        <td id="LC43" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.cors <span class="pl-k">import</span> CORSConfiguration</td>
-      </tr>
-      <tr>
-        <td id="L44" class="blob-num js-line-number" data-line-number="44"></td>
-        <td id="LC44" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3.bucketlogging <span class="pl-k">import</span> BucketLogging</td>
-      </tr>
-      <tr>
-        <td id="L45" class="blob-num js-line-number" data-line-number="45"></td>
-        <td id="LC45" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.s3 <span class="pl-k">import</span> website</td>
-      </tr>
-      <tr>
-        <td id="L46" class="blob-num js-line-number" data-line-number="46"></td>
-        <td id="LC46" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> boto.jsonresponse</td>
-      </tr>
-      <tr>
-        <td id="L47" class="blob-num js-line-number" data-line-number="47"></td>
-        <td id="LC47" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> boto.utils</td>
-      </tr>
-      <tr>
-        <td id="L48" class="blob-num js-line-number" data-line-number="48"></td>
-        <td id="LC48" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> xml.sax</td>
-      </tr>
-      <tr>
-        <td id="L49" class="blob-num js-line-number" data-line-number="49"></td>
-        <td id="LC49" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> xml.sax.saxutils</td>
-      </tr>
-      <tr>
-        <td id="L50" class="blob-num js-line-number" data-line-number="50"></td>
-        <td id="LC50" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> re</td>
-      </tr>
-      <tr>
-        <td id="L51" class="blob-num js-line-number" data-line-number="51"></td>
-        <td id="LC51" class="blob-code blob-code-inner js-file-line"><span class="pl-k">import</span> base64</td>
-      </tr>
-      <tr>
-        <td id="L52" class="blob-num js-line-number" data-line-number="52"></td>
-        <td id="LC52" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> collections <span class="pl-k">import</span> defaultdict</td>
-      </tr>
-      <tr>
-        <td id="L53" class="blob-num js-line-number" data-line-number="53"></td>
-        <td id="LC53" class="blob-code blob-code-inner js-file-line"><span class="pl-k">from</span> boto.compat <span class="pl-k">import</span> BytesIO, six, StringIO, urllib</td>
-      </tr>
-      <tr>
-        <td id="L54" class="blob-num js-line-number" data-line-number="54"></td>
-        <td id="LC54" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L55" class="blob-num js-line-number" data-line-number="55"></td>
-        <td id="LC55" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> as per http://goo.gl/BDuud (02/19/2011)</span></td>
-      </tr>
-      <tr>
-        <td id="L56" class="blob-num js-line-number" data-line-number="56"></td>
-        <td id="LC56" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L57" class="blob-num js-line-number" data-line-number="57"></td>
-        <td id="LC57" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L58" class="blob-num js-line-number" data-line-number="58"></td>
-        <td id="LC58" class="blob-code blob-code-inner js-file-line"><span class="pl-k">class</span> <span class="pl-en">S3WebsiteEndpointTranslate</span>(<span class="pl-c1">object</span>):</td>
-      </tr>
-      <tr>
-        <td id="L59" class="blob-num js-line-number" data-line-number="59"></td>
-        <td id="LC59" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L60" class="blob-num js-line-number" data-line-number="60"></td>
-        <td id="LC60" class="blob-code blob-code-inner js-file-line">    trans_region <span class="pl-k">=</span> defaultdict(<span class="pl-k">lambda</span>: <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-us-east-1<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L61" class="blob-num js-line-number" data-line-number="61"></td>
-        <td id="LC61" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>eu-west-1<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-eu-west-1<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L62" class="blob-num js-line-number" data-line-number="62"></td>
-        <td id="LC62" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>eu-central-1<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website.eu-central-1<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L63" class="blob-num js-line-number" data-line-number="63"></td>
-        <td id="LC63" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>us-west-1<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-us-west-1<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L64" class="blob-num js-line-number" data-line-number="64"></td>
-        <td id="LC64" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>us-west-2<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-us-west-2<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L65" class="blob-num js-line-number" data-line-number="65"></td>
-        <td id="LC65" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>sa-east-1<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-sa-east-1<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L66" class="blob-num js-line-number" data-line-number="66"></td>
-        <td id="LC66" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>ap-northeast-1<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-ap-northeast-1<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L67" class="blob-num js-line-number" data-line-number="67"></td>
-        <td id="LC67" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>ap-southeast-1<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-ap-southeast-1<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L68" class="blob-num js-line-number" data-line-number="68"></td>
-        <td id="LC68" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>ap-southeast-2<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website-ap-southeast-2<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L69" class="blob-num js-line-number" data-line-number="69"></td>
-        <td id="LC69" class="blob-code blob-code-inner js-file-line">    trans_region[<span class="pl-s"><span class="pl-pds">&#39;</span>cn-north-1<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>s3-website.cn-north-1<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L70" class="blob-num js-line-number" data-line-number="70"></td>
-        <td id="LC70" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L71" class="blob-num js-line-number" data-line-number="71"></td>
-        <td id="LC71" class="blob-code blob-code-inner js-file-line">    <span class="pl-en">@</span><span class="pl-c1">classmethod</span></td>
-      </tr>
-      <tr>
-        <td id="L72" class="blob-num js-line-number" data-line-number="72"></td>
-        <td id="LC72" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">translate_region</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">reg</span>):</td>
-      </tr>
-      <tr>
-        <td id="L73" class="blob-num js-line-number" data-line-number="73"></td>
-        <td id="LC73" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.trans_region[reg]</td>
-      </tr>
-      <tr>
-        <td id="L74" class="blob-num js-line-number" data-line-number="74"></td>
-        <td id="LC74" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L75" class="blob-num js-line-number" data-line-number="75"></td>
-        <td id="LC75" class="blob-code blob-code-inner js-file-line">S3Permissions <span class="pl-k">=</span> [<span class="pl-s"><span class="pl-pds">&#39;</span>READ<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>WRITE<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>READ_ACP<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>WRITE_ACP<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>FULL_CONTROL<span class="pl-pds">&#39;</span></span>]</td>
-      </tr>
-      <tr>
-        <td id="L76" class="blob-num js-line-number" data-line-number="76"></td>
-        <td id="LC76" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L77" class="blob-num js-line-number" data-line-number="77"></td>
-        <td id="LC77" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L78" class="blob-num js-line-number" data-line-number="78"></td>
-        <td id="LC78" class="blob-code blob-code-inner js-file-line"><span class="pl-k">class</span> <span class="pl-en">Bucket</span>(<span class="pl-c1">object</span>):</td>
-      </tr>
-      <tr>
-        <td id="L79" class="blob-num js-line-number" data-line-number="79"></td>
-        <td id="LC79" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L80" class="blob-num js-line-number" data-line-number="80"></td>
-        <td id="LC80" class="blob-code blob-code-inner js-file-line">    LoggingGroup <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>http://acs.amazonaws.com/groups/s3/LogDelivery<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L81" class="blob-num js-line-number" data-line-number="81"></td>
-        <td id="LC81" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L82" class="blob-num js-line-number" data-line-number="82"></td>
-        <td id="LC82" class="blob-code blob-code-inner js-file-line">    BucketPaymentBody <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;</span></td>
-      </tr>
-      <tr>
-        <td id="L83" class="blob-num js-line-number" data-line-number="83"></td>
-        <td id="LC83" class="blob-code blob-code-inner js-file-line"><span class="pl-s">       &lt;RequestPaymentConfiguration xmlns=&quot;http://s3.amazonaws.com/doc/2006-03-01/&quot;&gt;</span></td>
-      </tr>
-      <tr>
-        <td id="L84" class="blob-num js-line-number" data-line-number="84"></td>
-        <td id="LC84" class="blob-code blob-code-inner js-file-line"><span class="pl-s">         &lt;Payer&gt;<span class="pl-c1">%s</span>&lt;/Payer&gt;</span></td>
-      </tr>
-      <tr>
-        <td id="L85" class="blob-num js-line-number" data-line-number="85"></td>
-        <td id="LC85" class="blob-code blob-code-inner js-file-line"><span class="pl-s">       &lt;/RequestPaymentConfiguration&gt;<span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L86" class="blob-num js-line-number" data-line-number="86"></td>
-        <td id="LC86" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L87" class="blob-num js-line-number" data-line-number="87"></td>
-        <td id="LC87" class="blob-code blob-code-inner js-file-line">    VersioningBody <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;</span></td>
-      </tr>
-      <tr>
-        <td id="L88" class="blob-num js-line-number" data-line-number="88"></td>
-        <td id="LC88" class="blob-code blob-code-inner js-file-line"><span class="pl-s">       &lt;VersioningConfiguration xmlns=&quot;http://s3.amazonaws.com/doc/2006-03-01/&quot;&gt;</span></td>
-      </tr>
-      <tr>
-        <td id="L89" class="blob-num js-line-number" data-line-number="89"></td>
-        <td id="LC89" class="blob-code blob-code-inner js-file-line"><span class="pl-s">         &lt;Status&gt;<span class="pl-c1">%s</span>&lt;/Status&gt;</span></td>
-      </tr>
-      <tr>
-        <td id="L90" class="blob-num js-line-number" data-line-number="90"></td>
-        <td id="LC90" class="blob-code blob-code-inner js-file-line"><span class="pl-s">         &lt;MfaDelete&gt;<span class="pl-c1">%s</span>&lt;/MfaDelete&gt;</span></td>
-      </tr>
-      <tr>
-        <td id="L91" class="blob-num js-line-number" data-line-number="91"></td>
-        <td id="LC91" class="blob-code blob-code-inner js-file-line"><span class="pl-s">       &lt;/VersioningConfiguration&gt;<span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L92" class="blob-num js-line-number" data-line-number="92"></td>
-        <td id="LC92" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L93" class="blob-num js-line-number" data-line-number="93"></td>
-        <td id="LC93" class="blob-code blob-code-inner js-file-line">    VersionRE <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&lt;Status&gt;([A-Za-z]+)&lt;/Status&gt;<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L94" class="blob-num js-line-number" data-line-number="94"></td>
-        <td id="LC94" class="blob-code blob-code-inner js-file-line">    MFADeleteRE <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&lt;MfaDelete&gt;([A-Za-z]+)&lt;/MfaDelete&gt;<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L95" class="blob-num js-line-number" data-line-number="95"></td>
-        <td id="LC95" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L96" class="blob-num js-line-number" data-line-number="96"></td>
-        <td id="LC96" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-c1">__init__</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">connection</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">name</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">key_class</span><span class="pl-k">=</span>Key):</td>
-      </tr>
-      <tr>
-        <td id="L97" class="blob-num js-line-number" data-line-number="97"></td>
-        <td id="LC97" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.name <span class="pl-k">=</span> name</td>
-      </tr>
-      <tr>
-        <td id="L98" class="blob-num js-line-number" data-line-number="98"></td>
-        <td id="LC98" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.connection <span class="pl-k">=</span> connection</td>
-      </tr>
-      <tr>
-        <td id="L99" class="blob-num js-line-number" data-line-number="99"></td>
-        <td id="LC99" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.key_class <span class="pl-k">=</span> key_class</td>
-      </tr>
-      <tr>
-        <td id="L100" class="blob-num js-line-number" data-line-number="100"></td>
-        <td id="LC100" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L101" class="blob-num js-line-number" data-line-number="101"></td>
-        <td id="LC101" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-c1">__repr__</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>):</td>
-      </tr>
-      <tr>
-        <td id="L102" class="blob-num js-line-number" data-line-number="102"></td>
-        <td id="LC102" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&lt;Bucket: <span class="pl-c1">%s</span>&gt;<span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> <span class="pl-c1">self</span>.name</td>
-      </tr>
-      <tr>
-        <td id="L103" class="blob-num js-line-number" data-line-number="103"></td>
-        <td id="LC103" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L104" class="blob-num js-line-number" data-line-number="104"></td>
-        <td id="LC104" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-c1">__iter__</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>):</td>
-      </tr>
-      <tr>
-        <td id="L105" class="blob-num js-line-number" data-line-number="105"></td>
-        <td id="LC105" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">iter</span>(BucketListResultSet(<span class="pl-c1">self</span>))</td>
-      </tr>
-      <tr>
-        <td id="L106" class="blob-num js-line-number" data-line-number="106"></td>
-        <td id="LC106" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L107" class="blob-num js-line-number" data-line-number="107"></td>
-        <td id="LC107" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-c1">__contains__</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>):</td>
-      </tr>
-      <tr>
-        <td id="L108" class="blob-num js-line-number" data-line-number="108"></td>
-        <td id="LC108" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-k">not</span> (<span class="pl-c1">self</span>.get_key(key_name) <span class="pl-k">is</span> <span class="pl-c1">None</span>)</td>
-      </tr>
-      <tr>
-        <td id="L109" class="blob-num js-line-number" data-line-number="109"></td>
-        <td id="LC109" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L110" class="blob-num js-line-number" data-line-number="110"></td>
-        <td id="LC110" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">startElement</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">name</span>, <span class="pl-smi">attrs</span>, <span class="pl-smi">connection</span>):</td>
-      </tr>
-      <tr>
-        <td id="L111" class="blob-num js-line-number" data-line-number="111"></td>
-        <td id="LC111" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">None</span></td>
-      </tr>
-      <tr>
-        <td id="L112" class="blob-num js-line-number" data-line-number="112"></td>
-        <td id="LC112" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L113" class="blob-num js-line-number" data-line-number="113"></td>
-        <td id="LC113" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">endElement</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">name</span>, <span class="pl-smi">value</span>, <span class="pl-smi">connection</span>):</td>
-      </tr>
-      <tr>
-        <td id="L114" class="blob-num js-line-number" data-line-number="114"></td>
-        <td id="LC114" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> name <span class="pl-k">==</span> <span class="pl-s"><span class="pl-pds">&#39;</span>Name<span class="pl-pds">&#39;</span></span>:</td>
-      </tr>
-      <tr>
-        <td id="L115" class="blob-num js-line-number" data-line-number="115"></td>
-        <td id="LC115" class="blob-code blob-code-inner js-file-line">            <span class="pl-c1">self</span>.name <span class="pl-k">=</span> value</td>
-      </tr>
-      <tr>
-        <td id="L116" class="blob-num js-line-number" data-line-number="116"></td>
-        <td id="LC116" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">elif</span> name <span class="pl-k">==</span> <span class="pl-s"><span class="pl-pds">&#39;</span>CreationDate<span class="pl-pds">&#39;</span></span>:</td>
-      </tr>
-      <tr>
-        <td id="L117" class="blob-num js-line-number" data-line-number="117"></td>
-        <td id="LC117" class="blob-code blob-code-inner js-file-line">            <span class="pl-c1">self</span>.creation_date <span class="pl-k">=</span> value</td>
-      </tr>
-      <tr>
-        <td id="L118" class="blob-num js-line-number" data-line-number="118"></td>
-        <td id="LC118" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L119" class="blob-num js-line-number" data-line-number="119"></td>
-        <td id="LC119" class="blob-code blob-code-inner js-file-line">            <span class="pl-c1">setattr</span>(<span class="pl-c1">self</span>, name, value)</td>
-      </tr>
-      <tr>
-        <td id="L120" class="blob-num js-line-number" data-line-number="120"></td>
-        <td id="LC120" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L121" class="blob-num js-line-number" data-line-number="121"></td>
-        <td id="LC121" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_key_class</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_class</span>):</td>
-      </tr>
-      <tr>
-        <td id="L122" class="blob-num js-line-number" data-line-number="122"></td>
-        <td id="LC122" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L123" class="blob-num js-line-number" data-line-number="123"></td>
-        <td id="LC123" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Set the Key class associated with this bucket.  By default, this</span></td>
-      </tr>
-      <tr>
-        <td id="L124" class="blob-num js-line-number" data-line-number="124"></td>
-        <td id="LC124" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        would be the boto.s3.key.Key class but if you want to subclass that</span></td>
-      </tr>
-      <tr>
-        <td id="L125" class="blob-num js-line-number" data-line-number="125"></td>
-        <td id="LC125" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        for some reason this allows you to associate your new class with a</span></td>
-      </tr>
-      <tr>
-        <td id="L126" class="blob-num js-line-number" data-line-number="126"></td>
-        <td id="LC126" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        bucket so that when you call bucket.new_key() or when you get a listing</span></td>
-      </tr>
-      <tr>
-        <td id="L127" class="blob-num js-line-number" data-line-number="127"></td>
-        <td id="LC127" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        of keys in the bucket you will get an instances of your key class</span></td>
-      </tr>
-      <tr>
-        <td id="L128" class="blob-num js-line-number" data-line-number="128"></td>
-        <td id="LC128" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        rather than the default.</span></td>
-      </tr>
-      <tr>
-        <td id="L129" class="blob-num js-line-number" data-line-number="129"></td>
-        <td id="LC129" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L130" class="blob-num js-line-number" data-line-number="130"></td>
-        <td id="LC130" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_class: class</span></td>
-      </tr>
-      <tr>
-        <td id="L131" class="blob-num js-line-number" data-line-number="131"></td>
-        <td id="LC131" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_class: A subclass of Key that can be more specific</span></td>
-      </tr>
-      <tr>
-        <td id="L132" class="blob-num js-line-number" data-line-number="132"></td>
-        <td id="LC132" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L133" class="blob-num js-line-number" data-line-number="133"></td>
-        <td id="LC133" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.key_class <span class="pl-k">=</span> key_class</td>
-      </tr>
-      <tr>
-        <td id="L134" class="blob-num js-line-number" data-line-number="134"></td>
-        <td id="LC134" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L135" class="blob-num js-line-number" data-line-number="135"></td>
-        <td id="LC135" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">lookup</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L136" class="blob-num js-line-number" data-line-number="136"></td>
-        <td id="LC136" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L137" class="blob-num js-line-number" data-line-number="137"></td>
-        <td id="LC137" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Deprecated: Please use get_key method.</span></td>
-      </tr>
-      <tr>
-        <td id="L138" class="blob-num js-line-number" data-line-number="138"></td>
-        <td id="LC138" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L139" class="blob-num js-line-number" data-line-number="139"></td>
-        <td id="LC139" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_name: string</span></td>
-      </tr>
-      <tr>
-        <td id="L140" class="blob-num js-line-number" data-line-number="140"></td>
-        <td id="LC140" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_name: The name of the key to retrieve</span></td>
-      </tr>
-      <tr>
-        <td id="L141" class="blob-num js-line-number" data-line-number="141"></td>
-        <td id="LC141" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L142" class="blob-num js-line-number" data-line-number="142"></td>
-        <td id="LC142" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.key.Key`</span></td>
-      </tr>
-      <tr>
-        <td id="L143" class="blob-num js-line-number" data-line-number="143"></td>
-        <td id="LC143" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: A Key object from this bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L144" class="blob-num js-line-number" data-line-number="144"></td>
-        <td id="LC144" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L145" class="blob-num js-line-number" data-line-number="145"></td>
-        <td id="LC145" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.get_key(key_name, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L146" class="blob-num js-line-number" data-line-number="146"></td>
-        <td id="LC146" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L147" class="blob-num js-line-number" data-line-number="147"></td>
-        <td id="LC147" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_key</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
-      </tr>
-      <tr>
-        <td id="L148" class="blob-num js-line-number" data-line-number="148"></td>
-        <td id="LC148" class="blob-code blob-code-inner js-file-line">                <span class="pl-smi">response_headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">validate</span><span class="pl-k">=</span><span class="pl-c1">True</span>):</td>
-      </tr>
-      <tr>
-        <td id="L149" class="blob-num js-line-number" data-line-number="149"></td>
-        <td id="LC149" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L150" class="blob-num js-line-number" data-line-number="150"></td>
-        <td id="LC150" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Check to see if a particular key exists within the bucket.  This</span></td>
-      </tr>
-      <tr>
-        <td id="L151" class="blob-num js-line-number" data-line-number="151"></td>
-        <td id="LC151" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        method uses a HEAD request to check for the existence of the key.</span></td>
-      </tr>
-      <tr>
-        <td id="L152" class="blob-num js-line-number" data-line-number="152"></td>
-        <td id="LC152" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns: An instance of a Key object or None</span></td>
-      </tr>
-      <tr>
-        <td id="L153" class="blob-num js-line-number" data-line-number="153"></td>
-        <td id="LC153" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L154" class="blob-num js-line-number" data-line-number="154"></td>
-        <td id="LC154" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_name: The name of the key to retrieve</span></td>
-      </tr>
-      <tr>
-        <td id="L155" class="blob-num js-line-number" data-line-number="155"></td>
-        <td id="LC155" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_name: string</span></td>
-      </tr>
-      <tr>
-        <td id="L156" class="blob-num js-line-number" data-line-number="156"></td>
-        <td id="LC156" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L157" class="blob-num js-line-number" data-line-number="157"></td>
-        <td id="LC157" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param headers: The headers to send when retrieving the key</span></td>
-      </tr>
-      <tr>
-        <td id="L158" class="blob-num js-line-number" data-line-number="158"></td>
-        <td id="LC158" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type headers: dict</span></td>
-      </tr>
-      <tr>
-        <td id="L159" class="blob-num js-line-number" data-line-number="159"></td>
-        <td id="LC159" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L160" class="blob-num js-line-number" data-line-number="160"></td>
-        <td id="LC160" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param version_id:</span></td>
-      </tr>
-      <tr>
-        <td id="L161" class="blob-num js-line-number" data-line-number="161"></td>
-        <td id="LC161" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type version_id: string</span></td>
-      </tr>
-      <tr>
-        <td id="L162" class="blob-num js-line-number" data-line-number="162"></td>
-        <td id="LC162" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L163" class="blob-num js-line-number" data-line-number="163"></td>
-        <td id="LC163" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param response_headers: A dictionary containing HTTP</span></td>
-      </tr>
-      <tr>
-        <td id="L164" class="blob-num js-line-number" data-line-number="164"></td>
-        <td id="LC164" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            headers/values that will override any headers associated</span></td>
-      </tr>
-      <tr>
-        <td id="L165" class="blob-num js-line-number" data-line-number="165"></td>
-        <td id="LC165" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            with the stored object in the response.  See</span></td>
-      </tr>
-      <tr>
-        <td id="L166" class="blob-num js-line-number" data-line-number="166"></td>
-        <td id="LC166" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            http://goo.gl/EWOPb for details.</span></td>
-      </tr>
-      <tr>
-        <td id="L167" class="blob-num js-line-number" data-line-number="167"></td>
-        <td id="LC167" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type response_headers: dict</span></td>
-      </tr>
-      <tr>
-        <td id="L168" class="blob-num js-line-number" data-line-number="168"></td>
-        <td id="LC168" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L169" class="blob-num js-line-number" data-line-number="169"></td>
-        <td id="LC169" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param validate: Verifies whether the key exists. If ``False``, this</span></td>
-      </tr>
-      <tr>
-        <td id="L170" class="blob-num js-line-number" data-line-number="170"></td>
-        <td id="LC170" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            will not hit the service, constructing an in-memory object.</span></td>
-      </tr>
-      <tr>
-        <td id="L171" class="blob-num js-line-number" data-line-number="171"></td>
-        <td id="LC171" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Default is ``True``.</span></td>
-      </tr>
-      <tr>
-        <td id="L172" class="blob-num js-line-number" data-line-number="172"></td>
-        <td id="LC172" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type validate: bool</span></td>
-      </tr>
-      <tr>
-        <td id="L173" class="blob-num js-line-number" data-line-number="173"></td>
-        <td id="LC173" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L174" class="blob-num js-line-number" data-line-number="174"></td>
-        <td id="LC174" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.key.Key`</span></td>
-      </tr>
-      <tr>
-        <td id="L175" class="blob-num js-line-number" data-line-number="175"></td>
-        <td id="LC175" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: A Key object from this bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L176" class="blob-num js-line-number" data-line-number="176"></td>
-        <td id="LC176" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L177" class="blob-num js-line-number" data-line-number="177"></td>
-        <td id="LC177" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> validate <span class="pl-k">is</span> <span class="pl-c1">False</span>:</td>
-      </tr>
-      <tr>
-        <td id="L178" class="blob-num js-line-number" data-line-number="178"></td>
-        <td id="LC178" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> headers <span class="pl-k">or</span> version_id <span class="pl-k">or</span> response_headers:</td>
-      </tr>
-      <tr>
-        <td id="L179" class="blob-num js-line-number" data-line-number="179"></td>
-        <td id="LC179" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">raise</span> BotoClientError(</td>
-      </tr>
-      <tr>
-        <td id="L180" class="blob-num js-line-number" data-line-number="180"></td>
-        <td id="LC180" class="blob-code blob-code-inner js-file-line">                    <span class="pl-s"><span class="pl-pds">&quot;</span>When providing &#39;validate=False&#39;, no other params <span class="pl-pds">&quot;</span></span> <span class="pl-k">+</span> \</td>
-      </tr>
-      <tr>
-        <td id="L181" class="blob-num js-line-number" data-line-number="181"></td>
-        <td id="LC181" class="blob-code blob-code-inner js-file-line">                    <span class="pl-s"><span class="pl-pds">&quot;</span>are allowed.<span class="pl-pds">&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L182" class="blob-num js-line-number" data-line-number="182"></td>
-        <td id="LC182" class="blob-code blob-code-inner js-file-line">                )</td>
-      </tr>
-      <tr>
-        <td id="L183" class="blob-num js-line-number" data-line-number="183"></td>
-        <td id="LC183" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L184" class="blob-num js-line-number" data-line-number="184"></td>
-        <td id="LC184" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> This leans on the default behavior of ``new_key`` (not hitting</span></td>
-      </tr>
-      <tr>
-        <td id="L185" class="blob-num js-line-number" data-line-number="185"></td>
-        <td id="LC185" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> the service). If that changes, that behavior should migrate here.</span></td>
-      </tr>
-      <tr>
-        <td id="L186" class="blob-num js-line-number" data-line-number="186"></td>
-        <td id="LC186" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">self</span>.new_key(key_name)</td>
-      </tr>
-      <tr>
-        <td id="L187" class="blob-num js-line-number" data-line-number="187"></td>
-        <td id="LC187" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L188" class="blob-num js-line-number" data-line-number="188"></td>
-        <td id="LC188" class="blob-code blob-code-inner js-file-line">        query_args_l <span class="pl-k">=</span> []</td>
-      </tr>
-      <tr>
-        <td id="L189" class="blob-num js-line-number" data-line-number="189"></td>
-        <td id="LC189" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
-      </tr>
-      <tr>
-        <td id="L190" class="blob-num js-line-number" data-line-number="190"></td>
-        <td id="LC190" class="blob-code blob-code-inner js-file-line">            query_args_l.append(<span class="pl-s"><span class="pl-pds">&#39;</span>versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id)</td>
-      </tr>
-      <tr>
-        <td id="L191" class="blob-num js-line-number" data-line-number="191"></td>
-        <td id="LC191" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response_headers:</td>
-      </tr>
-      <tr>
-        <td id="L192" class="blob-num js-line-number" data-line-number="192"></td>
-        <td id="LC192" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">for</span> rk, rv <span class="pl-k">in</span> six.iteritems(response_headers):</td>
-      </tr>
-      <tr>
-        <td id="L193" class="blob-num js-line-number" data-line-number="193"></td>
-        <td id="LC193" class="blob-code blob-code-inner js-file-line">                query_args_l.append(<span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-c1">%s</span>=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> (rk, urllib.parse.quote(rv)))</td>
-      </tr>
-      <tr>
-        <td id="L194" class="blob-num js-line-number" data-line-number="194"></td>
-        <td id="LC194" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L195" class="blob-num js-line-number" data-line-number="195"></td>
-        <td id="LC195" class="blob-code blob-code-inner js-file-line">        key, resp <span class="pl-k">=</span> <span class="pl-c1">self</span>._get_key_internal(key_name, headers, query_args_l)</td>
-      </tr>
-      <tr>
-        <td id="L196" class="blob-num js-line-number" data-line-number="196"></td>
-        <td id="LC196" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> key</td>
-      </tr>
-      <tr>
-        <td id="L197" class="blob-num js-line-number" data-line-number="197"></td>
-        <td id="LC197" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L198" class="blob-num js-line-number" data-line-number="198"></td>
-        <td id="LC198" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">_get_key_internal</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">headers</span>, <span class="pl-smi">query_args_l</span>):</td>
-      </tr>
-      <tr>
-        <td id="L199" class="blob-num js-line-number" data-line-number="199"></td>
-        <td id="LC199" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;<span class="pl-pds">&#39;</span></span>.join(query_args_l) <span class="pl-k">or</span> <span class="pl-c1">None</span></td>
-      </tr>
-      <tr>
-        <td id="L200" class="blob-num js-line-number" data-line-number="200"></td>
-        <td id="LC200" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>HEAD<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
-      </tr>
-      <tr>
-        <td id="L201" class="blob-num js-line-number" data-line-number="201"></td>
-        <td id="LC201" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
-      </tr>
-      <tr>
-        <td id="L202" class="blob-num js-line-number" data-line-number="202"></td>
-        <td id="LC202" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args)</td>
-      </tr>
-      <tr>
-        <td id="L203" class="blob-num js-line-number" data-line-number="203"></td>
-        <td id="LC203" class="blob-code blob-code-inner js-file-line">        response.read()</td>
-      </tr>
-      <tr>
-        <td id="L204" class="blob-num js-line-number" data-line-number="204"></td>
-        <td id="LC204" class="blob-code blob-code-inner js-file-line">        <span class="pl-c"><span class="pl-c">#</span> Allow any success status (2xx) - for example this lets us</span></td>
-      </tr>
-      <tr>
-        <td id="L205" class="blob-num js-line-number" data-line-number="205"></td>
-        <td id="LC205" class="blob-code blob-code-inner js-file-line">        <span class="pl-c"><span class="pl-c">#</span> support Range gets, which return status 206:</span></td>
-      </tr>
-      <tr>
-        <td id="L206" class="blob-num js-line-number" data-line-number="206"></td>
-        <td id="LC206" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">//</span> <span class="pl-c1">100</span> <span class="pl-k">==</span> <span class="pl-c1">2</span>:</td>
-      </tr>
-      <tr>
-        <td id="L207" class="blob-num js-line-number" data-line-number="207"></td>
-        <td id="LC207" class="blob-code blob-code-inner js-file-line">            k <span class="pl-k">=</span> <span class="pl-c1">self</span>.key_class(<span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L208" class="blob-num js-line-number" data-line-number="208"></td>
-        <td id="LC208" class="blob-code blob-code-inner js-file-line">            provider <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.provider</td>
-      </tr>
-      <tr>
-        <td id="L209" class="blob-num js-line-number" data-line-number="209"></td>
-        <td id="LC209" class="blob-code blob-code-inner js-file-line">            k.metadata <span class="pl-k">=</span> boto.utils.get_aws_metadata(response.msg, provider)</td>
-      </tr>
-      <tr>
-        <td id="L210" class="blob-num js-line-number" data-line-number="210"></td>
-        <td id="LC210" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">for</span> field <span class="pl-k">in</span> Key.base_fields:</td>
-      </tr>
-      <tr>
-        <td id="L211" class="blob-num js-line-number" data-line-number="211"></td>
-        <td id="LC211" class="blob-code blob-code-inner js-file-line">                k.<span class="pl-c1">__dict__</span>[field.lower().replace(<span class="pl-s"><span class="pl-pds">&#39;</span>-<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>_<span class="pl-pds">&#39;</span></span>)] <span class="pl-k">=</span> \</td>
-      </tr>
-      <tr>
-        <td id="L212" class="blob-num js-line-number" data-line-number="212"></td>
-        <td id="LC212" class="blob-code blob-code-inner js-file-line">                    response.getheader(field)</td>
-      </tr>
-      <tr>
-        <td id="L213" class="blob-num js-line-number" data-line-number="213"></td>
-        <td id="LC213" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> the following machinations are a workaround to the fact that</span></td>
-      </tr>
-      <tr>
-        <td id="L214" class="blob-num js-line-number" data-line-number="214"></td>
-        <td id="LC214" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> apache/fastcgi omits the content-length header on HEAD</span></td>
-      </tr>
-      <tr>
-        <td id="L215" class="blob-num js-line-number" data-line-number="215"></td>
-        <td id="LC215" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> requests when the content-length is zero.</span></td>
-      </tr>
-      <tr>
-        <td id="L216" class="blob-num js-line-number" data-line-number="216"></td>
-        <td id="LC216" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> See http://goo.gl/0Tdax for more details.</span></td>
-      </tr>
-      <tr>
-        <td id="L217" class="blob-num js-line-number" data-line-number="217"></td>
-        <td id="LC217" class="blob-code blob-code-inner js-file-line">            clen <span class="pl-k">=</span> response.getheader(<span class="pl-s"><span class="pl-pds">&#39;</span>content-length<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L218" class="blob-num js-line-number" data-line-number="218"></td>
-        <td id="LC218" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> clen:</td>
-      </tr>
-      <tr>
-        <td id="L219" class="blob-num js-line-number" data-line-number="219"></td>
-        <td id="LC219" class="blob-code blob-code-inner js-file-line">                k.size <span class="pl-k">=</span> <span class="pl-c1">int</span>(response.getheader(<span class="pl-s"><span class="pl-pds">&#39;</span>content-length<span class="pl-pds">&#39;</span></span>))</td>
-      </tr>
-      <tr>
-        <td id="L220" class="blob-num js-line-number" data-line-number="220"></td>
-        <td id="LC220" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L221" class="blob-num js-line-number" data-line-number="221"></td>
-        <td id="LC221" class="blob-code blob-code-inner js-file-line">                k.size <span class="pl-k">=</span> <span class="pl-c1">0</span></td>
-      </tr>
-      <tr>
-        <td id="L222" class="blob-num js-line-number" data-line-number="222"></td>
-        <td id="LC222" class="blob-code blob-code-inner js-file-line">            k.name <span class="pl-k">=</span> key_name</td>
-      </tr>
-      <tr>
-        <td id="L223" class="blob-num js-line-number" data-line-number="223"></td>
-        <td id="LC223" class="blob-code blob-code-inner js-file-line">            k.handle_version_headers(response)</td>
-      </tr>
-      <tr>
-        <td id="L224" class="blob-num js-line-number" data-line-number="224"></td>
-        <td id="LC224" class="blob-code blob-code-inner js-file-line">            k.handle_encryption_headers(response)</td>
-      </tr>
-      <tr>
-        <td id="L225" class="blob-num js-line-number" data-line-number="225"></td>
-        <td id="LC225" class="blob-code blob-code-inner js-file-line">            k.handle_restore_headers(response)</td>
-      </tr>
-      <tr>
-        <td id="L226" class="blob-num js-line-number" data-line-number="226"></td>
-        <td id="LC226" class="blob-code blob-code-inner js-file-line">            k.handle_storage_class_header(response)</td>
-      </tr>
-      <tr>
-        <td id="L227" class="blob-num js-line-number" data-line-number="227"></td>
-        <td id="LC227" class="blob-code blob-code-inner js-file-line">            k.handle_addl_headers(response.getheaders())</td>
-      </tr>
-      <tr>
-        <td id="L228" class="blob-num js-line-number" data-line-number="228"></td>
-        <td id="LC228" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> k, response</td>
-      </tr>
-      <tr>
-        <td id="L229" class="blob-num js-line-number" data-line-number="229"></td>
-        <td id="LC229" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L230" class="blob-num js-line-number" data-line-number="230"></td>
-        <td id="LC230" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">404</span>:</td>
-      </tr>
-      <tr>
-        <td id="L231" class="blob-num js-line-number" data-line-number="231"></td>
-        <td id="LC231" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">return</span> <span class="pl-c1">None</span>, response</td>
-      </tr>
-      <tr>
-        <td id="L232" class="blob-num js-line-number" data-line-number="232"></td>
-        <td id="LC232" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L233" class="blob-num js-line-number" data-line-number="233"></td>
-        <td id="LC233" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L234" class="blob-num js-line-number" data-line-number="234"></td>
-        <td id="LC234" class="blob-code blob-code-inner js-file-line">                    response.status, response.reason, <span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L235" class="blob-num js-line-number" data-line-number="235"></td>
-        <td id="LC235" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L236" class="blob-num js-line-number" data-line-number="236"></td>
-        <td id="LC236" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-c1">list</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">prefix</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">delimiter</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">marker</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
-      </tr>
-      <tr>
-        <td id="L237" class="blob-num js-line-number" data-line-number="237"></td>
-        <td id="LC237" class="blob-code blob-code-inner js-file-line">             <span class="pl-smi">encoding_type</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L238" class="blob-num js-line-number" data-line-number="238"></td>
-        <td id="LC238" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L239" class="blob-num js-line-number" data-line-number="239"></td>
-        <td id="LC239" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        List key objects within a bucket.  This returns an instance of an</span></td>
-      </tr>
-      <tr>
-        <td id="L240" class="blob-num js-line-number" data-line-number="240"></td>
-        <td id="LC240" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        BucketListResultSet that automatically handles all of the result</span></td>
-      </tr>
-      <tr>
-        <td id="L241" class="blob-num js-line-number" data-line-number="241"></td>
-        <td id="LC241" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        paging, etc. from S3.  You just need to keep iterating until</span></td>
-      </tr>
-      <tr>
-        <td id="L242" class="blob-num js-line-number" data-line-number="242"></td>
-        <td id="LC242" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        there are no more results.</span></td>
-      </tr>
-      <tr>
-        <td id="L243" class="blob-num js-line-number" data-line-number="243"></td>
-        <td id="LC243" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L244" class="blob-num js-line-number" data-line-number="244"></td>
-        <td id="LC244" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Called with no arguments, this will return an iterator object across</span></td>
-      </tr>
-      <tr>
-        <td id="L245" class="blob-num js-line-number" data-line-number="245"></td>
-        <td id="LC245" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        all keys within the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L246" class="blob-num js-line-number" data-line-number="246"></td>
-        <td id="LC246" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L247" class="blob-num js-line-number" data-line-number="247"></td>
-        <td id="LC247" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        The Key objects returned by the iterator are obtained by parsing</span></td>
-      </tr>
-      <tr>
-        <td id="L248" class="blob-num js-line-number" data-line-number="248"></td>
-        <td id="LC248" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        the results of a GET on the bucket, also known as the List Objects</span></td>
-      </tr>
-      <tr>
-        <td id="L249" class="blob-num js-line-number" data-line-number="249"></td>
-        <td id="LC249" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        request.  The XML returned by this request contains only a subset</span></td>
-      </tr>
-      <tr>
-        <td id="L250" class="blob-num js-line-number" data-line-number="250"></td>
-        <td id="LC250" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        of the information about each key.  Certain metadata fields such</span></td>
-      </tr>
-      <tr>
-        <td id="L251" class="blob-num js-line-number" data-line-number="251"></td>
-        <td id="LC251" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        as Content-Type and user metadata are not available in the XML.</span></td>
-      </tr>
-      <tr>
-        <td id="L252" class="blob-num js-line-number" data-line-number="252"></td>
-        <td id="LC252" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Therefore, if you want these additional metadata fields you will</span></td>
-      </tr>
-      <tr>
-        <td id="L253" class="blob-num js-line-number" data-line-number="253"></td>
-        <td id="LC253" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        have to do a HEAD request on the Key in the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L254" class="blob-num js-line-number" data-line-number="254"></td>
-        <td id="LC254" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L255" class="blob-num js-line-number" data-line-number="255"></td>
-        <td id="LC255" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type prefix: string</span></td>
-      </tr>
-      <tr>
-        <td id="L256" class="blob-num js-line-number" data-line-number="256"></td>
-        <td id="LC256" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param prefix: allows you to limit the listing to a particular</span></td>
-      </tr>
-      <tr>
-        <td id="L257" class="blob-num js-line-number" data-line-number="257"></td>
-        <td id="LC257" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            prefix.  For example, if you call the method with</span></td>
-      </tr>
-      <tr>
-        <td id="L258" class="blob-num js-line-number" data-line-number="258"></td>
-        <td id="LC258" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            prefix=&#39;/foo/&#39; then the iterator will only cycle through</span></td>
-      </tr>
-      <tr>
-        <td id="L259" class="blob-num js-line-number" data-line-number="259"></td>
-        <td id="LC259" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the keys that begin with the string &#39;/foo/&#39;.</span></td>
-      </tr>
-      <tr>
-        <td id="L260" class="blob-num js-line-number" data-line-number="260"></td>
-        <td id="LC260" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L261" class="blob-num js-line-number" data-line-number="261"></td>
-        <td id="LC261" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type delimiter: string</span></td>
-      </tr>
-      <tr>
-        <td id="L262" class="blob-num js-line-number" data-line-number="262"></td>
-        <td id="LC262" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param delimiter: can be used in conjunction with the prefix</span></td>
-      </tr>
-      <tr>
-        <td id="L263" class="blob-num js-line-number" data-line-number="263"></td>
-        <td id="LC263" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            to allow you to organize and browse your keys</span></td>
-      </tr>
-      <tr>
-        <td id="L264" class="blob-num js-line-number" data-line-number="264"></td>
-        <td id="LC264" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            hierarchically. See http://goo.gl/Xx63h for more details.</span></td>
-      </tr>
-      <tr>
-        <td id="L265" class="blob-num js-line-number" data-line-number="265"></td>
-        <td id="LC265" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L266" class="blob-num js-line-number" data-line-number="266"></td>
-        <td id="LC266" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type marker: string</span></td>
-      </tr>
-      <tr>
-        <td id="L267" class="blob-num js-line-number" data-line-number="267"></td>
-        <td id="LC267" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param marker: The &quot;marker&quot; of where you are in the result set</span></td>
-      </tr>
-      <tr>
-        <td id="L268" class="blob-num js-line-number" data-line-number="268"></td>
-        <td id="LC268" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L269" class="blob-num js-line-number" data-line-number="269"></td>
-        <td id="LC269" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encoding_type: Requests Amazon S3 to encode the response and</span></td>
-      </tr>
-      <tr>
-        <td id="L270" class="blob-num js-line-number" data-line-number="270"></td>
-        <td id="LC270" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specifies the encoding method to use.</span></td>
-      </tr>
-      <tr>
-        <td id="L271" class="blob-num js-line-number" data-line-number="271"></td>
-        <td id="LC271" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L272" class="blob-num js-line-number" data-line-number="272"></td>
-        <td id="LC272" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            An object key can contain any Unicode character; however, XML 1.0</span></td>
-      </tr>
-      <tr>
-        <td id="L273" class="blob-num js-line-number" data-line-number="273"></td>
-        <td id="LC273" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parser cannot parse some characters, such as characters with an</span></td>
-      </tr>
-      <tr>
-        <td id="L274" class="blob-num js-line-number" data-line-number="274"></td>
-        <td id="LC274" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ASCII value from 0 to 10. For characters that are not supported in</span></td>
-      </tr>
-      <tr>
-        <td id="L275" class="blob-num js-line-number" data-line-number="275"></td>
-        <td id="LC275" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            XML 1.0, you can add this parameter to request that Amazon S3</span></td>
-      </tr>
-      <tr>
-        <td id="L276" class="blob-num js-line-number" data-line-number="276"></td>
-        <td id="LC276" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            encode the keys in the response.</span></td>
-      </tr>
-      <tr>
-        <td id="L277" class="blob-num js-line-number" data-line-number="277"></td>
-        <td id="LC277" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L278" class="blob-num js-line-number" data-line-number="278"></td>
-        <td id="LC278" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Valid options: ``url``</span></td>
-      </tr>
-      <tr>
-        <td id="L279" class="blob-num js-line-number" data-line-number="279"></td>
-        <td id="LC279" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encoding_type: string</span></td>
-      </tr>
-      <tr>
-        <td id="L280" class="blob-num js-line-number" data-line-number="280"></td>
-        <td id="LC280" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L281" class="blob-num js-line-number" data-line-number="281"></td>
-        <td id="LC281" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.bucketlistresultset.BucketListResultSet`</span></td>
-      </tr>
-      <tr>
-        <td id="L282" class="blob-num js-line-number" data-line-number="282"></td>
-        <td id="LC282" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: an instance of a BucketListResultSet that handles paging, etc</span></td>
-      </tr>
-      <tr>
-        <td id="L283" class="blob-num js-line-number" data-line-number="283"></td>
-        <td id="LC283" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L284" class="blob-num js-line-number" data-line-number="284"></td>
-        <td id="LC284" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> BucketListResultSet(<span class="pl-c1">self</span>, prefix, delimiter, marker, headers,</td>
-      </tr>
-      <tr>
-        <td id="L285" class="blob-num js-line-number" data-line-number="285"></td>
-        <td id="LC285" class="blob-code blob-code-inner js-file-line">                                   <span class="pl-v">encoding_type</span><span class="pl-k">=</span>encoding_type)</td>
-      </tr>
-      <tr>
-        <td id="L286" class="blob-num js-line-number" data-line-number="286"></td>
-        <td id="LC286" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L287" class="blob-num js-line-number" data-line-number="287"></td>
-        <td id="LC287" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">list_versions</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">prefix</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">delimiter</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">key_marker</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L288" class="blob-num js-line-number" data-line-number="288"></td>
-        <td id="LC288" class="blob-code blob-code-inner js-file-line">                      <span class="pl-smi">version_id_marker</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">encoding_type</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L289" class="blob-num js-line-number" data-line-number="289"></td>
-        <td id="LC289" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L290" class="blob-num js-line-number" data-line-number="290"></td>
-        <td id="LC290" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        List version objects within a bucket.  This returns an</span></td>
-      </tr>
-      <tr>
-        <td id="L291" class="blob-num js-line-number" data-line-number="291"></td>
-        <td id="LC291" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        instance of an VersionedBucketListResultSet that automatically</span></td>
-      </tr>
-      <tr>
-        <td id="L292" class="blob-num js-line-number" data-line-number="292"></td>
-        <td id="LC292" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        handles all of the result paging, etc. from S3.  You just need</span></td>
-      </tr>
-      <tr>
-        <td id="L293" class="blob-num js-line-number" data-line-number="293"></td>
-        <td id="LC293" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        to keep iterating until there are no more results.  Called</span></td>
-      </tr>
-      <tr>
-        <td id="L294" class="blob-num js-line-number" data-line-number="294"></td>
-        <td id="LC294" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        with no arguments, this will return an iterator object across</span></td>
-      </tr>
-      <tr>
-        <td id="L295" class="blob-num js-line-number" data-line-number="295"></td>
-        <td id="LC295" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        all keys within the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L296" class="blob-num js-line-number" data-line-number="296"></td>
-        <td id="LC296" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L297" class="blob-num js-line-number" data-line-number="297"></td>
-        <td id="LC297" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type prefix: string</span></td>
-      </tr>
-      <tr>
-        <td id="L298" class="blob-num js-line-number" data-line-number="298"></td>
-        <td id="LC298" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param prefix: allows you to limit the listing to a particular</span></td>
-      </tr>
-      <tr>
-        <td id="L299" class="blob-num js-line-number" data-line-number="299"></td>
-        <td id="LC299" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            prefix.  For example, if you call the method with</span></td>
-      </tr>
-      <tr>
-        <td id="L300" class="blob-num js-line-number" data-line-number="300"></td>
-        <td id="LC300" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            prefix=&#39;/foo/&#39; then the iterator will only cycle through</span></td>
-      </tr>
-      <tr>
-        <td id="L301" class="blob-num js-line-number" data-line-number="301"></td>
-        <td id="LC301" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the keys that begin with the string &#39;/foo/&#39;.</span></td>
-      </tr>
-      <tr>
-        <td id="L302" class="blob-num js-line-number" data-line-number="302"></td>
-        <td id="LC302" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L303" class="blob-num js-line-number" data-line-number="303"></td>
-        <td id="LC303" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type delimiter: string</span></td>
-      </tr>
-      <tr>
-        <td id="L304" class="blob-num js-line-number" data-line-number="304"></td>
-        <td id="LC304" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param delimiter: can be used in conjunction with the prefix</span></td>
-      </tr>
-      <tr>
-        <td id="L305" class="blob-num js-line-number" data-line-number="305"></td>
-        <td id="LC305" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            to allow you to organize and browse your keys</span></td>
-      </tr>
-      <tr>
-        <td id="L306" class="blob-num js-line-number" data-line-number="306"></td>
-        <td id="LC306" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            hierarchically. See:</span></td>
-      </tr>
-      <tr>
-        <td id="L307" class="blob-num js-line-number" data-line-number="307"></td>
-        <td id="LC307" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L308" class="blob-num js-line-number" data-line-number="308"></td>
-        <td id="LC308" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            http://aws.amazon.com/releasenotes/Amazon-S3/213</span></td>
-      </tr>
-      <tr>
-        <td id="L309" class="blob-num js-line-number" data-line-number="309"></td>
-        <td id="LC309" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L310" class="blob-num js-line-number" data-line-number="310"></td>
-        <td id="LC310" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            for more details.</span></td>
-      </tr>
-      <tr>
-        <td id="L311" class="blob-num js-line-number" data-line-number="311"></td>
-        <td id="LC311" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L312" class="blob-num js-line-number" data-line-number="312"></td>
-        <td id="LC312" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_marker: string</span></td>
-      </tr>
-      <tr>
-        <td id="L313" class="blob-num js-line-number" data-line-number="313"></td>
-        <td id="LC313" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_marker: The &quot;marker&quot; of where you are in the result set</span></td>
-      </tr>
-      <tr>
-        <td id="L314" class="blob-num js-line-number" data-line-number="314"></td>
-        <td id="LC314" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L315" class="blob-num js-line-number" data-line-number="315"></td>
-        <td id="LC315" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encoding_type: Requests Amazon S3 to encode the response and</span></td>
-      </tr>
-      <tr>
-        <td id="L316" class="blob-num js-line-number" data-line-number="316"></td>
-        <td id="LC316" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specifies the encoding method to use.</span></td>
-      </tr>
-      <tr>
-        <td id="L317" class="blob-num js-line-number" data-line-number="317"></td>
-        <td id="LC317" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L318" class="blob-num js-line-number" data-line-number="318"></td>
-        <td id="LC318" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            An object key can contain any Unicode character; however, XML 1.0</span></td>
-      </tr>
-      <tr>
-        <td id="L319" class="blob-num js-line-number" data-line-number="319"></td>
-        <td id="LC319" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parser cannot parse some characters, such as characters with an</span></td>
-      </tr>
-      <tr>
-        <td id="L320" class="blob-num js-line-number" data-line-number="320"></td>
-        <td id="LC320" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ASCII value from 0 to 10. For characters that are not supported in</span></td>
-      </tr>
-      <tr>
-        <td id="L321" class="blob-num js-line-number" data-line-number="321"></td>
-        <td id="LC321" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            XML 1.0, you can add this parameter to request that Amazon S3</span></td>
-      </tr>
-      <tr>
-        <td id="L322" class="blob-num js-line-number" data-line-number="322"></td>
-        <td id="LC322" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            encode the keys in the response.</span></td>
-      </tr>
-      <tr>
-        <td id="L323" class="blob-num js-line-number" data-line-number="323"></td>
-        <td id="LC323" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L324" class="blob-num js-line-number" data-line-number="324"></td>
-        <td id="LC324" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Valid options: ``url``</span></td>
-      </tr>
-      <tr>
-        <td id="L325" class="blob-num js-line-number" data-line-number="325"></td>
-        <td id="LC325" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encoding_type: string</span></td>
-      </tr>
-      <tr>
-        <td id="L326" class="blob-num js-line-number" data-line-number="326"></td>
-        <td id="LC326" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L327" class="blob-num js-line-number" data-line-number="327"></td>
-        <td id="LC327" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.bucketlistresultset.BucketListResultSet`</span></td>
-      </tr>
-      <tr>
-        <td id="L328" class="blob-num js-line-number" data-line-number="328"></td>
-        <td id="LC328" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: an instance of a BucketListResultSet that handles paging, etc</span></td>
-      </tr>
-      <tr>
-        <td id="L329" class="blob-num js-line-number" data-line-number="329"></td>
-        <td id="LC329" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L330" class="blob-num js-line-number" data-line-number="330"></td>
-        <td id="LC330" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> VersionedBucketListResultSet(<span class="pl-c1">self</span>, prefix, delimiter,</td>
-      </tr>
-      <tr>
-        <td id="L331" class="blob-num js-line-number" data-line-number="331"></td>
-        <td id="LC331" class="blob-code blob-code-inner js-file-line">                                            key_marker, version_id_marker,</td>
-      </tr>
-      <tr>
-        <td id="L332" class="blob-num js-line-number" data-line-number="332"></td>
-        <td id="LC332" class="blob-code blob-code-inner js-file-line">                                            headers,</td>
-      </tr>
-      <tr>
-        <td id="L333" class="blob-num js-line-number" data-line-number="333"></td>
-        <td id="LC333" class="blob-code blob-code-inner js-file-line">                                            <span class="pl-v">encoding_type</span><span class="pl-k">=</span>encoding_type)</td>
-      </tr>
-      <tr>
-        <td id="L334" class="blob-num js-line-number" data-line-number="334"></td>
-        <td id="LC334" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L335" class="blob-num js-line-number" data-line-number="335"></td>
-        <td id="LC335" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">list_multipart_uploads</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_marker</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L336" class="blob-num js-line-number" data-line-number="336"></td>
-        <td id="LC336" class="blob-code blob-code-inner js-file-line">                               <span class="pl-smi">upload_id_marker</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L337" class="blob-num js-line-number" data-line-number="337"></td>
-        <td id="LC337" class="blob-code blob-code-inner js-file-line">                               <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">encoding_type</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L338" class="blob-num js-line-number" data-line-number="338"></td>
-        <td id="LC338" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L339" class="blob-num js-line-number" data-line-number="339"></td>
-        <td id="LC339" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        List multipart upload objects within a bucket.  This returns an</span></td>
-      </tr>
-      <tr>
-        <td id="L340" class="blob-num js-line-number" data-line-number="340"></td>
-        <td id="LC340" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        instance of an MultiPartUploadListResultSet that automatically</span></td>
-      </tr>
-      <tr>
-        <td id="L341" class="blob-num js-line-number" data-line-number="341"></td>
-        <td id="LC341" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        handles all of the result paging, etc. from S3.  You just need</span></td>
-      </tr>
-      <tr>
-        <td id="L342" class="blob-num js-line-number" data-line-number="342"></td>
-        <td id="LC342" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        to keep iterating until there are no more results.</span></td>
-      </tr>
-      <tr>
-        <td id="L343" class="blob-num js-line-number" data-line-number="343"></td>
-        <td id="LC343" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L344" class="blob-num js-line-number" data-line-number="344"></td>
-        <td id="LC344" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_marker: string</span></td>
-      </tr>
-      <tr>
-        <td id="L345" class="blob-num js-line-number" data-line-number="345"></td>
-        <td id="LC345" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_marker: The &quot;marker&quot; of where you are in the result set</span></td>
-      </tr>
-      <tr>
-        <td id="L346" class="blob-num js-line-number" data-line-number="346"></td>
-        <td id="LC346" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L347" class="blob-num js-line-number" data-line-number="347"></td>
-        <td id="LC347" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type upload_id_marker: string</span></td>
-      </tr>
-      <tr>
-        <td id="L348" class="blob-num js-line-number" data-line-number="348"></td>
-        <td id="LC348" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param upload_id_marker: The upload identifier</span></td>
-      </tr>
-      <tr>
-        <td id="L349" class="blob-num js-line-number" data-line-number="349"></td>
-        <td id="LC349" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L350" class="blob-num js-line-number" data-line-number="350"></td>
-        <td id="LC350" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encoding_type: Requests Amazon S3 to encode the response and</span></td>
-      </tr>
-      <tr>
-        <td id="L351" class="blob-num js-line-number" data-line-number="351"></td>
-        <td id="LC351" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specifies the encoding method to use.</span></td>
-      </tr>
-      <tr>
-        <td id="L352" class="blob-num js-line-number" data-line-number="352"></td>
-        <td id="LC352" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L353" class="blob-num js-line-number" data-line-number="353"></td>
-        <td id="LC353" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            An object key can contain any Unicode character; however, XML 1.0</span></td>
-      </tr>
-      <tr>
-        <td id="L354" class="blob-num js-line-number" data-line-number="354"></td>
-        <td id="LC354" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parser cannot parse some characters, such as characters with an</span></td>
-      </tr>
-      <tr>
-        <td id="L355" class="blob-num js-line-number" data-line-number="355"></td>
-        <td id="LC355" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ASCII value from 0 to 10. For characters that are not supported in</span></td>
-      </tr>
-      <tr>
-        <td id="L356" class="blob-num js-line-number" data-line-number="356"></td>
-        <td id="LC356" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            XML 1.0, you can add this parameter to request that Amazon S3</span></td>
-      </tr>
-      <tr>
-        <td id="L357" class="blob-num js-line-number" data-line-number="357"></td>
-        <td id="LC357" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            encode the keys in the response.</span></td>
-      </tr>
-      <tr>
-        <td id="L358" class="blob-num js-line-number" data-line-number="358"></td>
-        <td id="LC358" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L359" class="blob-num js-line-number" data-line-number="359"></td>
-        <td id="LC359" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Valid options: ``url``</span></td>
-      </tr>
-      <tr>
-        <td id="L360" class="blob-num js-line-number" data-line-number="360"></td>
-        <td id="LC360" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encoding_type: string</span></td>
-      </tr>
-      <tr>
-        <td id="L361" class="blob-num js-line-number" data-line-number="361"></td>
-        <td id="LC361" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L362" class="blob-num js-line-number" data-line-number="362"></td>
-        <td id="LC362" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.bucketlistresultset.MultiPartUploadListResultSet`</span></td>
-      </tr>
-      <tr>
-        <td id="L363" class="blob-num js-line-number" data-line-number="363"></td>
-        <td id="LC363" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: an instance of a BucketListResultSet that handles paging, etc</span></td>
-      </tr>
-      <tr>
-        <td id="L364" class="blob-num js-line-number" data-line-number="364"></td>
-        <td id="LC364" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L365" class="blob-num js-line-number" data-line-number="365"></td>
-        <td id="LC365" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> MultiPartUploadListResultSet(<span class="pl-c1">self</span>, key_marker,</td>
-      </tr>
-      <tr>
-        <td id="L366" class="blob-num js-line-number" data-line-number="366"></td>
-        <td id="LC366" class="blob-code blob-code-inner js-file-line">                                            upload_id_marker,</td>
-      </tr>
-      <tr>
-        <td id="L367" class="blob-num js-line-number" data-line-number="367"></td>
-        <td id="LC367" class="blob-code blob-code-inner js-file-line">                                            headers,</td>
-      </tr>
-      <tr>
-        <td id="L368" class="blob-num js-line-number" data-line-number="368"></td>
-        <td id="LC368" class="blob-code blob-code-inner js-file-line">                                            <span class="pl-v">encoding_type</span><span class="pl-k">=</span>encoding_type)</td>
-      </tr>
-      <tr>
-        <td id="L369" class="blob-num js-line-number" data-line-number="369"></td>
-        <td id="LC369" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L370" class="blob-num js-line-number" data-line-number="370"></td>
-        <td id="LC370" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">_get_all_query_args</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">params</span>, <span class="pl-smi">initial_query_string</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>):</td>
-      </tr>
-      <tr>
-        <td id="L371" class="blob-num js-line-number" data-line-number="371"></td>
-        <td id="LC371" class="blob-code blob-code-inner js-file-line">        pairs <span class="pl-k">=</span> []</td>
-      </tr>
-      <tr>
-        <td id="L372" class="blob-num js-line-number" data-line-number="372"></td>
-        <td id="LC372" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L373" class="blob-num js-line-number" data-line-number="373"></td>
-        <td id="LC373" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> initial_query_string:</td>
-      </tr>
-      <tr>
-        <td id="L374" class="blob-num js-line-number" data-line-number="374"></td>
-        <td id="LC374" class="blob-code blob-code-inner js-file-line">            pairs.append(initial_query_string)</td>
-      </tr>
-      <tr>
-        <td id="L375" class="blob-num js-line-number" data-line-number="375"></td>
-        <td id="LC375" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L376" class="blob-num js-line-number" data-line-number="376"></td>
-        <td id="LC376" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">for</span> key, value <span class="pl-k">in</span> <span class="pl-c1">sorted</span>(params.items(), <span class="pl-v">key</span><span class="pl-k">=</span><span class="pl-k">lambda</span> <span class="pl-smi">x</span>: x[<span class="pl-c1">0</span>]):</td>
-      </tr>
-      <tr>
-        <td id="L377" class="blob-num js-line-number" data-line-number="377"></td>
-        <td id="LC377" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> value <span class="pl-k">is</span> <span class="pl-c1">None</span>:</td>
-      </tr>
-      <tr>
-        <td id="L378" class="blob-num js-line-number" data-line-number="378"></td>
-        <td id="LC378" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">continue</span></td>
-      </tr>
-      <tr>
-        <td id="L379" class="blob-num js-line-number" data-line-number="379"></td>
-        <td id="LC379" class="blob-code blob-code-inner js-file-line">            key <span class="pl-k">=</span> key.replace(<span class="pl-s"><span class="pl-pds">&#39;</span>_<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>-<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L380" class="blob-num js-line-number" data-line-number="380"></td>
-        <td id="LC380" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> key <span class="pl-k">==</span> <span class="pl-s"><span class="pl-pds">&#39;</span>maxkeys<span class="pl-pds">&#39;</span></span>:</td>
-      </tr>
-      <tr>
-        <td id="L381" class="blob-num js-line-number" data-line-number="381"></td>
-        <td id="LC381" class="blob-code blob-code-inner js-file-line">                key <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>max-keys<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L382" class="blob-num js-line-number" data-line-number="382"></td>
-        <td id="LC382" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(value, six.string_types <span class="pl-k">+</span> (six.binary_type,)):</td>
-      </tr>
-      <tr>
-        <td id="L383" class="blob-num js-line-number" data-line-number="383"></td>
-        <td id="LC383" class="blob-code blob-code-inner js-file-line">                value <span class="pl-k">=</span> six.text_type(value)</td>
-      </tr>
-      <tr>
-        <td id="L384" class="blob-num js-line-number" data-line-number="384"></td>
-        <td id="LC384" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(value, six.binary_type):</td>
-      </tr>
-      <tr>
-        <td id="L385" class="blob-num js-line-number" data-line-number="385"></td>
-        <td id="LC385" class="blob-code blob-code-inner js-file-line">                value <span class="pl-k">=</span> value.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L386" class="blob-num js-line-number" data-line-number="386"></td>
-        <td id="LC386" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> value:</td>
-      </tr>
-      <tr>
-        <td id="L387" class="blob-num js-line-number" data-line-number="387"></td>
-        <td id="LC387" class="blob-code blob-code-inner js-file-line">                pairs.append(<span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&#39;</span><span class="pl-c1">%s</span>=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> (</td>
-      </tr>
-      <tr>
-        <td id="L388" class="blob-num js-line-number" data-line-number="388"></td>
-        <td id="LC388" class="blob-code blob-code-inner js-file-line">                    urllib.parse.quote(key),</td>
-      </tr>
-      <tr>
-        <td id="L389" class="blob-num js-line-number" data-line-number="389"></td>
-        <td id="LC389" class="blob-code blob-code-inner js-file-line">                    urllib.parse.quote(value)</td>
-      </tr>
-      <tr>
-        <td id="L390" class="blob-num js-line-number" data-line-number="390"></td>
-        <td id="LC390" class="blob-code blob-code-inner js-file-line">                ))</td>
-      </tr>
-      <tr>
-        <td id="L391" class="blob-num js-line-number" data-line-number="391"></td>
-        <td id="LC391" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L392" class="blob-num js-line-number" data-line-number="392"></td>
-        <td id="LC392" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;<span class="pl-pds">&#39;</span></span>.join(pairs)</td>
-      </tr>
-      <tr>
-        <td id="L393" class="blob-num js-line-number" data-line-number="393"></td>
-        <td id="LC393" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L394" class="blob-num js-line-number" data-line-number="394"></td>
-        <td id="LC394" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">_get_all</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">element_map</span>, <span class="pl-smi">initial_query_string</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L395" class="blob-num js-line-number" data-line-number="395"></td>
-        <td id="LC395" class="blob-code blob-code-inner js-file-line">                 <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-k">**</span><span class="pl-smi">params</span>):</td>
-      </tr>
-      <tr>
-        <td id="L396" class="blob-num js-line-number" data-line-number="396"></td>
-        <td id="LC396" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-c1">self</span>._get_all_query_args(</td>
-      </tr>
-      <tr>
-        <td id="L397" class="blob-num js-line-number" data-line-number="397"></td>
-        <td id="LC397" class="blob-code blob-code-inner js-file-line">            params,</td>
-      </tr>
-      <tr>
-        <td id="L398" class="blob-num js-line-number" data-line-number="398"></td>
-        <td id="LC398" class="blob-code blob-code-inner js-file-line">            <span class="pl-v">initial_query_string</span><span class="pl-k">=</span>initial_query_string</td>
-      </tr>
-      <tr>
-        <td id="L399" class="blob-num js-line-number" data-line-number="399"></td>
-        <td id="LC399" class="blob-code blob-code-inner js-file-line">        )</td>
-      </tr>
-      <tr>
-        <td id="L400" class="blob-num js-line-number" data-line-number="400"></td>
-        <td id="LC400" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L401" class="blob-num js-line-number" data-line-number="401"></td>
-        <td id="LC401" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
-      </tr>
-      <tr>
-        <td id="L402" class="blob-num js-line-number" data-line-number="402"></td>
-        <td id="LC402" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args)</td>
-      </tr>
-      <tr>
-        <td id="L403" class="blob-num js-line-number" data-line-number="403"></td>
-        <td id="LC403" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L404" class="blob-num js-line-number" data-line-number="404"></td>
-        <td id="LC404" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
-      </tr>
-      <tr>
-        <td id="L405" class="blob-num js-line-number" data-line-number="405"></td>
-        <td id="LC405" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L406" class="blob-num js-line-number" data-line-number="406"></td>
-        <td id="LC406" class="blob-code blob-code-inner js-file-line">            rs <span class="pl-k">=</span> ResultSet(element_map)</td>
-      </tr>
-      <tr>
-        <td id="L407" class="blob-num js-line-number" data-line-number="407"></td>
-        <td id="LC407" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(rs, <span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L408" class="blob-num js-line-number" data-line-number="408"></td>
-        <td id="LC408" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
-      </tr>
-      <tr>
-        <td id="L409" class="blob-num js-line-number" data-line-number="409"></td>
-        <td id="LC409" class="blob-code blob-code-inner js-file-line">                body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L410" class="blob-num js-line-number" data-line-number="410"></td>
-        <td id="LC410" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
-      </tr>
-      <tr>
-        <td id="L411" class="blob-num js-line-number" data-line-number="411"></td>
-        <td id="LC411" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> rs</td>
-      </tr>
-      <tr>
-        <td id="L412" class="blob-num js-line-number" data-line-number="412"></td>
-        <td id="LC412" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L413" class="blob-num js-line-number" data-line-number="413"></td>
-        <td id="LC413" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L414" class="blob-num js-line-number" data-line-number="414"></td>
-        <td id="LC414" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L415" class="blob-num js-line-number" data-line-number="415"></td>
-        <td id="LC415" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L416" class="blob-num js-line-number" data-line-number="416"></td>
-        <td id="LC416" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">validate_kwarg_names</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">kwargs</span>, <span class="pl-smi">names</span>):</td>
-      </tr>
-      <tr>
-        <td id="L417" class="blob-num js-line-number" data-line-number="417"></td>
-        <td id="LC417" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L418" class="blob-num js-line-number" data-line-number="418"></td>
-        <td id="LC418" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Checks that all named arguments are in the specified list of names.</span></td>
-      </tr>
-      <tr>
-        <td id="L419" class="blob-num js-line-number" data-line-number="419"></td>
-        <td id="LC419" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L420" class="blob-num js-line-number" data-line-number="420"></td>
-        <td id="LC420" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type kwargs: dict</span></td>
-      </tr>
-      <tr>
-        <td id="L421" class="blob-num js-line-number" data-line-number="421"></td>
-        <td id="LC421" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param kwargs: Dictionary of kwargs to validate.</span></td>
-      </tr>
-      <tr>
-        <td id="L422" class="blob-num js-line-number" data-line-number="422"></td>
-        <td id="LC422" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L423" class="blob-num js-line-number" data-line-number="423"></td>
-        <td id="LC423" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type names: list</span></td>
-      </tr>
-      <tr>
-        <td id="L424" class="blob-num js-line-number" data-line-number="424"></td>
-        <td id="LC424" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param names: List of possible named arguments.</span></td>
-      </tr>
-      <tr>
-        <td id="L425" class="blob-num js-line-number" data-line-number="425"></td>
-        <td id="LC425" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L426" class="blob-num js-line-number" data-line-number="426"></td>
-        <td id="LC426" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">for</span> kwarg <span class="pl-k">in</span> kwargs:</td>
-      </tr>
-      <tr>
-        <td id="L427" class="blob-num js-line-number" data-line-number="427"></td>
-        <td id="LC427" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> kwarg <span class="pl-k">not</span> <span class="pl-k">in</span> names:</td>
-      </tr>
-      <tr>
-        <td id="L428" class="blob-num js-line-number" data-line-number="428"></td>
-        <td id="LC428" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">raise</span> <span class="pl-c1">TypeError</span>(<span class="pl-s"><span class="pl-pds">&#39;</span>Invalid argument &quot;<span class="pl-c1">%s</span>&quot;!<span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> kwarg)</td>
-      </tr>
-      <tr>
-        <td id="L429" class="blob-num js-line-number" data-line-number="429"></td>
-        <td id="LC429" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L430" class="blob-num js-line-number" data-line-number="430"></td>
-        <td id="LC430" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_all_keys</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-k">**</span><span class="pl-smi">params</span>):</td>
-      </tr>
-      <tr>
-        <td id="L431" class="blob-num js-line-number" data-line-number="431"></td>
-        <td id="LC431" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L432" class="blob-num js-line-number" data-line-number="432"></td>
-        <td id="LC432" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        A lower-level method for listing contents of a bucket.  This</span></td>
-      </tr>
-      <tr>
-        <td id="L433" class="blob-num js-line-number" data-line-number="433"></td>
-        <td id="LC433" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        closely models the actual S3 API and requires you to manually</span></td>
-      </tr>
-      <tr>
-        <td id="L434" class="blob-num js-line-number" data-line-number="434"></td>
-        <td id="LC434" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        handle the paging of results.  For a higher-level method that</span></td>
-      </tr>
-      <tr>
-        <td id="L435" class="blob-num js-line-number" data-line-number="435"></td>
-        <td id="LC435" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        handles the details of paging for you, you can use the list</span></td>
-      </tr>
-      <tr>
-        <td id="L436" class="blob-num js-line-number" data-line-number="436"></td>
-        <td id="LC436" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        method.</span></td>
-      </tr>
-      <tr>
-        <td id="L437" class="blob-num js-line-number" data-line-number="437"></td>
-        <td id="LC437" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L438" class="blob-num js-line-number" data-line-number="438"></td>
-        <td id="LC438" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type max_keys: int</span></td>
-      </tr>
-      <tr>
-        <td id="L439" class="blob-num js-line-number" data-line-number="439"></td>
-        <td id="LC439" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param max_keys: The maximum number of keys to retrieve</span></td>
-      </tr>
-      <tr>
-        <td id="L440" class="blob-num js-line-number" data-line-number="440"></td>
-        <td id="LC440" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L441" class="blob-num js-line-number" data-line-number="441"></td>
-        <td id="LC441" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type prefix: string</span></td>
-      </tr>
-      <tr>
-        <td id="L442" class="blob-num js-line-number" data-line-number="442"></td>
-        <td id="LC442" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param prefix: The prefix of the keys you want to retrieve</span></td>
-      </tr>
-      <tr>
-        <td id="L443" class="blob-num js-line-number" data-line-number="443"></td>
-        <td id="LC443" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L444" class="blob-num js-line-number" data-line-number="444"></td>
-        <td id="LC444" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type marker: string</span></td>
-      </tr>
-      <tr>
-        <td id="L445" class="blob-num js-line-number" data-line-number="445"></td>
-        <td id="LC445" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param marker: The &quot;marker&quot; of where you are in the result set</span></td>
-      </tr>
-      <tr>
-        <td id="L446" class="blob-num js-line-number" data-line-number="446"></td>
-        <td id="LC446" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L447" class="blob-num js-line-number" data-line-number="447"></td>
-        <td id="LC447" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type delimiter: string</span></td>
-      </tr>
-      <tr>
-        <td id="L448" class="blob-num js-line-number" data-line-number="448"></td>
-        <td id="LC448" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param delimiter: If this optional, Unicode string parameter</span></td>
-      </tr>
-      <tr>
-        <td id="L449" class="blob-num js-line-number" data-line-number="449"></td>
-        <td id="LC449" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            is included with your request, then keys that contain the</span></td>
-      </tr>
-      <tr>
-        <td id="L450" class="blob-num js-line-number" data-line-number="450"></td>
-        <td id="LC450" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            same string between the prefix and the first occurrence of</span></td>
-      </tr>
-      <tr>
-        <td id="L451" class="blob-num js-line-number" data-line-number="451"></td>
-        <td id="LC451" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the delimiter will be rolled up into a single result</span></td>
-      </tr>
-      <tr>
-        <td id="L452" class="blob-num js-line-number" data-line-number="452"></td>
-        <td id="LC452" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            element in the CommonPrefixes collection. These rolled-up</span></td>
-      </tr>
-      <tr>
-        <td id="L453" class="blob-num js-line-number" data-line-number="453"></td>
-        <td id="LC453" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            keys are not returned elsewhere in the response.</span></td>
-      </tr>
-      <tr>
-        <td id="L454" class="blob-num js-line-number" data-line-number="454"></td>
-        <td id="LC454" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L455" class="blob-num js-line-number" data-line-number="455"></td>
-        <td id="LC455" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encoding_type: Requests Amazon S3 to encode the response and</span></td>
-      </tr>
-      <tr>
-        <td id="L456" class="blob-num js-line-number" data-line-number="456"></td>
-        <td id="LC456" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specifies the encoding method to use.</span></td>
-      </tr>
-      <tr>
-        <td id="L457" class="blob-num js-line-number" data-line-number="457"></td>
-        <td id="LC457" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L458" class="blob-num js-line-number" data-line-number="458"></td>
-        <td id="LC458" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            An object key can contain any Unicode character; however, XML 1.0</span></td>
-      </tr>
-      <tr>
-        <td id="L459" class="blob-num js-line-number" data-line-number="459"></td>
-        <td id="LC459" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parser cannot parse some characters, such as characters with an</span></td>
-      </tr>
-      <tr>
-        <td id="L460" class="blob-num js-line-number" data-line-number="460"></td>
-        <td id="LC460" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ASCII value from 0 to 10. For characters that are not supported in</span></td>
-      </tr>
-      <tr>
-        <td id="L461" class="blob-num js-line-number" data-line-number="461"></td>
-        <td id="LC461" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            XML 1.0, you can add this parameter to request that Amazon S3</span></td>
-      </tr>
-      <tr>
-        <td id="L462" class="blob-num js-line-number" data-line-number="462"></td>
-        <td id="LC462" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            encode the keys in the response.</span></td>
-      </tr>
-      <tr>
-        <td id="L463" class="blob-num js-line-number" data-line-number="463"></td>
-        <td id="LC463" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L464" class="blob-num js-line-number" data-line-number="464"></td>
-        <td id="LC464" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Valid options: ``url``</span></td>
-      </tr>
-      <tr>
-        <td id="L465" class="blob-num js-line-number" data-line-number="465"></td>
-        <td id="LC465" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encoding_type: string</span></td>
-      </tr>
-      <tr>
-        <td id="L466" class="blob-num js-line-number" data-line-number="466"></td>
-        <td id="LC466" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L467" class="blob-num js-line-number" data-line-number="467"></td>
-        <td id="LC467" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: ResultSet</span></td>
-      </tr>
-      <tr>
-        <td id="L468" class="blob-num js-line-number" data-line-number="468"></td>
-        <td id="LC468" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: The result from S3 listing the keys requested</span></td>
-      </tr>
-      <tr>
-        <td id="L469" class="blob-num js-line-number" data-line-number="469"></td>
-        <td id="LC469" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L470" class="blob-num js-line-number" data-line-number="470"></td>
-        <td id="LC470" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L471" class="blob-num js-line-number" data-line-number="471"></td>
-        <td id="LC471" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.validate_kwarg_names(params, [<span class="pl-s"><span class="pl-pds">&#39;</span>maxkeys<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>max_keys<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>prefix<span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L472" class="blob-num js-line-number" data-line-number="472"></td>
-        <td id="LC472" class="blob-code blob-code-inner js-file-line">                                           <span class="pl-s"><span class="pl-pds">&#39;</span>marker<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>delimiter<span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L473" class="blob-num js-line-number" data-line-number="473"></td>
-        <td id="LC473" class="blob-code blob-code-inner js-file-line">                                           <span class="pl-s"><span class="pl-pds">&#39;</span>encoding_type<span class="pl-pds">&#39;</span></span>])</td>
-      </tr>
-      <tr>
-        <td id="L474" class="blob-num js-line-number" data-line-number="474"></td>
-        <td id="LC474" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>._get_all([(<span class="pl-s"><span class="pl-pds">&#39;</span>Contents<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.key_class),</td>
-      </tr>
-      <tr>
-        <td id="L475" class="blob-num js-line-number" data-line-number="475"></td>
-        <td id="LC475" class="blob-code blob-code-inner js-file-line">                              (<span class="pl-s"><span class="pl-pds">&#39;</span>CommonPrefixes<span class="pl-pds">&#39;</span></span>, Prefix)],</td>
-      </tr>
-      <tr>
-        <td id="L476" class="blob-num js-line-number" data-line-number="476"></td>
-        <td id="LC476" class="blob-code blob-code-inner js-file-line">                             <span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, headers, <span class="pl-k">**</span>params)</td>
-      </tr>
-      <tr>
-        <td id="L477" class="blob-num js-line-number" data-line-number="477"></td>
-        <td id="LC477" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L478" class="blob-num js-line-number" data-line-number="478"></td>
-        <td id="LC478" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_all_versions</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-k">**</span><span class="pl-smi">params</span>):</td>
-      </tr>
-      <tr>
-        <td id="L479" class="blob-num js-line-number" data-line-number="479"></td>
-        <td id="LC479" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L480" class="blob-num js-line-number" data-line-number="480"></td>
-        <td id="LC480" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        A lower-level, version-aware method for listing contents of a</span></td>
-      </tr>
-      <tr>
-        <td id="L481" class="blob-num js-line-number" data-line-number="481"></td>
-        <td id="LC481" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        bucket.  This closely models the actual S3 API and requires</span></td>
-      </tr>
-      <tr>
-        <td id="L482" class="blob-num js-line-number" data-line-number="482"></td>
-        <td id="LC482" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        you to manually handle the paging of results.  For a</span></td>
-      </tr>
-      <tr>
-        <td id="L483" class="blob-num js-line-number" data-line-number="483"></td>
-        <td id="LC483" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        higher-level method that handles the details of paging for</span></td>
-      </tr>
-      <tr>
-        <td id="L484" class="blob-num js-line-number" data-line-number="484"></td>
-        <td id="LC484" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        you, you can use the list method.</span></td>
-      </tr>
-      <tr>
-        <td id="L485" class="blob-num js-line-number" data-line-number="485"></td>
-        <td id="LC485" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L486" class="blob-num js-line-number" data-line-number="486"></td>
-        <td id="LC486" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type max_keys: int</span></td>
-      </tr>
-      <tr>
-        <td id="L487" class="blob-num js-line-number" data-line-number="487"></td>
-        <td id="LC487" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param max_keys: The maximum number of keys to retrieve</span></td>
-      </tr>
-      <tr>
-        <td id="L488" class="blob-num js-line-number" data-line-number="488"></td>
-        <td id="LC488" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L489" class="blob-num js-line-number" data-line-number="489"></td>
-        <td id="LC489" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type prefix: string</span></td>
-      </tr>
-      <tr>
-        <td id="L490" class="blob-num js-line-number" data-line-number="490"></td>
-        <td id="LC490" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param prefix: The prefix of the keys you want to retrieve</span></td>
-      </tr>
-      <tr>
-        <td id="L491" class="blob-num js-line-number" data-line-number="491"></td>
-        <td id="LC491" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L492" class="blob-num js-line-number" data-line-number="492"></td>
-        <td id="LC492" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_marker: string</span></td>
-      </tr>
-      <tr>
-        <td id="L493" class="blob-num js-line-number" data-line-number="493"></td>
-        <td id="LC493" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_marker: The &quot;marker&quot; of where you are in the result set</span></td>
-      </tr>
-      <tr>
-        <td id="L494" class="blob-num js-line-number" data-line-number="494"></td>
-        <td id="LC494" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            with respect to keys.</span></td>
-      </tr>
-      <tr>
-        <td id="L495" class="blob-num js-line-number" data-line-number="495"></td>
-        <td id="LC495" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L496" class="blob-num js-line-number" data-line-number="496"></td>
-        <td id="LC496" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type version_id_marker: string</span></td>
-      </tr>
-      <tr>
-        <td id="L497" class="blob-num js-line-number" data-line-number="497"></td>
-        <td id="LC497" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param version_id_marker: The &quot;marker&quot; of where you are in the result</span></td>
-      </tr>
-      <tr>
-        <td id="L498" class="blob-num js-line-number" data-line-number="498"></td>
-        <td id="LC498" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            set with respect to version-id&#39;s.</span></td>
-      </tr>
-      <tr>
-        <td id="L499" class="blob-num js-line-number" data-line-number="499"></td>
-        <td id="LC499" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L500" class="blob-num js-line-number" data-line-number="500"></td>
-        <td id="LC500" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type delimiter: string</span></td>
-      </tr>
-      <tr>
-        <td id="L501" class="blob-num js-line-number" data-line-number="501"></td>
-        <td id="LC501" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param delimiter: If this optional, Unicode string parameter</span></td>
-      </tr>
-      <tr>
-        <td id="L502" class="blob-num js-line-number" data-line-number="502"></td>
-        <td id="LC502" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            is included with your request, then keys that contain the</span></td>
-      </tr>
-      <tr>
-        <td id="L503" class="blob-num js-line-number" data-line-number="503"></td>
-        <td id="LC503" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            same string between the prefix and the first occurrence of</span></td>
-      </tr>
-      <tr>
-        <td id="L504" class="blob-num js-line-number" data-line-number="504"></td>
-        <td id="LC504" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the delimiter will be rolled up into a single result</span></td>
-      </tr>
-      <tr>
-        <td id="L505" class="blob-num js-line-number" data-line-number="505"></td>
-        <td id="LC505" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            element in the CommonPrefixes collection. These rolled-up</span></td>
-      </tr>
-      <tr>
-        <td id="L506" class="blob-num js-line-number" data-line-number="506"></td>
-        <td id="LC506" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            keys are not returned elsewhere in the response.</span></td>
-      </tr>
-      <tr>
-        <td id="L507" class="blob-num js-line-number" data-line-number="507"></td>
-        <td id="LC507" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L508" class="blob-num js-line-number" data-line-number="508"></td>
-        <td id="LC508" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encoding_type: Requests Amazon S3 to encode the response and</span></td>
-      </tr>
-      <tr>
-        <td id="L509" class="blob-num js-line-number" data-line-number="509"></td>
-        <td id="LC509" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specifies the encoding method to use.</span></td>
-      </tr>
-      <tr>
-        <td id="L510" class="blob-num js-line-number" data-line-number="510"></td>
-        <td id="LC510" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L511" class="blob-num js-line-number" data-line-number="511"></td>
-        <td id="LC511" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            An object key can contain any Unicode character; however, XML 1.0</span></td>
-      </tr>
-      <tr>
-        <td id="L512" class="blob-num js-line-number" data-line-number="512"></td>
-        <td id="LC512" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parser cannot parse some characters, such as characters with an</span></td>
-      </tr>
-      <tr>
-        <td id="L513" class="blob-num js-line-number" data-line-number="513"></td>
-        <td id="LC513" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ASCII value from 0 to 10. For characters that are not supported in</span></td>
-      </tr>
-      <tr>
-        <td id="L514" class="blob-num js-line-number" data-line-number="514"></td>
-        <td id="LC514" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            XML 1.0, you can add this parameter to request that Amazon S3</span></td>
-      </tr>
-      <tr>
-        <td id="L515" class="blob-num js-line-number" data-line-number="515"></td>
-        <td id="LC515" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            encode the keys in the response.</span></td>
-      </tr>
-      <tr>
-        <td id="L516" class="blob-num js-line-number" data-line-number="516"></td>
-        <td id="LC516" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L517" class="blob-num js-line-number" data-line-number="517"></td>
-        <td id="LC517" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Valid options: ``url``</span></td>
-      </tr>
-      <tr>
-        <td id="L518" class="blob-num js-line-number" data-line-number="518"></td>
-        <td id="LC518" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encoding_type: string</span></td>
-      </tr>
-      <tr>
-        <td id="L519" class="blob-num js-line-number" data-line-number="519"></td>
-        <td id="LC519" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L520" class="blob-num js-line-number" data-line-number="520"></td>
-        <td id="LC520" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: ResultSet</span></td>
-      </tr>
-      <tr>
-        <td id="L521" class="blob-num js-line-number" data-line-number="521"></td>
-        <td id="LC521" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: The result from S3 listing the keys requested</span></td>
-      </tr>
-      <tr>
-        <td id="L522" class="blob-num js-line-number" data-line-number="522"></td>
-        <td id="LC522" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L523" class="blob-num js-line-number" data-line-number="523"></td>
-        <td id="LC523" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.validate_get_all_versions_params(params)</td>
-      </tr>
-      <tr>
-        <td id="L524" class="blob-num js-line-number" data-line-number="524"></td>
-        <td id="LC524" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>._get_all([(<span class="pl-s"><span class="pl-pds">&#39;</span>Version<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.key_class),</td>
-      </tr>
-      <tr>
-        <td id="L525" class="blob-num js-line-number" data-line-number="525"></td>
-        <td id="LC525" class="blob-code blob-code-inner js-file-line">                              (<span class="pl-s"><span class="pl-pds">&#39;</span>CommonPrefixes<span class="pl-pds">&#39;</span></span>, Prefix),</td>
-      </tr>
-      <tr>
-        <td id="L526" class="blob-num js-line-number" data-line-number="526"></td>
-        <td id="LC526" class="blob-code blob-code-inner js-file-line">                              (<span class="pl-s"><span class="pl-pds">&#39;</span>DeleteMarker<span class="pl-pds">&#39;</span></span>, DeleteMarker)],</td>
-      </tr>
-      <tr>
-        <td id="L527" class="blob-num js-line-number" data-line-number="527"></td>
-        <td id="LC527" class="blob-code blob-code-inner js-file-line">                             <span class="pl-s"><span class="pl-pds">&#39;</span>versions<span class="pl-pds">&#39;</span></span>, headers, <span class="pl-k">**</span>params)</td>
-      </tr>
-      <tr>
-        <td id="L528" class="blob-num js-line-number" data-line-number="528"></td>
-        <td id="LC528" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L529" class="blob-num js-line-number" data-line-number="529"></td>
-        <td id="LC529" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">validate_get_all_versions_params</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">params</span>):</td>
-      </tr>
-      <tr>
-        <td id="L530" class="blob-num js-line-number" data-line-number="530"></td>
-        <td id="LC530" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L531" class="blob-num js-line-number" data-line-number="531"></td>
-        <td id="LC531" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Validate that the parameters passed to get_all_versions are valid.</span></td>
-      </tr>
-      <tr>
-        <td id="L532" class="blob-num js-line-number" data-line-number="532"></td>
-        <td id="LC532" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Overridden by subclasses that allow a different set of parameters.</span></td>
-      </tr>
-      <tr>
-        <td id="L533" class="blob-num js-line-number" data-line-number="533"></td>
-        <td id="LC533" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L534" class="blob-num js-line-number" data-line-number="534"></td>
-        <td id="LC534" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type params: dict</span></td>
-      </tr>
-      <tr>
-        <td id="L535" class="blob-num js-line-number" data-line-number="535"></td>
-        <td id="LC535" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param params: Parameters to validate.</span></td>
-      </tr>
-      <tr>
-        <td id="L536" class="blob-num js-line-number" data-line-number="536"></td>
-        <td id="LC536" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L537" class="blob-num js-line-number" data-line-number="537"></td>
-        <td id="LC537" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.validate_kwarg_names(</td>
-      </tr>
-      <tr>
-        <td id="L538" class="blob-num js-line-number" data-line-number="538"></td>
-        <td id="LC538" class="blob-code blob-code-inner js-file-line">                params, [<span class="pl-s"><span class="pl-pds">&#39;</span>maxkeys<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>max_keys<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>prefix<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>key_marker<span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L539" class="blob-num js-line-number" data-line-number="539"></td>
-        <td id="LC539" class="blob-code blob-code-inner js-file-line">                         <span class="pl-s"><span class="pl-pds">&#39;</span>version_id_marker<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>delimiter<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>encoding_type<span class="pl-pds">&#39;</span></span>])</td>
-      </tr>
-      <tr>
-        <td id="L540" class="blob-num js-line-number" data-line-number="540"></td>
-        <td id="LC540" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L541" class="blob-num js-line-number" data-line-number="541"></td>
-        <td id="LC541" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_all_multipart_uploads</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-k">**</span><span class="pl-smi">params</span>):</td>
-      </tr>
-      <tr>
-        <td id="L542" class="blob-num js-line-number" data-line-number="542"></td>
-        <td id="LC542" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L543" class="blob-num js-line-number" data-line-number="543"></td>
-        <td id="LC543" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        A lower-level, version-aware method for listing active</span></td>
-      </tr>
-      <tr>
-        <td id="L544" class="blob-num js-line-number" data-line-number="544"></td>
-        <td id="LC544" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        MultiPart uploads for a bucket.  This closely models the</span></td>
-      </tr>
-      <tr>
-        <td id="L545" class="blob-num js-line-number" data-line-number="545"></td>
-        <td id="LC545" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        actual S3 API and requires you to manually handle the paging</span></td>
-      </tr>
-      <tr>
-        <td id="L546" class="blob-num js-line-number" data-line-number="546"></td>
-        <td id="LC546" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        of results.  For a higher-level method that handles the</span></td>
-      </tr>
-      <tr>
-        <td id="L547" class="blob-num js-line-number" data-line-number="547"></td>
-        <td id="LC547" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        details of paging for you, you can use the list method.</span></td>
-      </tr>
-      <tr>
-        <td id="L548" class="blob-num js-line-number" data-line-number="548"></td>
-        <td id="LC548" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L549" class="blob-num js-line-number" data-line-number="549"></td>
-        <td id="LC549" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type max_uploads: int</span></td>
-      </tr>
-      <tr>
-        <td id="L550" class="blob-num js-line-number" data-line-number="550"></td>
-        <td id="LC550" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param max_uploads: The maximum number of uploads to retrieve.</span></td>
-      </tr>
-      <tr>
-        <td id="L551" class="blob-num js-line-number" data-line-number="551"></td>
-        <td id="LC551" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Default value is 1000.</span></td>
-      </tr>
-      <tr>
-        <td id="L552" class="blob-num js-line-number" data-line-number="552"></td>
-        <td id="LC552" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L553" class="blob-num js-line-number" data-line-number="553"></td>
-        <td id="LC553" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_marker: string</span></td>
-      </tr>
-      <tr>
-        <td id="L554" class="blob-num js-line-number" data-line-number="554"></td>
-        <td id="LC554" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_marker: Together with upload_id_marker, this</span></td>
-      </tr>
-      <tr>
-        <td id="L555" class="blob-num js-line-number" data-line-number="555"></td>
-        <td id="LC555" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parameter specifies the multipart upload after which</span></td>
-      </tr>
-      <tr>
-        <td id="L556" class="blob-num js-line-number" data-line-number="556"></td>
-        <td id="LC556" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            listing should begin.  If upload_id_marker is not</span></td>
-      </tr>
-      <tr>
-        <td id="L557" class="blob-num js-line-number" data-line-number="557"></td>
-        <td id="LC557" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specified, only the keys lexicographically greater than</span></td>
-      </tr>
-      <tr>
-        <td id="L558" class="blob-num js-line-number" data-line-number="558"></td>
-        <td id="LC558" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the specified key_marker will be included in the list.</span></td>
-      </tr>
-      <tr>
-        <td id="L559" class="blob-num js-line-number" data-line-number="559"></td>
-        <td id="LC559" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L560" class="blob-num js-line-number" data-line-number="560"></td>
-        <td id="LC560" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            If upload_id_marker is specified, any multipart uploads</span></td>
-      </tr>
-      <tr>
-        <td id="L561" class="blob-num js-line-number" data-line-number="561"></td>
-        <td id="LC561" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            for a key equal to the key_marker might also be included,</span></td>
-      </tr>
-      <tr>
-        <td id="L562" class="blob-num js-line-number" data-line-number="562"></td>
-        <td id="LC562" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            provided those multipart uploads have upload IDs</span></td>
-      </tr>
-      <tr>
-        <td id="L563" class="blob-num js-line-number" data-line-number="563"></td>
-        <td id="LC563" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            lexicographically greater than the specified</span></td>
-      </tr>
-      <tr>
-        <td id="L564" class="blob-num js-line-number" data-line-number="564"></td>
-        <td id="LC564" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            upload_id_marker.</span></td>
-      </tr>
-      <tr>
-        <td id="L565" class="blob-num js-line-number" data-line-number="565"></td>
-        <td id="LC565" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L566" class="blob-num js-line-number" data-line-number="566"></td>
-        <td id="LC566" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type upload_id_marker: string</span></td>
-      </tr>
-      <tr>
-        <td id="L567" class="blob-num js-line-number" data-line-number="567"></td>
-        <td id="LC567" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param upload_id_marker: Together with key-marker, specifies</span></td>
-      </tr>
-      <tr>
-        <td id="L568" class="blob-num js-line-number" data-line-number="568"></td>
-        <td id="LC568" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the multipart upload after which listing should begin. If</span></td>
-      </tr>
-      <tr>
-        <td id="L569" class="blob-num js-line-number" data-line-number="569"></td>
-        <td id="LC569" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            key_marker is not specified, the upload_id_marker</span></td>
-      </tr>
-      <tr>
-        <td id="L570" class="blob-num js-line-number" data-line-number="570"></td>
-        <td id="LC570" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parameter is ignored.  Otherwise, any multipart uploads</span></td>
-      </tr>
-      <tr>
-        <td id="L571" class="blob-num js-line-number" data-line-number="571"></td>
-        <td id="LC571" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            for a key equal to the key_marker might be included in the</span></td>
-      </tr>
-      <tr>
-        <td id="L572" class="blob-num js-line-number" data-line-number="572"></td>
-        <td id="LC572" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            list only if they have an upload ID lexicographically</span></td>
-      </tr>
-      <tr>
-        <td id="L573" class="blob-num js-line-number" data-line-number="573"></td>
-        <td id="LC573" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            greater than the specified upload_id_marker.</span></td>
-      </tr>
-      <tr>
-        <td id="L574" class="blob-num js-line-number" data-line-number="574"></td>
-        <td id="LC574" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L575" class="blob-num js-line-number" data-line-number="575"></td>
-        <td id="LC575" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encoding_type: string</span></td>
-      </tr>
-      <tr>
-        <td id="L576" class="blob-num js-line-number" data-line-number="576"></td>
-        <td id="LC576" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encoding_type: Requests Amazon S3 to encode the response and</span></td>
-      </tr>
-      <tr>
-        <td id="L577" class="blob-num js-line-number" data-line-number="577"></td>
-        <td id="LC577" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specifies the encoding method to use.</span></td>
-      </tr>
-      <tr>
-        <td id="L578" class="blob-num js-line-number" data-line-number="578"></td>
-        <td id="LC578" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L579" class="blob-num js-line-number" data-line-number="579"></td>
-        <td id="LC579" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            An object key can contain any Unicode character; however, XML 1.0</span></td>
-      </tr>
-      <tr>
-        <td id="L580" class="blob-num js-line-number" data-line-number="580"></td>
-        <td id="LC580" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parser cannot parse some characters, such as characters with an</span></td>
-      </tr>
-      <tr>
-        <td id="L581" class="blob-num js-line-number" data-line-number="581"></td>
-        <td id="LC581" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ASCII value from 0 to 10. For characters that are not supported in</span></td>
-      </tr>
-      <tr>
-        <td id="L582" class="blob-num js-line-number" data-line-number="582"></td>
-        <td id="LC582" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            XML 1.0, you can add this parameter to request that Amazon S3</span></td>
-      </tr>
-      <tr>
-        <td id="L583" class="blob-num js-line-number" data-line-number="583"></td>
-        <td id="LC583" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            encode the keys in the response.</span></td>
-      </tr>
-      <tr>
-        <td id="L584" class="blob-num js-line-number" data-line-number="584"></td>
-        <td id="LC584" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L585" class="blob-num js-line-number" data-line-number="585"></td>
-        <td id="LC585" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Valid options: ``url``</span></td>
-      </tr>
-      <tr>
-        <td id="L586" class="blob-num js-line-number" data-line-number="586"></td>
-        <td id="LC586" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L587" class="blob-num js-line-number" data-line-number="587"></td>
-        <td id="LC587" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type delimiter: string</span></td>
-      </tr>
-      <tr>
-        <td id="L588" class="blob-num js-line-number" data-line-number="588"></td>
-        <td id="LC588" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param delimiter: Character you use to group keys.</span></td>
-      </tr>
-      <tr>
-        <td id="L589" class="blob-num js-line-number" data-line-number="589"></td>
-        <td id="LC589" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            All keys that contain the same string between the prefix, if</span></td>
-      </tr>
-      <tr>
-        <td id="L590" class="blob-num js-line-number" data-line-number="590"></td>
-        <td id="LC590" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            specified, and the first occurrence of the delimiter after the</span></td>
-      </tr>
-      <tr>
-        <td id="L591" class="blob-num js-line-number" data-line-number="591"></td>
-        <td id="LC591" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            prefix are grouped under a single result element, CommonPrefixes.</span></td>
-      </tr>
-      <tr>
-        <td id="L592" class="blob-num js-line-number" data-line-number="592"></td>
-        <td id="LC592" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            If you don&#39;t specify the prefix parameter, then the substring</span></td>
-      </tr>
-      <tr>
-        <td id="L593" class="blob-num js-line-number" data-line-number="593"></td>
-        <td id="LC593" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            starts at the beginning of the key. The keys that are grouped</span></td>
-      </tr>
-      <tr>
-        <td id="L594" class="blob-num js-line-number" data-line-number="594"></td>
-        <td id="LC594" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            under CommonPrefixes result element are not returned elsewhere</span></td>
-      </tr>
-      <tr>
-        <td id="L595" class="blob-num js-line-number" data-line-number="595"></td>
-        <td id="LC595" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            in the response.</span></td>
-      </tr>
-      <tr>
-        <td id="L596" class="blob-num js-line-number" data-line-number="596"></td>
-        <td id="LC596" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L597" class="blob-num js-line-number" data-line-number="597"></td>
-        <td id="LC597" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type prefix: string</span></td>
-      </tr>
-      <tr>
-        <td id="L598" class="blob-num js-line-number" data-line-number="598"></td>
-        <td id="LC598" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param prefix: Lists in-progress uploads only for those keys that</span></td>
-      </tr>
-      <tr>
-        <td id="L599" class="blob-num js-line-number" data-line-number="599"></td>
-        <td id="LC599" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            begin with the specified prefix. You can use prefixes to separate</span></td>
-      </tr>
-      <tr>
-        <td id="L600" class="blob-num js-line-number" data-line-number="600"></td>
-        <td id="LC600" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            a bucket into different grouping of keys. (You can think of using</span></td>
-      </tr>
-      <tr>
-        <td id="L601" class="blob-num js-line-number" data-line-number="601"></td>
-        <td id="LC601" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            prefix to make groups in the same way you&#39;d use a folder in a</span></td>
-      </tr>
-      <tr>
-        <td id="L602" class="blob-num js-line-number" data-line-number="602"></td>
-        <td id="LC602" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            file system.)</span></td>
-      </tr>
-      <tr>
-        <td id="L603" class="blob-num js-line-number" data-line-number="603"></td>
-        <td id="LC603" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L604" class="blob-num js-line-number" data-line-number="604"></td>
-        <td id="LC604" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: ResultSet</span></td>
-      </tr>
-      <tr>
-        <td id="L605" class="blob-num js-line-number" data-line-number="605"></td>
-        <td id="LC605" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: The result from S3 listing the uploads requested</span></td>
-      </tr>
-      <tr>
-        <td id="L606" class="blob-num js-line-number" data-line-number="606"></td>
-        <td id="LC606" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L607" class="blob-num js-line-number" data-line-number="607"></td>
-        <td id="LC607" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L608" class="blob-num js-line-number" data-line-number="608"></td>
-        <td id="LC608" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.validate_kwarg_names(params, [<span class="pl-s"><span class="pl-pds">&#39;</span>max_uploads<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>key_marker<span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L609" class="blob-num js-line-number" data-line-number="609"></td>
-        <td id="LC609" class="blob-code blob-code-inner js-file-line">                                           <span class="pl-s"><span class="pl-pds">&#39;</span>upload_id_marker<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>encoding_type<span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L610" class="blob-num js-line-number" data-line-number="610"></td>
-        <td id="LC610" class="blob-code blob-code-inner js-file-line">                                           <span class="pl-s"><span class="pl-pds">&#39;</span>delimiter<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>prefix<span class="pl-pds">&#39;</span></span>])</td>
-      </tr>
-      <tr>
-        <td id="L611" class="blob-num js-line-number" data-line-number="611"></td>
-        <td id="LC611" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>._get_all([(<span class="pl-s"><span class="pl-pds">&#39;</span>Upload<span class="pl-pds">&#39;</span></span>, MultiPartUpload),</td>
-      </tr>
-      <tr>
-        <td id="L612" class="blob-num js-line-number" data-line-number="612"></td>
-        <td id="LC612" class="blob-code blob-code-inner js-file-line">                              (<span class="pl-s"><span class="pl-pds">&#39;</span>CommonPrefixes<span class="pl-pds">&#39;</span></span>, Prefix)],</td>
-      </tr>
-      <tr>
-        <td id="L613" class="blob-num js-line-number" data-line-number="613"></td>
-        <td id="LC613" class="blob-code blob-code-inner js-file-line">                             <span class="pl-s"><span class="pl-pds">&#39;</span>uploads<span class="pl-pds">&#39;</span></span>, headers, <span class="pl-k">**</span>params)</td>
-      </tr>
-      <tr>
-        <td id="L614" class="blob-num js-line-number" data-line-number="614"></td>
-        <td id="LC614" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L615" class="blob-num js-line-number" data-line-number="615"></td>
-        <td id="LC615" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">new_key</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L616" class="blob-num js-line-number" data-line-number="616"></td>
-        <td id="LC616" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L617" class="blob-num js-line-number" data-line-number="617"></td>
-        <td id="LC617" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Creates a new key</span></td>
-      </tr>
-      <tr>
-        <td id="L618" class="blob-num js-line-number" data-line-number="618"></td>
-        <td id="LC618" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L619" class="blob-num js-line-number" data-line-number="619"></td>
-        <td id="LC619" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_name: string</span></td>
-      </tr>
-      <tr>
-        <td id="L620" class="blob-num js-line-number" data-line-number="620"></td>
-        <td id="LC620" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_name: The name of the key to create</span></td>
-      </tr>
-      <tr>
-        <td id="L621" class="blob-num js-line-number" data-line-number="621"></td>
-        <td id="LC621" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L622" class="blob-num js-line-number" data-line-number="622"></td>
-        <td id="LC622" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.key.Key` or subclass</span></td>
-      </tr>
-      <tr>
-        <td id="L623" class="blob-num js-line-number" data-line-number="623"></td>
-        <td id="LC623" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: An instance of the newly created key object</span></td>
-      </tr>
-      <tr>
-        <td id="L624" class="blob-num js-line-number" data-line-number="624"></td>
-        <td id="LC624" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L625" class="blob-num js-line-number" data-line-number="625"></td>
-        <td id="LC625" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> key_name:</td>
-      </tr>
-      <tr>
-        <td id="L626" class="blob-num js-line-number" data-line-number="626"></td>
-        <td id="LC626" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">ValueError</span>(<span class="pl-s"><span class="pl-pds">&#39;</span>Empty key names are not allowed<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L627" class="blob-num js-line-number" data-line-number="627"></td>
-        <td id="LC627" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.key_class(<span class="pl-c1">self</span>, key_name)</td>
-      </tr>
-      <tr>
-        <td id="L628" class="blob-num js-line-number" data-line-number="628"></td>
-        <td id="LC628" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L629" class="blob-num js-line-number" data-line-number="629"></td>
-        <td id="LC629" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">generate_url</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">expires_in</span>, <span class="pl-smi">method</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
-      </tr>
-      <tr>
-        <td id="L630" class="blob-num js-line-number" data-line-number="630"></td>
-        <td id="LC630" class="blob-code blob-code-inner js-file-line">                     <span class="pl-smi">force_http</span><span class="pl-k">=</span><span class="pl-c1">False</span>, <span class="pl-smi">response_headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
-      </tr>
-      <tr>
-        <td id="L631" class="blob-num js-line-number" data-line-number="631"></td>
-        <td id="LC631" class="blob-code blob-code-inner js-file-line">                     <span class="pl-smi">expires_in_absolute</span><span class="pl-k">=</span><span class="pl-c1">False</span>):</td>
-      </tr>
-      <tr>
-        <td id="L632" class="blob-num js-line-number" data-line-number="632"></td>
-        <td id="LC632" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.connection.generate_url(expires_in, method, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L633" class="blob-num js-line-number" data-line-number="633"></td>
-        <td id="LC633" class="blob-code blob-code-inner js-file-line">                                            <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
-      </tr>
-      <tr>
-        <td id="L634" class="blob-num js-line-number" data-line-number="634"></td>
-        <td id="LC634" class="blob-code blob-code-inner js-file-line">                                            <span class="pl-v">force_http</span><span class="pl-k">=</span>force_http,</td>
-      </tr>
-      <tr>
-        <td id="L635" class="blob-num js-line-number" data-line-number="635"></td>
-        <td id="LC635" class="blob-code blob-code-inner js-file-line">                                            <span class="pl-v">response_headers</span><span class="pl-k">=</span>response_headers,</td>
-      </tr>
-      <tr>
-        <td id="L636" class="blob-num js-line-number" data-line-number="636"></td>
-        <td id="LC636" class="blob-code blob-code-inner js-file-line">                                            <span class="pl-v">expires_in_absolute</span><span class="pl-k">=</span>expires_in_absolute)</td>
-      </tr>
-      <tr>
-        <td id="L637" class="blob-num js-line-number" data-line-number="637"></td>
-        <td id="LC637" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L638" class="blob-num js-line-number" data-line-number="638"></td>
-        <td id="LC638" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete_keys</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">keys</span>, <span class="pl-smi">quiet</span><span class="pl-k">=</span><span class="pl-c1">False</span>, <span class="pl-smi">mfa_token</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L639" class="blob-num js-line-number" data-line-number="639"></td>
-        <td id="LC639" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L640" class="blob-num js-line-number" data-line-number="640"></td>
-        <td id="LC640" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Deletes a set of keys using S3&#39;s Multi-object delete API. If a</span></td>
-      </tr>
-      <tr>
-        <td id="L641" class="blob-num js-line-number" data-line-number="641"></td>
-        <td id="LC641" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        VersionID is specified for that key then that version is removed.</span></td>
-      </tr>
-      <tr>
-        <td id="L642" class="blob-num js-line-number" data-line-number="642"></td>
-        <td id="LC642" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns a MultiDeleteResult Object, which contains Deleted</span></td>
-      </tr>
-      <tr>
-        <td id="L643" class="blob-num js-line-number" data-line-number="643"></td>
-        <td id="LC643" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        and Error elements for each key you ask to delete.</span></td>
-      </tr>
-      <tr>
-        <td id="L644" class="blob-num js-line-number" data-line-number="644"></td>
-        <td id="LC644" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L645" class="blob-num js-line-number" data-line-number="645"></td>
-        <td id="LC645" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type keys: list</span></td>
-      </tr>
-      <tr>
-        <td id="L646" class="blob-num js-line-number" data-line-number="646"></td>
-        <td id="LC646" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param keys: A list of either key_names or (key_name, versionid) pairs</span></td>
-      </tr>
-      <tr>
-        <td id="L647" class="blob-num js-line-number" data-line-number="647"></td>
-        <td id="LC647" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            or a list of Key instances.</span></td>
-      </tr>
-      <tr>
-        <td id="L648" class="blob-num js-line-number" data-line-number="648"></td>
-        <td id="LC648" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L649" class="blob-num js-line-number" data-line-number="649"></td>
-        <td id="LC649" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type quiet: boolean</span></td>
-      </tr>
-      <tr>
-        <td id="L650" class="blob-num js-line-number" data-line-number="650"></td>
-        <td id="LC650" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param quiet: In quiet mode the response includes only keys</span></td>
-      </tr>
-      <tr>
-        <td id="L651" class="blob-num js-line-number" data-line-number="651"></td>
-        <td id="LC651" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            where the delete operation encountered an error. For a</span></td>
-      </tr>
-      <tr>
-        <td id="L652" class="blob-num js-line-number" data-line-number="652"></td>
-        <td id="LC652" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            successful deletion, the operation does not return any</span></td>
-      </tr>
-      <tr>
-        <td id="L653" class="blob-num js-line-number" data-line-number="653"></td>
-        <td id="LC653" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            information about the delete in the response body.</span></td>
-      </tr>
-      <tr>
-        <td id="L654" class="blob-num js-line-number" data-line-number="654"></td>
-        <td id="LC654" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L655" class="blob-num js-line-number" data-line-number="655"></td>
-        <td id="LC655" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type mfa_token: tuple or list of strings</span></td>
-      </tr>
-      <tr>
-        <td id="L656" class="blob-num js-line-number" data-line-number="656"></td>
-        <td id="LC656" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param mfa_token: A tuple or list consisting of the serial</span></td>
-      </tr>
-      <tr>
-        <td id="L657" class="blob-num js-line-number" data-line-number="657"></td>
-        <td id="LC657" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            number from the MFA device and the current value of the</span></td>
-      </tr>
-      <tr>
-        <td id="L658" class="blob-num js-line-number" data-line-number="658"></td>
-        <td id="LC658" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            six-digit token associated with the device.  This value is</span></td>
-      </tr>
-      <tr>
-        <td id="L659" class="blob-num js-line-number" data-line-number="659"></td>
-        <td id="LC659" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            required anytime you are deleting versioned objects from a</span></td>
-      </tr>
-      <tr>
-        <td id="L660" class="blob-num js-line-number" data-line-number="660"></td>
-        <td id="LC660" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            bucket that has the MFADelete option on the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L661" class="blob-num js-line-number" data-line-number="661"></td>
-        <td id="LC661" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L662" class="blob-num js-line-number" data-line-number="662"></td>
-        <td id="LC662" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: An instance of MultiDeleteResult</span></td>
-      </tr>
-      <tr>
-        <td id="L663" class="blob-num js-line-number" data-line-number="663"></td>
-        <td id="LC663" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L664" class="blob-num js-line-number" data-line-number="664"></td>
-        <td id="LC664" class="blob-code blob-code-inner js-file-line">        ikeys <span class="pl-k">=</span> <span class="pl-c1">iter</span>(keys)</td>
-      </tr>
-      <tr>
-        <td id="L665" class="blob-num js-line-number" data-line-number="665"></td>
-        <td id="LC665" class="blob-code blob-code-inner js-file-line">        result <span class="pl-k">=</span> MultiDeleteResult(<span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L666" class="blob-num js-line-number" data-line-number="666"></td>
-        <td id="LC666" class="blob-code blob-code-inner js-file-line">        provider <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.provider</td>
-      </tr>
-      <tr>
-        <td id="L667" class="blob-num js-line-number" data-line-number="667"></td>
-        <td id="LC667" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>delete<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L668" class="blob-num js-line-number" data-line-number="668"></td>
-        <td id="LC668" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L669" class="blob-num js-line-number" data-line-number="669"></td>
-        <td id="LC669" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">def</span> <span class="pl-en">delete_keys2</span>(<span class="pl-smi">hdrs</span>):</td>
-      </tr>
-      <tr>
-        <td id="L670" class="blob-num js-line-number" data-line-number="670"></td>
-        <td id="LC670" class="blob-code blob-code-inner js-file-line">            hdrs <span class="pl-k">=</span> hdrs <span class="pl-k">or</span> {}</td>
-      </tr>
-      <tr>
-        <td id="L671" class="blob-num js-line-number" data-line-number="671"></td>
-        <td id="LC671" class="blob-code blob-code-inner js-file-line">            data <span class="pl-k">=</span> <span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&quot;&quot;&quot;</span>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;<span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L672" class="blob-num js-line-number" data-line-number="672"></td>
-        <td id="LC672" class="blob-code blob-code-inner js-file-line">            data <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&quot;</span>&lt;Delete&gt;<span class="pl-pds">&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L673" class="blob-num js-line-number" data-line-number="673"></td>
-        <td id="LC673" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> quiet:</td>
-      </tr>
-      <tr>
-        <td id="L674" class="blob-num js-line-number" data-line-number="674"></td>
-        <td id="LC674" class="blob-code blob-code-inner js-file-line">                data <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&quot;</span>&lt;Quiet&gt;true&lt;/Quiet&gt;<span class="pl-pds">&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L675" class="blob-num js-line-number" data-line-number="675"></td>
-        <td id="LC675" class="blob-code blob-code-inner js-file-line">            count <span class="pl-k">=</span> <span class="pl-c1">0</span></td>
-      </tr>
-      <tr>
-        <td id="L676" class="blob-num js-line-number" data-line-number="676"></td>
-        <td id="LC676" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">while</span> count <span class="pl-k">&lt;</span> <span class="pl-c1">1000</span>:</td>
-      </tr>
-      <tr>
-        <td id="L677" class="blob-num js-line-number" data-line-number="677"></td>
-        <td id="LC677" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">try</span>:</td>
-      </tr>
-      <tr>
-        <td id="L678" class="blob-num js-line-number" data-line-number="678"></td>
-        <td id="LC678" class="blob-code blob-code-inner js-file-line">                    key <span class="pl-k">=</span> <span class="pl-c1">next</span>(ikeys)</td>
-      </tr>
-      <tr>
-        <td id="L679" class="blob-num js-line-number" data-line-number="679"></td>
-        <td id="LC679" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">except</span> <span class="pl-c1">StopIteration</span>:</td>
-      </tr>
-      <tr>
-        <td id="L680" class="blob-num js-line-number" data-line-number="680"></td>
-        <td id="LC680" class="blob-code blob-code-inner js-file-line">                    <span class="pl-k">break</span></td>
-      </tr>
-      <tr>
-        <td id="L681" class="blob-num js-line-number" data-line-number="681"></td>
-        <td id="LC681" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">if</span> <span class="pl-c1">isinstance</span>(key, six.string_types):</td>
-      </tr>
-      <tr>
-        <td id="L682" class="blob-num js-line-number" data-line-number="682"></td>
-        <td id="LC682" class="blob-code blob-code-inner js-file-line">                    key_name <span class="pl-k">=</span> key</td>
-      </tr>
-      <tr>
-        <td id="L683" class="blob-num js-line-number" data-line-number="683"></td>
-        <td id="LC683" class="blob-code blob-code-inner js-file-line">                    version_id <span class="pl-k">=</span> <span class="pl-c1">None</span></td>
-      </tr>
-      <tr>
-        <td id="L684" class="blob-num js-line-number" data-line-number="684"></td>
-        <td id="LC684" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">elif</span> <span class="pl-c1">isinstance</span>(key, <span class="pl-c1">tuple</span>) <span class="pl-k">and</span> <span class="pl-c1">len</span>(key) <span class="pl-k">==</span> <span class="pl-c1">2</span>:</td>
-      </tr>
-      <tr>
-        <td id="L685" class="blob-num js-line-number" data-line-number="685"></td>
-        <td id="LC685" class="blob-code blob-code-inner js-file-line">                    key_name, version_id <span class="pl-k">=</span> key</td>
-      </tr>
-      <tr>
-        <td id="L686" class="blob-num js-line-number" data-line-number="686"></td>
-        <td id="LC686" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">elif</span> (<span class="pl-c1">isinstance</span>(key, Key) <span class="pl-k">or</span> <span class="pl-c1">isinstance</span>(key, DeleteMarker)) <span class="pl-k">and</span> key.name:</td>
-      </tr>
-      <tr>
-        <td id="L687" class="blob-num js-line-number" data-line-number="687"></td>
-        <td id="LC687" class="blob-code blob-code-inner js-file-line">                    key_name <span class="pl-k">=</span> key.name</td>
-      </tr>
-      <tr>
-        <td id="L688" class="blob-num js-line-number" data-line-number="688"></td>
-        <td id="LC688" class="blob-code blob-code-inner js-file-line">                    version_id <span class="pl-k">=</span> key.version_id</td>
-      </tr>
-      <tr>
-        <td id="L689" class="blob-num js-line-number" data-line-number="689"></td>
-        <td id="LC689" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L690" class="blob-num js-line-number" data-line-number="690"></td>
-        <td id="LC690" class="blob-code blob-code-inner js-file-line">                    <span class="pl-k">if</span> <span class="pl-c1">isinstance</span>(key, Prefix):</td>
-      </tr>
-      <tr>
-        <td id="L691" class="blob-num js-line-number" data-line-number="691"></td>
-        <td id="LC691" class="blob-code blob-code-inner js-file-line">                        key_name <span class="pl-k">=</span> key.name</td>
-      </tr>
-      <tr>
-        <td id="L692" class="blob-num js-line-number" data-line-number="692"></td>
-        <td id="LC692" class="blob-code blob-code-inner js-file-line">                        code <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>PrefixSkipped<span class="pl-pds">&#39;</span></span>   <span class="pl-c"><span class="pl-c">#</span> Don&#39;t delete Prefix</span></td>
-      </tr>
-      <tr>
-        <td id="L693" class="blob-num js-line-number" data-line-number="693"></td>
-        <td id="LC693" class="blob-code blob-code-inner js-file-line">                    <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L694" class="blob-num js-line-number" data-line-number="694"></td>
-        <td id="LC694" class="blob-code blob-code-inner js-file-line">                        key_name <span class="pl-k">=</span> <span class="pl-c1">repr</span>(key)   <span class="pl-c"><span class="pl-c">#</span> try get a string</span></td>
-      </tr>
-      <tr>
-        <td id="L695" class="blob-num js-line-number" data-line-number="695"></td>
-        <td id="LC695" class="blob-code blob-code-inner js-file-line">                        code <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>InvalidArgument<span class="pl-pds">&#39;</span></span>  <span class="pl-c"><span class="pl-c">#</span> other unknown type</span></td>
-      </tr>
-      <tr>
-        <td id="L696" class="blob-num js-line-number" data-line-number="696"></td>
-        <td id="LC696" class="blob-code blob-code-inner js-file-line">                    message <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>Invalid. No delete action taken for this object.<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L697" class="blob-num js-line-number" data-line-number="697"></td>
-        <td id="LC697" class="blob-code blob-code-inner js-file-line">                    error <span class="pl-k">=</span> Error(key_name, <span class="pl-v">code</span><span class="pl-k">=</span>code, <span class="pl-v">message</span><span class="pl-k">=</span>message)</td>
-      </tr>
-      <tr>
-        <td id="L698" class="blob-num js-line-number" data-line-number="698"></td>
-        <td id="LC698" class="blob-code blob-code-inner js-file-line">                    result.errors.append(error)</td>
-      </tr>
-      <tr>
-        <td id="L699" class="blob-num js-line-number" data-line-number="699"></td>
-        <td id="LC699" class="blob-code blob-code-inner js-file-line">                    <span class="pl-k">continue</span></td>
-      </tr>
-      <tr>
-        <td id="L700" class="blob-num js-line-number" data-line-number="700"></td>
-        <td id="LC700" class="blob-code blob-code-inner js-file-line">                count <span class="pl-k">+=</span> <span class="pl-c1">1</span></td>
-      </tr>
-      <tr>
-        <td id="L701" class="blob-num js-line-number" data-line-number="701"></td>
-        <td id="LC701" class="blob-code blob-code-inner js-file-line">                data <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&quot;</span>&lt;Object&gt;&lt;Key&gt;<span class="pl-c1">%s</span>&lt;/Key&gt;<span class="pl-pds">&quot;</span></span> <span class="pl-k">%</span> xml.sax.saxutils.escape(key_name)</td>
-      </tr>
-      <tr>
-        <td id="L702" class="blob-num js-line-number" data-line-number="702"></td>
-        <td id="LC702" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">if</span> version_id:</td>
-      </tr>
-      <tr>
-        <td id="L703" class="blob-num js-line-number" data-line-number="703"></td>
-        <td id="LC703" class="blob-code blob-code-inner js-file-line">                    data <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&quot;</span>&lt;VersionId&gt;<span class="pl-c1">%s</span>&lt;/VersionId&gt;<span class="pl-pds">&quot;</span></span> <span class="pl-k">%</span> version_id</td>
-      </tr>
-      <tr>
-        <td id="L704" class="blob-num js-line-number" data-line-number="704"></td>
-        <td id="LC704" class="blob-code blob-code-inner js-file-line">                data <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&quot;</span>&lt;/Object&gt;<span class="pl-pds">&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L705" class="blob-num js-line-number" data-line-number="705"></td>
-        <td id="LC705" class="blob-code blob-code-inner js-file-line">            data <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-k">u</span><span class="pl-pds">&quot;</span>&lt;/Delete&gt;<span class="pl-pds">&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L706" class="blob-num js-line-number" data-line-number="706"></td>
-        <td id="LC706" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> count <span class="pl-k">&lt;=</span> <span class="pl-c1">0</span>:</td>
-      </tr>
-      <tr>
-        <td id="L707" class="blob-num js-line-number" data-line-number="707"></td>
-        <td id="LC707" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">return</span> <span class="pl-c1">False</span>  <span class="pl-c"><span class="pl-c">#</span> no more</span></td>
-      </tr>
-      <tr>
-        <td id="L708" class="blob-num js-line-number" data-line-number="708"></td>
-        <td id="LC708" class="blob-code blob-code-inner js-file-line">            data <span class="pl-k">=</span> data.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L709" class="blob-num js-line-number" data-line-number="709"></td>
-        <td id="LC709" class="blob-code blob-code-inner js-file-line">            fp <span class="pl-k">=</span> BytesIO(data)</td>
-      </tr>
-      <tr>
-        <td id="L710" class="blob-num js-line-number" data-line-number="710"></td>
-        <td id="LC710" class="blob-code blob-code-inner js-file-line">            md5 <span class="pl-k">=</span> boto.utils.compute_md5(fp)</td>
-      </tr>
-      <tr>
-        <td id="L711" class="blob-num js-line-number" data-line-number="711"></td>
-        <td id="LC711" class="blob-code blob-code-inner js-file-line">            hdrs[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-MD5<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> md5[<span class="pl-c1">1</span>]</td>
-      </tr>
-      <tr>
-        <td id="L712" class="blob-num js-line-number" data-line-number="712"></td>
-        <td id="LC712" class="blob-code blob-code-inner js-file-line">            hdrs[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-Type<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>text/xml<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L713" class="blob-num js-line-number" data-line-number="713"></td>
-        <td id="LC713" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> mfa_token:</td>
-      </tr>
-      <tr>
-        <td id="L714" class="blob-num js-line-number" data-line-number="714"></td>
-        <td id="LC714" class="blob-code blob-code-inner js-file-line">                hdrs[provider.mfa_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span> <span class="pl-pds">&#39;</span></span>.join(mfa_token)</td>
-      </tr>
-      <tr>
-        <td id="L715" class="blob-num js-line-number" data-line-number="715"></td>
-        <td id="LC715" class="blob-code blob-code-inner js-file-line">            response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>POST<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L716" class="blob-num js-line-number" data-line-number="716"></td>
-        <td id="LC716" class="blob-code blob-code-inner js-file-line">                                                    <span class="pl-v">headers</span><span class="pl-k">=</span>hdrs,</td>
-      </tr>
-      <tr>
-        <td id="L717" class="blob-num js-line-number" data-line-number="717"></td>
-        <td id="LC717" class="blob-code blob-code-inner js-file-line">                                                    <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
-      </tr>
-      <tr>
-        <td id="L718" class="blob-num js-line-number" data-line-number="718"></td>
-        <td id="LC718" class="blob-code blob-code-inner js-file-line">                                                    <span class="pl-v">data</span><span class="pl-k">=</span>data)</td>
-      </tr>
-      <tr>
-        <td id="L719" class="blob-num js-line-number" data-line-number="719"></td>
-        <td id="LC719" class="blob-code blob-code-inner js-file-line">            body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L720" class="blob-num js-line-number" data-line-number="720"></td>
-        <td id="LC720" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L721" class="blob-num js-line-number" data-line-number="721"></td>
-        <td id="LC721" class="blob-code blob-code-inner js-file-line">                h <span class="pl-k">=</span> handler.XmlHandler(result, <span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L722" class="blob-num js-line-number" data-line-number="722"></td>
-        <td id="LC722" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
-      </tr>
-      <tr>
-        <td id="L723" class="blob-num js-line-number" data-line-number="723"></td>
-        <td id="LC723" class="blob-code blob-code-inner js-file-line">                    body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L724" class="blob-num js-line-number" data-line-number="724"></td>
-        <td id="LC724" class="blob-code blob-code-inner js-file-line">                xml.sax.parseString(body, h)</td>
-      </tr>
-      <tr>
-        <td id="L725" class="blob-num js-line-number" data-line-number="725"></td>
-        <td id="LC725" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">return</span> count <span class="pl-k">&gt;=</span> <span class="pl-c1">1000</span>  <span class="pl-c"><span class="pl-c">#</span> more?</span></td>
-      </tr>
-      <tr>
-        <td id="L726" class="blob-num js-line-number" data-line-number="726"></td>
-        <td id="LC726" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L727" class="blob-num js-line-number" data-line-number="727"></td>
-        <td id="LC727" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">raise</span> provider.storage_response_error(response.status,</td>
-      </tr>
-      <tr>
-        <td id="L728" class="blob-num js-line-number" data-line-number="728"></td>
-        <td id="LC728" class="blob-code blob-code-inner js-file-line">                                                      response.reason,</td>
-      </tr>
-      <tr>
-        <td id="L729" class="blob-num js-line-number" data-line-number="729"></td>
-        <td id="LC729" class="blob-code blob-code-inner js-file-line">                                                      body)</td>
-      </tr>
-      <tr>
-        <td id="L730" class="blob-num js-line-number" data-line-number="730"></td>
-        <td id="LC730" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">while</span> delete_keys2(headers):</td>
-      </tr>
-      <tr>
-        <td id="L731" class="blob-num js-line-number" data-line-number="731"></td>
-        <td id="LC731" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">pass</span></td>
-      </tr>
-      <tr>
-        <td id="L732" class="blob-num js-line-number" data-line-number="732"></td>
-        <td id="LC732" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> result</td>
-      </tr>
-      <tr>
-        <td id="L733" class="blob-num js-line-number" data-line-number="733"></td>
-        <td id="LC733" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L734" class="blob-num js-line-number" data-line-number="734"></td>
-        <td id="LC734" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete_key</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
-      </tr>
-      <tr>
-        <td id="L735" class="blob-num js-line-number" data-line-number="735"></td>
-        <td id="LC735" class="blob-code blob-code-inner js-file-line">                   <span class="pl-smi">mfa_token</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L736" class="blob-num js-line-number" data-line-number="736"></td>
-        <td id="LC736" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L737" class="blob-num js-line-number" data-line-number="737"></td>
-        <td id="LC737" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Deletes a key from the bucket.  If a version_id is provided,</span></td>
-      </tr>
-      <tr>
-        <td id="L738" class="blob-num js-line-number" data-line-number="738"></td>
-        <td id="LC738" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        only that version of the key will be deleted.</span></td>
-      </tr>
-      <tr>
-        <td id="L739" class="blob-num js-line-number" data-line-number="739"></td>
-        <td id="LC739" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L740" class="blob-num js-line-number" data-line-number="740"></td>
-        <td id="LC740" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_name: string</span></td>
-      </tr>
-      <tr>
-        <td id="L741" class="blob-num js-line-number" data-line-number="741"></td>
-        <td id="LC741" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_name: The key name to delete</span></td>
-      </tr>
-      <tr>
-        <td id="L742" class="blob-num js-line-number" data-line-number="742"></td>
-        <td id="LC742" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L743" class="blob-num js-line-number" data-line-number="743"></td>
-        <td id="LC743" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type version_id: string</span></td>
-      </tr>
-      <tr>
-        <td id="L744" class="blob-num js-line-number" data-line-number="744"></td>
-        <td id="LC744" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param version_id: The version ID (optional)</span></td>
-      </tr>
-      <tr>
-        <td id="L745" class="blob-num js-line-number" data-line-number="745"></td>
-        <td id="LC745" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L746" class="blob-num js-line-number" data-line-number="746"></td>
-        <td id="LC746" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type mfa_token: tuple or list of strings</span></td>
-      </tr>
-      <tr>
-        <td id="L747" class="blob-num js-line-number" data-line-number="747"></td>
-        <td id="LC747" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param mfa_token: A tuple or list consisting of the serial</span></td>
-      </tr>
-      <tr>
-        <td id="L748" class="blob-num js-line-number" data-line-number="748"></td>
-        <td id="LC748" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            number from the MFA device and the current value of the</span></td>
-      </tr>
-      <tr>
-        <td id="L749" class="blob-num js-line-number" data-line-number="749"></td>
-        <td id="LC749" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            six-digit token associated with the device.  This value is</span></td>
-      </tr>
-      <tr>
-        <td id="L750" class="blob-num js-line-number" data-line-number="750"></td>
-        <td id="LC750" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            required anytime you are deleting versioned objects from a</span></td>
-      </tr>
-      <tr>
-        <td id="L751" class="blob-num js-line-number" data-line-number="751"></td>
-        <td id="LC751" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            bucket that has the MFADelete option on the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L752" class="blob-num js-line-number" data-line-number="752"></td>
-        <td id="LC752" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L753" class="blob-num js-line-number" data-line-number="753"></td>
-        <td id="LC753" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.key.Key` or subclass</span></td>
-      </tr>
-      <tr>
-        <td id="L754" class="blob-num js-line-number" data-line-number="754"></td>
-        <td id="LC754" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: A key object holding information on what was</span></td>
-      </tr>
-      <tr>
-        <td id="L755" class="blob-num js-line-number" data-line-number="755"></td>
-        <td id="LC755" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            deleted.  The Caller can see if a delete_marker was</span></td>
-      </tr>
-      <tr>
-        <td id="L756" class="blob-num js-line-number" data-line-number="756"></td>
-        <td id="LC756" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            created or removed and what version_id the delete created</span></td>
-      </tr>
-      <tr>
-        <td id="L757" class="blob-num js-line-number" data-line-number="757"></td>
-        <td id="LC757" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            or removed.</span></td>
-      </tr>
-      <tr>
-        <td id="L758" class="blob-num js-line-number" data-line-number="758"></td>
-        <td id="LC758" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L759" class="blob-num js-line-number" data-line-number="759"></td>
-        <td id="LC759" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> key_name:</td>
-      </tr>
-      <tr>
-        <td id="L760" class="blob-num js-line-number" data-line-number="760"></td>
-        <td id="LC760" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">ValueError</span>(<span class="pl-s"><span class="pl-pds">&#39;</span>Empty key names are not allowed<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L761" class="blob-num js-line-number" data-line-number="761"></td>
-        <td id="LC761" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>._delete_key_internal(key_name, <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
-      </tr>
-      <tr>
-        <td id="L762" class="blob-num js-line-number" data-line-number="762"></td>
-        <td id="LC762" class="blob-code blob-code-inner js-file-line">                                         <span class="pl-v">version_id</span><span class="pl-k">=</span>version_id,</td>
-      </tr>
-      <tr>
-        <td id="L763" class="blob-num js-line-number" data-line-number="763"></td>
-        <td id="LC763" class="blob-code blob-code-inner js-file-line">                                         <span class="pl-v">mfa_token</span><span class="pl-k">=</span>mfa_token,</td>
-      </tr>
-      <tr>
-        <td id="L764" class="blob-num js-line-number" data-line-number="764"></td>
-        <td id="LC764" class="blob-code blob-code-inner js-file-line">                                         <span class="pl-v">query_args_l</span><span class="pl-k">=</span><span class="pl-c1">None</span>)</td>
-      </tr>
-      <tr>
-        <td id="L765" class="blob-num js-line-number" data-line-number="765"></td>
-        <td id="LC765" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L766" class="blob-num js-line-number" data-line-number="766"></td>
-        <td id="LC766" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">_delete_key_internal</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
-      </tr>
-      <tr>
-        <td id="L767" class="blob-num js-line-number" data-line-number="767"></td>
-        <td id="LC767" class="blob-code blob-code-inner js-file-line">                             <span class="pl-smi">mfa_token</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">query_args_l</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L768" class="blob-num js-line-number" data-line-number="768"></td>
-        <td id="LC768" class="blob-code blob-code-inner js-file-line">        query_args_l <span class="pl-k">=</span> query_args_l <span class="pl-k">or</span> []</td>
-      </tr>
-      <tr>
-        <td id="L769" class="blob-num js-line-number" data-line-number="769"></td>
-        <td id="LC769" class="blob-code blob-code-inner js-file-line">        provider <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.provider</td>
-      </tr>
-      <tr>
-        <td id="L770" class="blob-num js-line-number" data-line-number="770"></td>
-        <td id="LC770" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
-      </tr>
-      <tr>
-        <td id="L771" class="blob-num js-line-number" data-line-number="771"></td>
-        <td id="LC771" class="blob-code blob-code-inner js-file-line">            query_args_l.append(<span class="pl-s"><span class="pl-pds">&#39;</span>versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id)</td>
-      </tr>
-      <tr>
-        <td id="L772" class="blob-num js-line-number" data-line-number="772"></td>
-        <td id="LC772" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;<span class="pl-pds">&#39;</span></span>.join(query_args_l) <span class="pl-k">or</span> <span class="pl-c1">None</span></td>
-      </tr>
-      <tr>
-        <td id="L773" class="blob-num js-line-number" data-line-number="773"></td>
-        <td id="LC773" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> mfa_token:</td>
-      </tr>
-      <tr>
-        <td id="L774" class="blob-num js-line-number" data-line-number="774"></td>
-        <td id="LC774" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> headers:</td>
-      </tr>
-      <tr>
-        <td id="L775" class="blob-num js-line-number" data-line-number="775"></td>
-        <td id="LC775" class="blob-code blob-code-inner js-file-line">                headers <span class="pl-k">=</span> {}</td>
-      </tr>
-      <tr>
-        <td id="L776" class="blob-num js-line-number" data-line-number="776"></td>
-        <td id="LC776" class="blob-code blob-code-inner js-file-line">            headers[provider.mfa_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span> <span class="pl-pds">&#39;</span></span>.join(mfa_token)</td>
-      </tr>
-      <tr>
-        <td id="L777" class="blob-num js-line-number" data-line-number="777"></td>
-        <td id="LC777" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>DELETE<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
-      </tr>
-      <tr>
-        <td id="L778" class="blob-num js-line-number" data-line-number="778"></td>
-        <td id="LC778" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
-      </tr>
-      <tr>
-        <td id="L779" class="blob-num js-line-number" data-line-number="779"></td>
-        <td id="LC779" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args)</td>
-      </tr>
-      <tr>
-        <td id="L780" class="blob-num js-line-number" data-line-number="780"></td>
-        <td id="LC780" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L781" class="blob-num js-line-number" data-line-number="781"></td>
-        <td id="LC781" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">204</span>:</td>
-      </tr>
-      <tr>
-        <td id="L782" class="blob-num js-line-number" data-line-number="782"></td>
-        <td id="LC782" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> provider.storage_response_error(response.status,</td>
-      </tr>
-      <tr>
-        <td id="L783" class="blob-num js-line-number" data-line-number="783"></td>
-        <td id="LC783" class="blob-code blob-code-inner js-file-line">                                                  response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L784" class="blob-num js-line-number" data-line-number="784"></td>
-        <td id="LC784" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L785" class="blob-num js-line-number" data-line-number="785"></td>
-        <td id="LC785" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> return a key object with information on what was deleted.</span></td>
-      </tr>
-      <tr>
-        <td id="L786" class="blob-num js-line-number" data-line-number="786"></td>
-        <td id="LC786" class="blob-code blob-code-inner js-file-line">            k <span class="pl-k">=</span> <span class="pl-c1">self</span>.key_class(<span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L787" class="blob-num js-line-number" data-line-number="787"></td>
-        <td id="LC787" class="blob-code blob-code-inner js-file-line">            k.name <span class="pl-k">=</span> key_name</td>
-      </tr>
-      <tr>
-        <td id="L788" class="blob-num js-line-number" data-line-number="788"></td>
-        <td id="LC788" class="blob-code blob-code-inner js-file-line">            k.handle_version_headers(response)</td>
-      </tr>
-      <tr>
-        <td id="L789" class="blob-num js-line-number" data-line-number="789"></td>
-        <td id="LC789" class="blob-code blob-code-inner js-file-line">            k.handle_addl_headers(response.getheaders())</td>
-      </tr>
-      <tr>
-        <td id="L790" class="blob-num js-line-number" data-line-number="790"></td>
-        <td id="LC790" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> k</td>
-      </tr>
-      <tr>
-        <td id="L791" class="blob-num js-line-number" data-line-number="791"></td>
-        <td id="LC791" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L792" class="blob-num js-line-number" data-line-number="792"></td>
-        <td id="LC792" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">copy_key</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">new_key_name</span>, <span class="pl-smi">src_bucket_name</span>,</td>
-      </tr>
-      <tr>
-        <td id="L793" class="blob-num js-line-number" data-line-number="793"></td>
-        <td id="LC793" class="blob-code blob-code-inner js-file-line">                 <span class="pl-smi">src_key_name</span>, <span class="pl-smi">metadata</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">src_version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
-      </tr>
-      <tr>
-        <td id="L794" class="blob-num js-line-number" data-line-number="794"></td>
-        <td id="LC794" class="blob-code blob-code-inner js-file-line">                 <span class="pl-smi">storage_class</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>STANDARD<span class="pl-pds">&#39;</span></span>, <span class="pl-smi">preserve_acl</span><span class="pl-k">=</span><span class="pl-c1">False</span>,</td>
-      </tr>
-      <tr>
-        <td id="L795" class="blob-num js-line-number" data-line-number="795"></td>
-        <td id="LC795" class="blob-code blob-code-inner js-file-line">                 <span class="pl-smi">encrypt_key</span><span class="pl-k">=</span><span class="pl-c1">False</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">query_args</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L796" class="blob-num js-line-number" data-line-number="796"></td>
-        <td id="LC796" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L797" class="blob-num js-line-number" data-line-number="797"></td>
-        <td id="LC797" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Create a new key in the bucket by copying another existing key.</span></td>
-      </tr>
-      <tr>
-        <td id="L798" class="blob-num js-line-number" data-line-number="798"></td>
-        <td id="LC798" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L799" class="blob-num js-line-number" data-line-number="799"></td>
-        <td id="LC799" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type new_key_name: string</span></td>
-      </tr>
-      <tr>
-        <td id="L800" class="blob-num js-line-number" data-line-number="800"></td>
-        <td id="LC800" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param new_key_name: The name of the new key</span></td>
-      </tr>
-      <tr>
-        <td id="L801" class="blob-num js-line-number" data-line-number="801"></td>
-        <td id="LC801" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L802" class="blob-num js-line-number" data-line-number="802"></td>
-        <td id="LC802" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type src_bucket_name: string</span></td>
-      </tr>
-      <tr>
-        <td id="L803" class="blob-num js-line-number" data-line-number="803"></td>
-        <td id="LC803" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param src_bucket_name: The name of the source bucket</span></td>
-      </tr>
-      <tr>
-        <td id="L804" class="blob-num js-line-number" data-line-number="804"></td>
-        <td id="LC804" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L805" class="blob-num js-line-number" data-line-number="805"></td>
-        <td id="LC805" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type src_key_name: string</span></td>
-      </tr>
-      <tr>
-        <td id="L806" class="blob-num js-line-number" data-line-number="806"></td>
-        <td id="LC806" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param src_key_name: The name of the source key</span></td>
-      </tr>
-      <tr>
-        <td id="L807" class="blob-num js-line-number" data-line-number="807"></td>
-        <td id="LC807" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L808" class="blob-num js-line-number" data-line-number="808"></td>
-        <td id="LC808" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type src_version_id: string</span></td>
-      </tr>
-      <tr>
-        <td id="L809" class="blob-num js-line-number" data-line-number="809"></td>
-        <td id="LC809" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param src_version_id: The version id for the key.  This param</span></td>
-      </tr>
-      <tr>
-        <td id="L810" class="blob-num js-line-number" data-line-number="810"></td>
-        <td id="LC810" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            is optional.  If not specified, the newest version of the</span></td>
-      </tr>
-      <tr>
-        <td id="L811" class="blob-num js-line-number" data-line-number="811"></td>
-        <td id="LC811" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            key will be copied.</span></td>
-      </tr>
-      <tr>
-        <td id="L812" class="blob-num js-line-number" data-line-number="812"></td>
-        <td id="LC812" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L813" class="blob-num js-line-number" data-line-number="813"></td>
-        <td id="LC813" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type metadata: dict</span></td>
-      </tr>
-      <tr>
-        <td id="L814" class="blob-num js-line-number" data-line-number="814"></td>
-        <td id="LC814" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param metadata: Metadata to be associated with new key.  If</span></td>
-      </tr>
-      <tr>
-        <td id="L815" class="blob-num js-line-number" data-line-number="815"></td>
-        <td id="LC815" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            metadata is supplied, it will replace the metadata of the</span></td>
-      </tr>
-      <tr>
-        <td id="L816" class="blob-num js-line-number" data-line-number="816"></td>
-        <td id="LC816" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            source key being copied.  If no metadata is supplied, the</span></td>
-      </tr>
-      <tr>
-        <td id="L817" class="blob-num js-line-number" data-line-number="817"></td>
-        <td id="LC817" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            source key&#39;s metadata will be copied to the new key.</span></td>
-      </tr>
-      <tr>
-        <td id="L818" class="blob-num js-line-number" data-line-number="818"></td>
-        <td id="LC818" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L819" class="blob-num js-line-number" data-line-number="819"></td>
-        <td id="LC819" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type storage_class: string</span></td>
-      </tr>
-      <tr>
-        <td id="L820" class="blob-num js-line-number" data-line-number="820"></td>
-        <td id="LC820" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param storage_class: The storage class of the new key.  By</span></td>
-      </tr>
-      <tr>
-        <td id="L821" class="blob-num js-line-number" data-line-number="821"></td>
-        <td id="LC821" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            default, the new key will use the standard storage class.</span></td>
-      </tr>
-      <tr>
-        <td id="L822" class="blob-num js-line-number" data-line-number="822"></td>
-        <td id="LC822" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Possible values are: STANDARD | REDUCED_REDUNDANCY</span></td>
-      </tr>
-      <tr>
-        <td id="L823" class="blob-num js-line-number" data-line-number="823"></td>
-        <td id="LC823" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L824" class="blob-num js-line-number" data-line-number="824"></td>
-        <td id="LC824" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type preserve_acl: bool</span></td>
-      </tr>
-      <tr>
-        <td id="L825" class="blob-num js-line-number" data-line-number="825"></td>
-        <td id="LC825" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param preserve_acl: If True, the ACL from the source key will</span></td>
-      </tr>
-      <tr>
-        <td id="L826" class="blob-num js-line-number" data-line-number="826"></td>
-        <td id="LC826" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            be copied to the destination key.  If False, the</span></td>
-      </tr>
-      <tr>
-        <td id="L827" class="blob-num js-line-number" data-line-number="827"></td>
-        <td id="LC827" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            destination key will have the default ACL.  Note that</span></td>
-      </tr>
-      <tr>
-        <td id="L828" class="blob-num js-line-number" data-line-number="828"></td>
-        <td id="LC828" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            preserving the ACL in the new key object will require two</span></td>
-      </tr>
-      <tr>
-        <td id="L829" class="blob-num js-line-number" data-line-number="829"></td>
-        <td id="LC829" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            additional API calls to S3, one to retrieve the current</span></td>
-      </tr>
-      <tr>
-        <td id="L830" class="blob-num js-line-number" data-line-number="830"></td>
-        <td id="LC830" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ACL and one to set that ACL on the new object.  If you</span></td>
-      </tr>
-      <tr>
-        <td id="L831" class="blob-num js-line-number" data-line-number="831"></td>
-        <td id="LC831" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            don&#39;t care about the ACL, a value of False will be</span></td>
-      </tr>
-      <tr>
-        <td id="L832" class="blob-num js-line-number" data-line-number="832"></td>
-        <td id="LC832" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            significantly more efficient.</span></td>
-      </tr>
-      <tr>
-        <td id="L833" class="blob-num js-line-number" data-line-number="833"></td>
-        <td id="LC833" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L834" class="blob-num js-line-number" data-line-number="834"></td>
-        <td id="LC834" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encrypt_key: bool</span></td>
-      </tr>
-      <tr>
-        <td id="L835" class="blob-num js-line-number" data-line-number="835"></td>
-        <td id="LC835" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encrypt_key: If True, the new copy of the object will</span></td>
-      </tr>
-      <tr>
-        <td id="L836" class="blob-num js-line-number" data-line-number="836"></td>
-        <td id="LC836" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            be encrypted on the server-side by S3 and will be stored</span></td>
-      </tr>
-      <tr>
-        <td id="L837" class="blob-num js-line-number" data-line-number="837"></td>
-        <td id="LC837" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            in an encrypted form while at rest in S3.</span></td>
-      </tr>
-      <tr>
-        <td id="L838" class="blob-num js-line-number" data-line-number="838"></td>
-        <td id="LC838" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L839" class="blob-num js-line-number" data-line-number="839"></td>
-        <td id="LC839" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type headers: dict</span></td>
-      </tr>
-      <tr>
-        <td id="L840" class="blob-num js-line-number" data-line-number="840"></td>
-        <td id="LC840" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param headers: A dictionary of header name/value pairs.</span></td>
-      </tr>
-      <tr>
-        <td id="L841" class="blob-num js-line-number" data-line-number="841"></td>
-        <td id="LC841" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L842" class="blob-num js-line-number" data-line-number="842"></td>
-        <td id="LC842" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type query_args: string</span></td>
-      </tr>
-      <tr>
-        <td id="L843" class="blob-num js-line-number" data-line-number="843"></td>
-        <td id="LC843" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param query_args: A string of additional querystring arguments</span></td>
-      </tr>
-      <tr>
-        <td id="L844" class="blob-num js-line-number" data-line-number="844"></td>
-        <td id="LC844" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            to append to the request</span></td>
-      </tr>
-      <tr>
-        <td id="L845" class="blob-num js-line-number" data-line-number="845"></td>
-        <td id="LC845" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L846" class="blob-num js-line-number" data-line-number="846"></td>
-        <td id="LC846" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.key.Key` or subclass</span></td>
-      </tr>
-      <tr>
-        <td id="L847" class="blob-num js-line-number" data-line-number="847"></td>
-        <td id="LC847" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: An instance of the newly created key object</span></td>
-      </tr>
-      <tr>
-        <td id="L848" class="blob-num js-line-number" data-line-number="848"></td>
-        <td id="LC848" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L849" class="blob-num js-line-number" data-line-number="849"></td>
-        <td id="LC849" class="blob-code blob-code-inner js-file-line">        headers <span class="pl-k">=</span> headers <span class="pl-k">or</span> {}</td>
-      </tr>
-      <tr>
-        <td id="L850" class="blob-num js-line-number" data-line-number="850"></td>
-        <td id="LC850" class="blob-code blob-code-inner js-file-line">        provider <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.provider</td>
-      </tr>
-      <tr>
-        <td id="L851" class="blob-num js-line-number" data-line-number="851"></td>
-        <td id="LC851" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> six.<span class="pl-c1">PY3</span>:</td>
-      </tr>
-      <tr>
-        <td id="L852" class="blob-num js-line-number" data-line-number="852"></td>
-        <td id="LC852" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-c1">isinstance</span>(src_key_name, <span class="pl-c1">bytes</span>):</td>
-      </tr>
-      <tr>
-        <td id="L853" class="blob-num js-line-number" data-line-number="853"></td>
-        <td id="LC853" class="blob-code blob-code-inner js-file-line">                src_key_name <span class="pl-k">=</span> src_key_name.decode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L854" class="blob-num js-line-number" data-line-number="854"></td>
-        <td id="LC854" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L855" class="blob-num js-line-number" data-line-number="855"></td>
-        <td id="LC855" class="blob-code blob-code-inner js-file-line">            src_key_name <span class="pl-k">=</span> boto.utils.get_utf8_value(src_key_name)</td>
-      </tr>
-      <tr>
-        <td id="L856" class="blob-num js-line-number" data-line-number="856"></td>
-        <td id="LC856" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> preserve_acl:</td>
-      </tr>
-      <tr>
-        <td id="L857" class="blob-num js-line-number" data-line-number="857"></td>
-        <td id="LC857" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-c1">self</span>.name <span class="pl-k">==</span> src_bucket_name:</td>
-      </tr>
-      <tr>
-        <td id="L858" class="blob-num js-line-number" data-line-number="858"></td>
-        <td id="LC858" class="blob-code blob-code-inner js-file-line">                src_bucket <span class="pl-k">=</span> <span class="pl-c1">self</span></td>
-      </tr>
-      <tr>
-        <td id="L859" class="blob-num js-line-number" data-line-number="859"></td>
-        <td id="LC859" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L860" class="blob-num js-line-number" data-line-number="860"></td>
-        <td id="LC860" class="blob-code blob-code-inner js-file-line">                src_bucket <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.get_bucket(</td>
-      </tr>
-      <tr>
-        <td id="L861" class="blob-num js-line-number" data-line-number="861"></td>
-        <td id="LC861" class="blob-code blob-code-inner js-file-line">                    src_bucket_name, <span class="pl-v">validate</span><span class="pl-k">=</span><span class="pl-c1">False</span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L862" class="blob-num js-line-number" data-line-number="862"></td>
-        <td id="LC862" class="blob-code blob-code-inner js-file-line">            acl <span class="pl-k">=</span> src_bucket.get_xml_acl(src_key_name, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L863" class="blob-num js-line-number" data-line-number="863"></td>
-        <td id="LC863" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> encrypt_key:</td>
-      </tr>
-      <tr>
-        <td id="L864" class="blob-num js-line-number" data-line-number="864"></td>
-        <td id="LC864" class="blob-code blob-code-inner js-file-line">            headers[provider.server_side_encryption_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>AES256<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L865" class="blob-num js-line-number" data-line-number="865"></td>
-        <td id="LC865" class="blob-code blob-code-inner js-file-line">        src <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-c1">%s</span>/<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> (src_bucket_name, urllib.parse.quote(src_key_name))</td>
-      </tr>
-      <tr>
-        <td id="L866" class="blob-num js-line-number" data-line-number="866"></td>
-        <td id="LC866" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> src_version_id:</td>
-      </tr>
-      <tr>
-        <td id="L867" class="blob-num js-line-number" data-line-number="867"></td>
-        <td id="LC867" class="blob-code blob-code-inner js-file-line">            src <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>?versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> src_version_id</td>
-      </tr>
-      <tr>
-        <td id="L868" class="blob-num js-line-number" data-line-number="868"></td>
-        <td id="LC868" class="blob-code blob-code-inner js-file-line">        headers[provider.copy_source_header] <span class="pl-k">=</span> <span class="pl-c1">str</span>(src)</td>
-      </tr>
-      <tr>
-        <td id="L869" class="blob-num js-line-number" data-line-number="869"></td>
-        <td id="LC869" class="blob-code blob-code-inner js-file-line">        <span class="pl-c"><span class="pl-c">#</span> make sure storage_class_header key exists before accessing it</span></td>
-      </tr>
-      <tr>
-        <td id="L870" class="blob-num js-line-number" data-line-number="870"></td>
-        <td id="LC870" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> provider.storage_class_header <span class="pl-k">and</span> storage_class:</td>
-      </tr>
-      <tr>
-        <td id="L871" class="blob-num js-line-number" data-line-number="871"></td>
-        <td id="LC871" class="blob-code blob-code-inner js-file-line">            headers[provider.storage_class_header] <span class="pl-k">=</span> storage_class</td>
-      </tr>
-      <tr>
-        <td id="L872" class="blob-num js-line-number" data-line-number="872"></td>
-        <td id="LC872" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> metadata <span class="pl-k">is</span> <span class="pl-k">not</span> <span class="pl-c1">None</span>:</td>
-      </tr>
-      <tr>
-        <td id="L873" class="blob-num js-line-number" data-line-number="873"></td>
-        <td id="LC873" class="blob-code blob-code-inner js-file-line">            headers[provider.metadata_directive_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>REPLACE<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L874" class="blob-num js-line-number" data-line-number="874"></td>
-        <td id="LC874" class="blob-code blob-code-inner js-file-line">            headers <span class="pl-k">=</span> boto.utils.merge_meta(headers, metadata, provider)</td>
-      </tr>
-      <tr>
-        <td id="L875" class="blob-num js-line-number" data-line-number="875"></td>
-        <td id="LC875" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">elif</span> <span class="pl-k">not</span> query_args:  <span class="pl-c"><span class="pl-c">#</span> Can&#39;t use this header with multi-part copy.</span></td>
-      </tr>
-      <tr>
-        <td id="L876" class="blob-num js-line-number" data-line-number="876"></td>
-        <td id="LC876" class="blob-code blob-code-inner js-file-line">            headers[provider.metadata_directive_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>COPY<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L877" class="blob-num js-line-number" data-line-number="877"></td>
-        <td id="LC877" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, new_key_name,</td>
-      </tr>
-      <tr>
-        <td id="L878" class="blob-num js-line-number" data-line-number="878"></td>
-        <td id="LC878" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
-      </tr>
-      <tr>
-        <td id="L879" class="blob-num js-line-number" data-line-number="879"></td>
-        <td id="LC879" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args)</td>
-      </tr>
-      <tr>
-        <td id="L880" class="blob-num js-line-number" data-line-number="880"></td>
-        <td id="LC880" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L881" class="blob-num js-line-number" data-line-number="881"></td>
-        <td id="LC881" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L882" class="blob-num js-line-number" data-line-number="882"></td>
-        <td id="LC882" class="blob-code blob-code-inner js-file-line">            key <span class="pl-k">=</span> <span class="pl-c1">self</span>.new_key(new_key_name)</td>
-      </tr>
-      <tr>
-        <td id="L883" class="blob-num js-line-number" data-line-number="883"></td>
-        <td id="LC883" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(key, <span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L884" class="blob-num js-line-number" data-line-number="884"></td>
-        <td id="LC884" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
-      </tr>
-      <tr>
-        <td id="L885" class="blob-num js-line-number" data-line-number="885"></td>
-        <td id="LC885" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-c1">hasattr</span>(key, <span class="pl-s"><span class="pl-pds">&#39;</span>Error<span class="pl-pds">&#39;</span></span>):</td>
-      </tr>
-      <tr>
-        <td id="L886" class="blob-num js-line-number" data-line-number="886"></td>
-        <td id="LC886" class="blob-code blob-code-inner js-file-line">                <span class="pl-k">raise</span> provider.storage_copy_error(key.Code, key.Message, body)</td>
-      </tr>
-      <tr>
-        <td id="L887" class="blob-num js-line-number" data-line-number="887"></td>
-        <td id="LC887" class="blob-code blob-code-inner js-file-line">            key.handle_version_headers(response)</td>
-      </tr>
-      <tr>
-        <td id="L888" class="blob-num js-line-number" data-line-number="888"></td>
-        <td id="LC888" class="blob-code blob-code-inner js-file-line">            key.handle_addl_headers(response.getheaders())</td>
-      </tr>
-      <tr>
-        <td id="L889" class="blob-num js-line-number" data-line-number="889"></td>
-        <td id="LC889" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> preserve_acl:</td>
-      </tr>
-      <tr>
-        <td id="L890" class="blob-num js-line-number" data-line-number="890"></td>
-        <td id="LC890" class="blob-code blob-code-inner js-file-line">                <span class="pl-c1">self</span>.set_xml_acl(acl, new_key_name)</td>
-      </tr>
-      <tr>
-        <td id="L891" class="blob-num js-line-number" data-line-number="891"></td>
-        <td id="LC891" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> key</td>
-      </tr>
-      <tr>
-        <td id="L892" class="blob-num js-line-number" data-line-number="892"></td>
-        <td id="LC892" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L893" class="blob-num js-line-number" data-line-number="893"></td>
-        <td id="LC893" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> provider.storage_response_error(response.status,</td>
-      </tr>
-      <tr>
-        <td id="L894" class="blob-num js-line-number" data-line-number="894"></td>
-        <td id="LC894" class="blob-code blob-code-inner js-file-line">                                                  response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L895" class="blob-num js-line-number" data-line-number="895"></td>
-        <td id="LC895" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L896" class="blob-num js-line-number" data-line-number="896"></td>
-        <td id="LC896" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_canned_acl</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">acl_str</span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
-      </tr>
-      <tr>
-        <td id="L897" class="blob-num js-line-number" data-line-number="897"></td>
-        <td id="LC897" class="blob-code blob-code-inner js-file-line">                       <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L898" class="blob-num js-line-number" data-line-number="898"></td>
-        <td id="LC898" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">assert</span> acl_str <span class="pl-k">in</span> CannedACLStrings</td>
-      </tr>
-      <tr>
-        <td id="L899" class="blob-num js-line-number" data-line-number="899"></td>
-        <td id="LC899" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L900" class="blob-num js-line-number" data-line-number="900"></td>
-        <td id="LC900" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> headers:</td>
-      </tr>
-      <tr>
-        <td id="L901" class="blob-num js-line-number" data-line-number="901"></td>
-        <td id="LC901" class="blob-code blob-code-inner js-file-line">            headers[<span class="pl-c1">self</span>.connection.provider.acl_header] <span class="pl-k">=</span> acl_str</td>
-      </tr>
-      <tr>
-        <td id="L902" class="blob-num js-line-number" data-line-number="902"></td>
-        <td id="LC902" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L903" class="blob-num js-line-number" data-line-number="903"></td>
-        <td id="LC903" class="blob-code blob-code-inner js-file-line">            headers <span class="pl-k">=</span> {<span class="pl-c1">self</span>.connection.provider.acl_header: acl_str}</td>
-      </tr>
-      <tr>
-        <td id="L904" class="blob-num js-line-number" data-line-number="904"></td>
-        <td id="LC904" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L905" class="blob-num js-line-number" data-line-number="905"></td>
-        <td id="LC905" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>acl<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L906" class="blob-num js-line-number" data-line-number="906"></td>
-        <td id="LC906" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
-      </tr>
-      <tr>
-        <td id="L907" class="blob-num js-line-number" data-line-number="907"></td>
-        <td id="LC907" class="blob-code blob-code-inner js-file-line">            query_args <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id</td>
-      </tr>
-      <tr>
-        <td id="L908" class="blob-num js-line-number" data-line-number="908"></td>
-        <td id="LC908" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
-      </tr>
-      <tr>
-        <td id="L909" class="blob-num js-line-number" data-line-number="909"></td>
-        <td id="LC909" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">headers</span><span class="pl-k">=</span>headers, <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args)</td>
-      </tr>
-      <tr>
-        <td id="L910" class="blob-num js-line-number" data-line-number="910"></td>
-        <td id="LC910" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L911" class="blob-num js-line-number" data-line-number="911"></td>
-        <td id="LC911" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L912" class="blob-num js-line-number" data-line-number="912"></td>
-        <td id="LC912" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L913" class="blob-num js-line-number" data-line-number="913"></td>
-        <td id="LC913" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L914" class="blob-num js-line-number" data-line-number="914"></td>
-        <td id="LC914" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L915" class="blob-num js-line-number" data-line-number="915"></td>
-        <td id="LC915" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_xml_acl</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L916" class="blob-num js-line-number" data-line-number="916"></td>
-        <td id="LC916" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>acl<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L917" class="blob-num js-line-number" data-line-number="917"></td>
-        <td id="LC917" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
-      </tr>
-      <tr>
-        <td id="L918" class="blob-num js-line-number" data-line-number="918"></td>
-        <td id="LC918" class="blob-code blob-code-inner js-file-line">            query_args <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id</td>
-      </tr>
-      <tr>
-        <td id="L919" class="blob-num js-line-number" data-line-number="919"></td>
-        <td id="LC919" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
-      </tr>
-      <tr>
-        <td id="L920" class="blob-num js-line-number" data-line-number="920"></td>
-        <td id="LC920" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
-      </tr>
-      <tr>
-        <td id="L921" class="blob-num js-line-number" data-line-number="921"></td>
-        <td id="LC921" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L922" class="blob-num js-line-number" data-line-number="922"></td>
-        <td id="LC922" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L923" class="blob-num js-line-number" data-line-number="923"></td>
-        <td id="LC923" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L924" class="blob-num js-line-number" data-line-number="924"></td>
-        <td id="LC924" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L925" class="blob-num js-line-number" data-line-number="925"></td>
-        <td id="LC925" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L926" class="blob-num js-line-number" data-line-number="926"></td>
-        <td id="LC926" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> body</td>
-      </tr>
-      <tr>
-        <td id="L927" class="blob-num js-line-number" data-line-number="927"></td>
-        <td id="LC927" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L928" class="blob-num js-line-number" data-line-number="928"></td>
-        <td id="LC928" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_xml_acl</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">acl_str</span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
-      </tr>
-      <tr>
-        <td id="L929" class="blob-num js-line-number" data-line-number="929"></td>
-        <td id="LC929" class="blob-code blob-code-inner js-file-line">                    <span class="pl-smi">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>acl<span class="pl-pds">&#39;</span></span>):</td>
-      </tr>
-      <tr>
-        <td id="L930" class="blob-num js-line-number" data-line-number="930"></td>
-        <td id="LC930" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
-      </tr>
-      <tr>
-        <td id="L931" class="blob-num js-line-number" data-line-number="931"></td>
-        <td id="LC931" class="blob-code blob-code-inner js-file-line">            query_args <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id</td>
-      </tr>
-      <tr>
-        <td id="L932" class="blob-num js-line-number" data-line-number="932"></td>
-        <td id="LC932" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(acl_str, <span class="pl-c1">bytes</span>):</td>
-      </tr>
-      <tr>
-        <td id="L933" class="blob-num js-line-number" data-line-number="933"></td>
-        <td id="LC933" class="blob-code blob-code-inner js-file-line">            acl_str <span class="pl-k">=</span> acl_str.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L934" class="blob-num js-line-number" data-line-number="934"></td>
-        <td id="LC934" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
-      </tr>
-      <tr>
-        <td id="L935" class="blob-num js-line-number" data-line-number="935"></td>
-        <td id="LC935" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">data</span><span class="pl-k">=</span>acl_str,</td>
-      </tr>
-      <tr>
-        <td id="L936" class="blob-num js-line-number" data-line-number="936"></td>
-        <td id="LC936" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
-      </tr>
-      <tr>
-        <td id="L937" class="blob-num js-line-number" data-line-number="937"></td>
-        <td id="LC937" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L938" class="blob-num js-line-number" data-line-number="938"></td>
-        <td id="LC938" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L939" class="blob-num js-line-number" data-line-number="939"></td>
-        <td id="LC939" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L940" class="blob-num js-line-number" data-line-number="940"></td>
-        <td id="LC940" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L941" class="blob-num js-line-number" data-line-number="941"></td>
-        <td id="LC941" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L942" class="blob-num js-line-number" data-line-number="942"></td>
-        <td id="LC942" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L943" class="blob-num js-line-number" data-line-number="943"></td>
-        <td id="LC943" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_acl</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">acl_or_str</span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L944" class="blob-num js-line-number" data-line-number="944"></td>
-        <td id="LC944" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-c1">isinstance</span>(acl_or_str, Policy):</td>
-      </tr>
-      <tr>
-        <td id="L945" class="blob-num js-line-number" data-line-number="945"></td>
-        <td id="LC945" class="blob-code blob-code-inner js-file-line">            <span class="pl-c1">self</span>.set_xml_acl(acl_or_str.to_xml(), key_name,</td>
-      </tr>
-      <tr>
-        <td id="L946" class="blob-num js-line-number" data-line-number="946"></td>
-        <td id="LC946" class="blob-code blob-code-inner js-file-line">                             headers, version_id)</td>
-      </tr>
-      <tr>
-        <td id="L947" class="blob-num js-line-number" data-line-number="947"></td>
-        <td id="LC947" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L948" class="blob-num js-line-number" data-line-number="948"></td>
-        <td id="LC948" class="blob-code blob-code-inner js-file-line">            <span class="pl-c1">self</span>.set_canned_acl(acl_or_str, key_name,</td>
-      </tr>
-      <tr>
-        <td id="L949" class="blob-num js-line-number" data-line-number="949"></td>
-        <td id="LC949" class="blob-code blob-code-inner js-file-line">                                headers, version_id)</td>
-      </tr>
-      <tr>
-        <td id="L950" class="blob-num js-line-number" data-line-number="950"></td>
-        <td id="LC950" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L951" class="blob-num js-line-number" data-line-number="951"></td>
-        <td id="LC951" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_acl</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L952" class="blob-num js-line-number" data-line-number="952"></td>
-        <td id="LC952" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>acl<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L953" class="blob-num js-line-number" data-line-number="953"></td>
-        <td id="LC953" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
-      </tr>
-      <tr>
-        <td id="L954" class="blob-num js-line-number" data-line-number="954"></td>
-        <td id="LC954" class="blob-code blob-code-inner js-file-line">            query_args <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id</td>
-      </tr>
-      <tr>
-        <td id="L955" class="blob-num js-line-number" data-line-number="955"></td>
-        <td id="LC955" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
-      </tr>
-      <tr>
-        <td id="L956" class="blob-num js-line-number" data-line-number="956"></td>
-        <td id="LC956" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
-      </tr>
-      <tr>
-        <td id="L957" class="blob-num js-line-number" data-line-number="957"></td>
-        <td id="LC957" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L958" class="blob-num js-line-number" data-line-number="958"></td>
-        <td id="LC958" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L959" class="blob-num js-line-number" data-line-number="959"></td>
-        <td id="LC959" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L960" class="blob-num js-line-number" data-line-number="960"></td>
-        <td id="LC960" class="blob-code blob-code-inner js-file-line">            policy <span class="pl-k">=</span> Policy(<span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L961" class="blob-num js-line-number" data-line-number="961"></td>
-        <td id="LC961" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(policy, <span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L962" class="blob-num js-line-number" data-line-number="962"></td>
-        <td id="LC962" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
-      </tr>
-      <tr>
-        <td id="L963" class="blob-num js-line-number" data-line-number="963"></td>
-        <td id="LC963" class="blob-code blob-code-inner js-file-line">                body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L964" class="blob-num js-line-number" data-line-number="964"></td>
-        <td id="LC964" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
-      </tr>
-      <tr>
-        <td id="L965" class="blob-num js-line-number" data-line-number="965"></td>
-        <td id="LC965" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> policy</td>
-      </tr>
-      <tr>
-        <td id="L966" class="blob-num js-line-number" data-line-number="966"></td>
-        <td id="LC966" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L967" class="blob-num js-line-number" data-line-number="967"></td>
-        <td id="LC967" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L968" class="blob-num js-line-number" data-line-number="968"></td>
-        <td id="LC968" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L969" class="blob-num js-line-number" data-line-number="969"></td>
-        <td id="LC969" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L970" class="blob-num js-line-number" data-line-number="970"></td>
-        <td id="LC970" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_subresource</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">subresource</span>, <span class="pl-smi">value</span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
-      </tr>
-      <tr>
-        <td id="L971" class="blob-num js-line-number" data-line-number="971"></td>
-        <td id="LC971" class="blob-code blob-code-inner js-file-line">                        <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L972" class="blob-num js-line-number" data-line-number="972"></td>
-        <td id="LC972" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L973" class="blob-num js-line-number" data-line-number="973"></td>
-        <td id="LC973" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Set a subresource for a bucket or key.</span></td>
-      </tr>
-      <tr>
-        <td id="L974" class="blob-num js-line-number" data-line-number="974"></td>
-        <td id="LC974" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L975" class="blob-num js-line-number" data-line-number="975"></td>
-        <td id="LC975" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type subresource: string</span></td>
-      </tr>
-      <tr>
-        <td id="L976" class="blob-num js-line-number" data-line-number="976"></td>
-        <td id="LC976" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param subresource: The subresource to set.</span></td>
-      </tr>
-      <tr>
-        <td id="L977" class="blob-num js-line-number" data-line-number="977"></td>
-        <td id="LC977" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L978" class="blob-num js-line-number" data-line-number="978"></td>
-        <td id="LC978" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type value: string</span></td>
-      </tr>
-      <tr>
-        <td id="L979" class="blob-num js-line-number" data-line-number="979"></td>
-        <td id="LC979" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param value: The value of the subresource.</span></td>
-      </tr>
-      <tr>
-        <td id="L980" class="blob-num js-line-number" data-line-number="980"></td>
-        <td id="LC980" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L981" class="blob-num js-line-number" data-line-number="981"></td>
-        <td id="LC981" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_name: string</span></td>
-      </tr>
-      <tr>
-        <td id="L982" class="blob-num js-line-number" data-line-number="982"></td>
-        <td id="LC982" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_name: The key to operate on, or None to operate on the</span></td>
-      </tr>
-      <tr>
-        <td id="L983" class="blob-num js-line-number" data-line-number="983"></td>
-        <td id="LC983" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L984" class="blob-num js-line-number" data-line-number="984"></td>
-        <td id="LC984" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L985" class="blob-num js-line-number" data-line-number="985"></td>
-        <td id="LC985" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type headers: dict</span></td>
-      </tr>
-      <tr>
-        <td id="L986" class="blob-num js-line-number" data-line-number="986"></td>
-        <td id="LC986" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param headers: Additional HTTP headers to include in the request.</span></td>
-      </tr>
-      <tr>
-        <td id="L987" class="blob-num js-line-number" data-line-number="987"></td>
-        <td id="LC987" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L988" class="blob-num js-line-number" data-line-number="988"></td>
-        <td id="LC988" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type src_version_id: string</span></td>
-      </tr>
-      <tr>
-        <td id="L989" class="blob-num js-line-number" data-line-number="989"></td>
-        <td id="LC989" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param src_version_id: Optional. The version id of the key to</span></td>
-      </tr>
-      <tr>
-        <td id="L990" class="blob-num js-line-number" data-line-number="990"></td>
-        <td id="LC990" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            operate on. If not specified, operate on the newest</span></td>
-      </tr>
-      <tr>
-        <td id="L991" class="blob-num js-line-number" data-line-number="991"></td>
-        <td id="LC991" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            version.</span></td>
-      </tr>
-      <tr>
-        <td id="L992" class="blob-num js-line-number" data-line-number="992"></td>
-        <td id="LC992" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L993" class="blob-num js-line-number" data-line-number="993"></td>
-        <td id="LC993" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> subresource:</td>
-      </tr>
-      <tr>
-        <td id="L994" class="blob-num js-line-number" data-line-number="994"></td>
-        <td id="LC994" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">TypeError</span>(<span class="pl-s"><span class="pl-pds">&#39;</span>set_subresource called with subresource=None<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L995" class="blob-num js-line-number" data-line-number="995"></td>
-        <td id="LC995" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> subresource</td>
-      </tr>
-      <tr>
-        <td id="L996" class="blob-num js-line-number" data-line-number="996"></td>
-        <td id="LC996" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
-      </tr>
-      <tr>
-        <td id="L997" class="blob-num js-line-number" data-line-number="997"></td>
-        <td id="LC997" class="blob-code blob-code-inner js-file-line">            query_args <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id</td>
-      </tr>
-      <tr>
-        <td id="L998" class="blob-num js-line-number" data-line-number="998"></td>
-        <td id="LC998" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(value, <span class="pl-c1">bytes</span>):</td>
-      </tr>
-      <tr>
-        <td id="L999" class="blob-num js-line-number" data-line-number="999"></td>
-        <td id="LC999" class="blob-code blob-code-inner js-file-line">            value <span class="pl-k">=</span> value.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L1000" class="blob-num js-line-number" data-line-number="1000"></td>
-        <td id="LC1000" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
-      </tr>
-      <tr>
-        <td id="L1001" class="blob-num js-line-number" data-line-number="1001"></td>
-        <td id="LC1001" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">data</span><span class="pl-k">=</span>value,</td>
-      </tr>
-      <tr>
-        <td id="L1002" class="blob-num js-line-number" data-line-number="1002"></td>
-        <td id="LC1002" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
-      </tr>
-      <tr>
-        <td id="L1003" class="blob-num js-line-number" data-line-number="1003"></td>
-        <td id="LC1003" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1004" class="blob-num js-line-number" data-line-number="1004"></td>
-        <td id="LC1004" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1005" class="blob-num js-line-number" data-line-number="1005"></td>
-        <td id="LC1005" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1006" class="blob-num js-line-number" data-line-number="1006"></td>
-        <td id="LC1006" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1007" class="blob-num js-line-number" data-line-number="1007"></td>
-        <td id="LC1007" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1008" class="blob-num js-line-number" data-line-number="1008"></td>
-        <td id="LC1008" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1009" class="blob-num js-line-number" data-line-number="1009"></td>
-        <td id="LC1009" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_subresource</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">subresource</span>, <span class="pl-smi">key_name</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
-      </tr>
-      <tr>
-        <td id="L1010" class="blob-num js-line-number" data-line-number="1010"></td>
-        <td id="LC1010" class="blob-code blob-code-inner js-file-line">                        <span class="pl-smi">version_id</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1011" class="blob-num js-line-number" data-line-number="1011"></td>
-        <td id="LC1011" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1012" class="blob-num js-line-number" data-line-number="1012"></td>
-        <td id="LC1012" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Get a subresource for a bucket or key.</span></td>
-      </tr>
-      <tr>
-        <td id="L1013" class="blob-num js-line-number" data-line-number="1013"></td>
-        <td id="LC1013" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1014" class="blob-num js-line-number" data-line-number="1014"></td>
-        <td id="LC1014" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type subresource: string</span></td>
-      </tr>
-      <tr>
-        <td id="L1015" class="blob-num js-line-number" data-line-number="1015"></td>
-        <td id="LC1015" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param subresource: The subresource to get.</span></td>
-      </tr>
-      <tr>
-        <td id="L1016" class="blob-num js-line-number" data-line-number="1016"></td>
-        <td id="LC1016" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1017" class="blob-num js-line-number" data-line-number="1017"></td>
-        <td id="LC1017" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_name: string</span></td>
-      </tr>
-      <tr>
-        <td id="L1018" class="blob-num js-line-number" data-line-number="1018"></td>
-        <td id="LC1018" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_name: The key to operate on, or None to operate on the</span></td>
-      </tr>
-      <tr>
-        <td id="L1019" class="blob-num js-line-number" data-line-number="1019"></td>
-        <td id="LC1019" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1020" class="blob-num js-line-number" data-line-number="1020"></td>
-        <td id="LC1020" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1021" class="blob-num js-line-number" data-line-number="1021"></td>
-        <td id="LC1021" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type headers: dict</span></td>
-      </tr>
-      <tr>
-        <td id="L1022" class="blob-num js-line-number" data-line-number="1022"></td>
-        <td id="LC1022" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param headers: Additional HTTP headers to include in the request.</span></td>
-      </tr>
-      <tr>
-        <td id="L1023" class="blob-num js-line-number" data-line-number="1023"></td>
-        <td id="LC1023" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1024" class="blob-num js-line-number" data-line-number="1024"></td>
-        <td id="LC1024" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type src_version_id: string</span></td>
-      </tr>
-      <tr>
-        <td id="L1025" class="blob-num js-line-number" data-line-number="1025"></td>
-        <td id="LC1025" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param src_version_id: Optional. The version id of the key to</span></td>
-      </tr>
-      <tr>
-        <td id="L1026" class="blob-num js-line-number" data-line-number="1026"></td>
-        <td id="LC1026" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            operate on. If not specified, operate on the newest</span></td>
-      </tr>
-      <tr>
-        <td id="L1027" class="blob-num js-line-number" data-line-number="1027"></td>
-        <td id="LC1027" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            version.</span></td>
-      </tr>
-      <tr>
-        <td id="L1028" class="blob-num js-line-number" data-line-number="1028"></td>
-        <td id="LC1028" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1029" class="blob-num js-line-number" data-line-number="1029"></td>
-        <td id="LC1029" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: string</span></td>
-      </tr>
-      <tr>
-        <td id="L1030" class="blob-num js-line-number" data-line-number="1030"></td>
-        <td id="LC1030" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: The value of the subresource.</span></td>
-      </tr>
-      <tr>
-        <td id="L1031" class="blob-num js-line-number" data-line-number="1031"></td>
-        <td id="LC1031" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1032" class="blob-num js-line-number" data-line-number="1032"></td>
-        <td id="LC1032" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> subresource:</td>
-      </tr>
-      <tr>
-        <td id="L1033" class="blob-num js-line-number" data-line-number="1033"></td>
-        <td id="LC1033" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">TypeError</span>(<span class="pl-s"><span class="pl-pds">&#39;</span>get_subresource called with subresource=None<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L1034" class="blob-num js-line-number" data-line-number="1034"></td>
-        <td id="LC1034" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> subresource</td>
-      </tr>
-      <tr>
-        <td id="L1035" class="blob-num js-line-number" data-line-number="1035"></td>
-        <td id="LC1035" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> version_id:</td>
-      </tr>
-      <tr>
-        <td id="L1036" class="blob-num js-line-number" data-line-number="1036"></td>
-        <td id="LC1036" class="blob-code blob-code-inner js-file-line">            query_args <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>&amp;versionId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> version_id</td>
-      </tr>
-      <tr>
-        <td id="L1037" class="blob-num js-line-number" data-line-number="1037"></td>
-        <td id="LC1037" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
-      </tr>
-      <tr>
-        <td id="L1038" class="blob-num js-line-number" data-line-number="1038"></td>
-        <td id="LC1038" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
-      </tr>
-      <tr>
-        <td id="L1039" class="blob-num js-line-number" data-line-number="1039"></td>
-        <td id="LC1039" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1040" class="blob-num js-line-number" data-line-number="1040"></td>
-        <td id="LC1040" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1041" class="blob-num js-line-number" data-line-number="1041"></td>
-        <td id="LC1041" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1042" class="blob-num js-line-number" data-line-number="1042"></td>
-        <td id="LC1042" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1043" class="blob-num js-line-number" data-line-number="1043"></td>
-        <td id="LC1043" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1044" class="blob-num js-line-number" data-line-number="1044"></td>
-        <td id="LC1044" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> body</td>
-      </tr>
-      <tr>
-        <td id="L1045" class="blob-num js-line-number" data-line-number="1045"></td>
-        <td id="LC1045" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1046" class="blob-num js-line-number" data-line-number="1046"></td>
-        <td id="LC1046" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">make_public</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">recursive</span><span class="pl-k">=</span><span class="pl-c1">False</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1047" class="blob-num js-line-number" data-line-number="1047"></td>
-        <td id="LC1047" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.set_canned_acl(<span class="pl-s"><span class="pl-pds">&#39;</span>public-read<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1048" class="blob-num js-line-number" data-line-number="1048"></td>
-        <td id="LC1048" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> recursive:</td>
-      </tr>
-      <tr>
-        <td id="L1049" class="blob-num js-line-number" data-line-number="1049"></td>
-        <td id="LC1049" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">for</span> key <span class="pl-k">in</span> <span class="pl-c1">self</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1050" class="blob-num js-line-number" data-line-number="1050"></td>
-        <td id="LC1050" class="blob-code blob-code-inner js-file-line">                <span class="pl-c1">self</span>.set_canned_acl(<span class="pl-s"><span class="pl-pds">&#39;</span>public-read<span class="pl-pds">&#39;</span></span>, key.name, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1051" class="blob-num js-line-number" data-line-number="1051"></td>
-        <td id="LC1051" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1052" class="blob-num js-line-number" data-line-number="1052"></td>
-        <td id="LC1052" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">add_email_grant</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">permission</span>, <span class="pl-smi">email_address</span>,</td>
-      </tr>
-      <tr>
-        <td id="L1053" class="blob-num js-line-number" data-line-number="1053"></td>
-        <td id="LC1053" class="blob-code blob-code-inner js-file-line">                        <span class="pl-smi">recursive</span><span class="pl-k">=</span><span class="pl-c1">False</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1054" class="blob-num js-line-number" data-line-number="1054"></td>
-        <td id="LC1054" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1055" class="blob-num js-line-number" data-line-number="1055"></td>
-        <td id="LC1055" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Convenience method that provides a quick way to add an email grant</span></td>
-      </tr>
-      <tr>
-        <td id="L1056" class="blob-num js-line-number" data-line-number="1056"></td>
-        <td id="LC1056" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        to a bucket. This method retrieves the current ACL, creates a new</span></td>
-      </tr>
-      <tr>
-        <td id="L1057" class="blob-num js-line-number" data-line-number="1057"></td>
-        <td id="LC1057" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        grant based on the parameters passed in, adds that grant to the ACL</span></td>
-      </tr>
-      <tr>
-        <td id="L1058" class="blob-num js-line-number" data-line-number="1058"></td>
-        <td id="LC1058" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        and then PUT&#39;s the new ACL back to S3.</span></td>
-      </tr>
-      <tr>
-        <td id="L1059" class="blob-num js-line-number" data-line-number="1059"></td>
-        <td id="LC1059" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1060" class="blob-num js-line-number" data-line-number="1060"></td>
-        <td id="LC1060" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type permission: string</span></td>
-      </tr>
-      <tr>
-        <td id="L1061" class="blob-num js-line-number" data-line-number="1061"></td>
-        <td id="LC1061" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param permission: The permission being granted. Should be one of:</span></td>
-      </tr>
-      <tr>
-        <td id="L1062" class="blob-num js-line-number" data-line-number="1062"></td>
-        <td id="LC1062" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            (READ, WRITE, READ_ACP, WRITE_ACP, FULL_CONTROL).</span></td>
-      </tr>
-      <tr>
-        <td id="L1063" class="blob-num js-line-number" data-line-number="1063"></td>
-        <td id="LC1063" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1064" class="blob-num js-line-number" data-line-number="1064"></td>
-        <td id="LC1064" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type email_address: string</span></td>
-      </tr>
-      <tr>
-        <td id="L1065" class="blob-num js-line-number" data-line-number="1065"></td>
-        <td id="LC1065" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param email_address: The email address associated with the AWS</span></td>
-      </tr>
-      <tr>
-        <td id="L1066" class="blob-num js-line-number" data-line-number="1066"></td>
-        <td id="LC1066" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            account your are granting the permission to.</span></td>
-      </tr>
-      <tr>
-        <td id="L1067" class="blob-num js-line-number" data-line-number="1067"></td>
-        <td id="LC1067" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1068" class="blob-num js-line-number" data-line-number="1068"></td>
-        <td id="LC1068" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type recursive: boolean</span></td>
-      </tr>
-      <tr>
-        <td id="L1069" class="blob-num js-line-number" data-line-number="1069"></td>
-        <td id="LC1069" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param recursive: A boolean value to controls whether the</span></td>
-      </tr>
-      <tr>
-        <td id="L1070" class="blob-num js-line-number" data-line-number="1070"></td>
-        <td id="LC1070" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            command will apply the grant to all keys within the bucket</span></td>
-      </tr>
-      <tr>
-        <td id="L1071" class="blob-num js-line-number" data-line-number="1071"></td>
-        <td id="LC1071" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            or not.  The default value is False.  By passing a True</span></td>
-      </tr>
-      <tr>
-        <td id="L1072" class="blob-num js-line-number" data-line-number="1072"></td>
-        <td id="LC1072" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            value, the call will iterate through all keys in the</span></td>
-      </tr>
-      <tr>
-        <td id="L1073" class="blob-num js-line-number" data-line-number="1073"></td>
-        <td id="LC1073" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            bucket and apply the same grant to each key.  CAUTION: If</span></td>
-      </tr>
-      <tr>
-        <td id="L1074" class="blob-num js-line-number" data-line-number="1074"></td>
-        <td id="LC1074" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            you have a lot of keys, this could take a long time!</span></td>
-      </tr>
-      <tr>
-        <td id="L1075" class="blob-num js-line-number" data-line-number="1075"></td>
-        <td id="LC1075" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1076" class="blob-num js-line-number" data-line-number="1076"></td>
-        <td id="LC1076" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> permission <span class="pl-k">not</span> <span class="pl-k">in</span> S3Permissions:</td>
-      </tr>
-      <tr>
-        <td id="L1077" class="blob-num js-line-number" data-line-number="1077"></td>
-        <td id="LC1077" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_permissions_error(</td>
-      </tr>
-      <tr>
-        <td id="L1078" class="blob-num js-line-number" data-line-number="1078"></td>
-        <td id="LC1078" class="blob-code blob-code-inner js-file-line">                <span class="pl-s"><span class="pl-pds">&#39;</span>Unknown Permission: <span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> permission)</td>
-      </tr>
-      <tr>
-        <td id="L1079" class="blob-num js-line-number" data-line-number="1079"></td>
-        <td id="LC1079" class="blob-code blob-code-inner js-file-line">        policy <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_acl(<span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1080" class="blob-num js-line-number" data-line-number="1080"></td>
-        <td id="LC1080" class="blob-code blob-code-inner js-file-line">        policy.acl.add_email_grant(permission, email_address)</td>
-      </tr>
-      <tr>
-        <td id="L1081" class="blob-num js-line-number" data-line-number="1081"></td>
-        <td id="LC1081" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.set_acl(policy, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1082" class="blob-num js-line-number" data-line-number="1082"></td>
-        <td id="LC1082" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> recursive:</td>
-      </tr>
-      <tr>
-        <td id="L1083" class="blob-num js-line-number" data-line-number="1083"></td>
-        <td id="LC1083" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">for</span> key <span class="pl-k">in</span> <span class="pl-c1">self</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1084" class="blob-num js-line-number" data-line-number="1084"></td>
-        <td id="LC1084" class="blob-code blob-code-inner js-file-line">                key.add_email_grant(permission, email_address, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1085" class="blob-num js-line-number" data-line-number="1085"></td>
-        <td id="LC1085" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1086" class="blob-num js-line-number" data-line-number="1086"></td>
-        <td id="LC1086" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">add_user_grant</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">permission</span>, <span class="pl-smi">user_id</span>, <span class="pl-smi">recursive</span><span class="pl-k">=</span><span class="pl-c1">False</span>,</td>
-      </tr>
-      <tr>
-        <td id="L1087" class="blob-num js-line-number" data-line-number="1087"></td>
-        <td id="LC1087" class="blob-code blob-code-inner js-file-line">                       <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">display_name</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1088" class="blob-num js-line-number" data-line-number="1088"></td>
-        <td id="LC1088" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1089" class="blob-num js-line-number" data-line-number="1089"></td>
-        <td id="LC1089" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Convenience method that provides a quick way to add a canonical</span></td>
-      </tr>
-      <tr>
-        <td id="L1090" class="blob-num js-line-number" data-line-number="1090"></td>
-        <td id="LC1090" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        user grant to a bucket.  This method retrieves the current ACL,</span></td>
-      </tr>
-      <tr>
-        <td id="L1091" class="blob-num js-line-number" data-line-number="1091"></td>
-        <td id="LC1091" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        creates a new grant based on the parameters passed in, adds that</span></td>
-      </tr>
-      <tr>
-        <td id="L1092" class="blob-num js-line-number" data-line-number="1092"></td>
-        <td id="LC1092" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        grant to the ACL and then PUT&#39;s the new ACL back to S3.</span></td>
-      </tr>
-      <tr>
-        <td id="L1093" class="blob-num js-line-number" data-line-number="1093"></td>
-        <td id="LC1093" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1094" class="blob-num js-line-number" data-line-number="1094"></td>
-        <td id="LC1094" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type permission: string</span></td>
-      </tr>
-      <tr>
-        <td id="L1095" class="blob-num js-line-number" data-line-number="1095"></td>
-        <td id="LC1095" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param permission: The permission being granted. Should be one of:</span></td>
-      </tr>
-      <tr>
-        <td id="L1096" class="blob-num js-line-number" data-line-number="1096"></td>
-        <td id="LC1096" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            (READ, WRITE, READ_ACP, WRITE_ACP, FULL_CONTROL).</span></td>
-      </tr>
-      <tr>
-        <td id="L1097" class="blob-num js-line-number" data-line-number="1097"></td>
-        <td id="LC1097" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1098" class="blob-num js-line-number" data-line-number="1098"></td>
-        <td id="LC1098" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type user_id: string</span></td>
-      </tr>
-      <tr>
-        <td id="L1099" class="blob-num js-line-number" data-line-number="1099"></td>
-        <td id="LC1099" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param user_id:     The canonical user id associated with the AWS</span></td>
-      </tr>
-      <tr>
-        <td id="L1100" class="blob-num js-line-number" data-line-number="1100"></td>
-        <td id="LC1100" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            account your are granting the permission to.</span></td>
-      </tr>
-      <tr>
-        <td id="L1101" class="blob-num js-line-number" data-line-number="1101"></td>
-        <td id="LC1101" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1102" class="blob-num js-line-number" data-line-number="1102"></td>
-        <td id="LC1102" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type recursive: boolean</span></td>
-      </tr>
-      <tr>
-        <td id="L1103" class="blob-num js-line-number" data-line-number="1103"></td>
-        <td id="LC1103" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param recursive: A boolean value to controls whether the</span></td>
-      </tr>
-      <tr>
-        <td id="L1104" class="blob-num js-line-number" data-line-number="1104"></td>
-        <td id="LC1104" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            command will apply the grant to all keys within the bucket</span></td>
-      </tr>
-      <tr>
-        <td id="L1105" class="blob-num js-line-number" data-line-number="1105"></td>
-        <td id="LC1105" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            or not.  The default value is False.  By passing a True</span></td>
-      </tr>
-      <tr>
-        <td id="L1106" class="blob-num js-line-number" data-line-number="1106"></td>
-        <td id="LC1106" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            value, the call will iterate through all keys in the</span></td>
-      </tr>
-      <tr>
-        <td id="L1107" class="blob-num js-line-number" data-line-number="1107"></td>
-        <td id="LC1107" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            bucket and apply the same grant to each key.  CAUTION: If</span></td>
-      </tr>
-      <tr>
-        <td id="L1108" class="blob-num js-line-number" data-line-number="1108"></td>
-        <td id="LC1108" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            you have a lot of keys, this could take a long time!</span></td>
-      </tr>
-      <tr>
-        <td id="L1109" class="blob-num js-line-number" data-line-number="1109"></td>
-        <td id="LC1109" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1110" class="blob-num js-line-number" data-line-number="1110"></td>
-        <td id="LC1110" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type display_name: string</span></td>
-      </tr>
-      <tr>
-        <td id="L1111" class="blob-num js-line-number" data-line-number="1111"></td>
-        <td id="LC1111" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param display_name: An option string containing the user&#39;s</span></td>
-      </tr>
-      <tr>
-        <td id="L1112" class="blob-num js-line-number" data-line-number="1112"></td>
-        <td id="LC1112" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Display Name.  Only required on Walrus.</span></td>
-      </tr>
-      <tr>
-        <td id="L1113" class="blob-num js-line-number" data-line-number="1113"></td>
-        <td id="LC1113" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1114" class="blob-num js-line-number" data-line-number="1114"></td>
-        <td id="LC1114" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> permission <span class="pl-k">not</span> <span class="pl-k">in</span> S3Permissions:</td>
-      </tr>
-      <tr>
-        <td id="L1115" class="blob-num js-line-number" data-line-number="1115"></td>
-        <td id="LC1115" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_permissions_error(</td>
-      </tr>
-      <tr>
-        <td id="L1116" class="blob-num js-line-number" data-line-number="1116"></td>
-        <td id="LC1116" class="blob-code blob-code-inner js-file-line">                <span class="pl-s"><span class="pl-pds">&#39;</span>Unknown Permission: <span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> permission)</td>
-      </tr>
-      <tr>
-        <td id="L1117" class="blob-num js-line-number" data-line-number="1117"></td>
-        <td id="LC1117" class="blob-code blob-code-inner js-file-line">        policy <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_acl(<span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1118" class="blob-num js-line-number" data-line-number="1118"></td>
-        <td id="LC1118" class="blob-code blob-code-inner js-file-line">        policy.acl.add_user_grant(permission, user_id,</td>
-      </tr>
-      <tr>
-        <td id="L1119" class="blob-num js-line-number" data-line-number="1119"></td>
-        <td id="LC1119" class="blob-code blob-code-inner js-file-line">                                  <span class="pl-v">display_name</span><span class="pl-k">=</span>display_name)</td>
-      </tr>
-      <tr>
-        <td id="L1120" class="blob-num js-line-number" data-line-number="1120"></td>
-        <td id="LC1120" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.set_acl(policy, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1121" class="blob-num js-line-number" data-line-number="1121"></td>
-        <td id="LC1121" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> recursive:</td>
-      </tr>
-      <tr>
-        <td id="L1122" class="blob-num js-line-number" data-line-number="1122"></td>
-        <td id="LC1122" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">for</span> key <span class="pl-k">in</span> <span class="pl-c1">self</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1123" class="blob-num js-line-number" data-line-number="1123"></td>
-        <td id="LC1123" class="blob-code blob-code-inner js-file-line">                key.add_user_grant(permission, user_id, <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
-      </tr>
-      <tr>
-        <td id="L1124" class="blob-num js-line-number" data-line-number="1124"></td>
-        <td id="LC1124" class="blob-code blob-code-inner js-file-line">                                   <span class="pl-v">display_name</span><span class="pl-k">=</span>display_name)</td>
-      </tr>
-      <tr>
-        <td id="L1125" class="blob-num js-line-number" data-line-number="1125"></td>
-        <td id="LC1125" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1126" class="blob-num js-line-number" data-line-number="1126"></td>
-        <td id="LC1126" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">list_grants</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1127" class="blob-num js-line-number" data-line-number="1127"></td>
-        <td id="LC1127" class="blob-code blob-code-inner js-file-line">        policy <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_acl(<span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1128" class="blob-num js-line-number" data-line-number="1128"></td>
-        <td id="LC1128" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> policy.acl.grants</td>
-      </tr>
-      <tr>
-        <td id="L1129" class="blob-num js-line-number" data-line-number="1129"></td>
-        <td id="LC1129" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1130" class="blob-num js-line-number" data-line-number="1130"></td>
-        <td id="LC1130" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_location</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1131" class="blob-num js-line-number" data-line-number="1131"></td>
-        <td id="LC1131" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1132" class="blob-num js-line-number" data-line-number="1132"></td>
-        <td id="LC1132" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the LocationConstraint for the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1133" class="blob-num js-line-number" data-line-number="1133"></td>
-        <td id="LC1133" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1134" class="blob-num js-line-number" data-line-number="1134"></td>
-        <td id="LC1134" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: str</span></td>
-      </tr>
-      <tr>
-        <td id="L1135" class="blob-num js-line-number" data-line-number="1135"></td>
-        <td id="LC1135" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: The LocationConstraint for the bucket or the empty</span></td>
-      </tr>
-      <tr>
-        <td id="L1136" class="blob-num js-line-number" data-line-number="1136"></td>
-        <td id="LC1136" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            string if no constraint was specified when bucket was created.</span></td>
-      </tr>
-      <tr>
-        <td id="L1137" class="blob-num js-line-number" data-line-number="1137"></td>
-        <td id="LC1137" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1138" class="blob-num js-line-number" data-line-number="1138"></td>
-        <td id="LC1138" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1139" class="blob-num js-line-number" data-line-number="1139"></td>
-        <td id="LC1139" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers,</td>
-      </tr>
-      <tr>
-        <td id="L1140" class="blob-num js-line-number" data-line-number="1140"></td>
-        <td id="LC1140" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>location<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L1141" class="blob-num js-line-number" data-line-number="1141"></td>
-        <td id="LC1141" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1142" class="blob-num js-line-number" data-line-number="1142"></td>
-        <td id="LC1142" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1143" class="blob-num js-line-number" data-line-number="1143"></td>
-        <td id="LC1143" class="blob-code blob-code-inner js-file-line">            rs <span class="pl-k">=</span> ResultSet(<span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L1144" class="blob-num js-line-number" data-line-number="1144"></td>
-        <td id="LC1144" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(rs, <span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L1145" class="blob-num js-line-number" data-line-number="1145"></td>
-        <td id="LC1145" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1146" class="blob-num js-line-number" data-line-number="1146"></td>
-        <td id="LC1146" class="blob-code blob-code-inner js-file-line">                body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L1147" class="blob-num js-line-number" data-line-number="1147"></td>
-        <td id="LC1147" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
-      </tr>
-      <tr>
-        <td id="L1148" class="blob-num js-line-number" data-line-number="1148"></td>
-        <td id="LC1148" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> rs.LocationConstraint</td>
-      </tr>
-      <tr>
-        <td id="L1149" class="blob-num js-line-number" data-line-number="1149"></td>
-        <td id="LC1149" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1150" class="blob-num js-line-number" data-line-number="1150"></td>
-        <td id="LC1150" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1151" class="blob-num js-line-number" data-line-number="1151"></td>
-        <td id="LC1151" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1152" class="blob-num js-line-number" data-line-number="1152"></td>
-        <td id="LC1152" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1153" class="blob-num js-line-number" data-line-number="1153"></td>
-        <td id="LC1153" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_xml_logging</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">logging_str</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1154" class="blob-num js-line-number" data-line-number="1154"></td>
-        <td id="LC1154" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1155" class="blob-num js-line-number" data-line-number="1155"></td>
-        <td id="LC1155" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Set logging on a bucket directly to the given xml string.</span></td>
-      </tr>
-      <tr>
-        <td id="L1156" class="blob-num js-line-number" data-line-number="1156"></td>
-        <td id="LC1156" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1157" class="blob-num js-line-number" data-line-number="1157"></td>
-        <td id="LC1157" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type logging_str: unicode string</span></td>
-      </tr>
-      <tr>
-        <td id="L1158" class="blob-num js-line-number" data-line-number="1158"></td>
-        <td id="LC1158" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param logging_str: The XML for the bucketloggingstatus which</span></td>
-      </tr>
-      <tr>
-        <td id="L1159" class="blob-num js-line-number" data-line-number="1159"></td>
-        <td id="LC1159" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            will be set.  The string will be converted to utf-8 before</span></td>
-      </tr>
-      <tr>
-        <td id="L1160" class="blob-num js-line-number" data-line-number="1160"></td>
-        <td id="LC1160" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            it is sent.  Usually, you will obtain this XML from the</span></td>
-      </tr>
-      <tr>
-        <td id="L1161" class="blob-num js-line-number" data-line-number="1161"></td>
-        <td id="LC1161" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            BucketLogging object.</span></td>
-      </tr>
-      <tr>
-        <td id="L1162" class="blob-num js-line-number" data-line-number="1162"></td>
-        <td id="LC1162" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1163" class="blob-num js-line-number" data-line-number="1163"></td>
-        <td id="LC1163" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: bool</span></td>
-      </tr>
-      <tr>
-        <td id="L1164" class="blob-num js-line-number" data-line-number="1164"></td>
-        <td id="LC1164" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: True if ok or raises an exception.</span></td>
-      </tr>
-      <tr>
-        <td id="L1165" class="blob-num js-line-number" data-line-number="1165"></td>
-        <td id="LC1165" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1166" class="blob-num js-line-number" data-line-number="1166"></td>
-        <td id="LC1166" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> logging_str</td>
-      </tr>
-      <tr>
-        <td id="L1167" class="blob-num js-line-number" data-line-number="1167"></td>
-        <td id="LC1167" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1168" class="blob-num js-line-number" data-line-number="1168"></td>
-        <td id="LC1168" class="blob-code blob-code-inner js-file-line">            body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L1169" class="blob-num js-line-number" data-line-number="1169"></td>
-        <td id="LC1169" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, <span class="pl-v">data</span><span class="pl-k">=</span>body,</td>
-      </tr>
-      <tr>
-        <td id="L1170" class="blob-num js-line-number" data-line-number="1170"></td>
-        <td id="LC1170" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>logging<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1171" class="blob-num js-line-number" data-line-number="1171"></td>
-        <td id="LC1171" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1172" class="blob-num js-line-number" data-line-number="1172"></td>
-        <td id="LC1172" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1173" class="blob-num js-line-number" data-line-number="1173"></td>
-        <td id="LC1173" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
-      </tr>
-      <tr>
-        <td id="L1174" class="blob-num js-line-number" data-line-number="1174"></td>
-        <td id="LC1174" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1175" class="blob-num js-line-number" data-line-number="1175"></td>
-        <td id="LC1175" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1176" class="blob-num js-line-number" data-line-number="1176"></td>
-        <td id="LC1176" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1177" class="blob-num js-line-number" data-line-number="1177"></td>
-        <td id="LC1177" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1178" class="blob-num js-line-number" data-line-number="1178"></td>
-        <td id="LC1178" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">enable_logging</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">target_bucket</span>, <span class="pl-smi">target_prefix</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L1179" class="blob-num js-line-number" data-line-number="1179"></td>
-        <td id="LC1179" class="blob-code blob-code-inner js-file-line">                       <span class="pl-smi">grants</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1180" class="blob-num js-line-number" data-line-number="1180"></td>
-        <td id="LC1180" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1181" class="blob-num js-line-number" data-line-number="1181"></td>
-        <td id="LC1181" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Enable logging on a bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1182" class="blob-num js-line-number" data-line-number="1182"></td>
-        <td id="LC1182" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1183" class="blob-num js-line-number" data-line-number="1183"></td>
-        <td id="LC1183" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type target_bucket: bucket or string</span></td>
-      </tr>
-      <tr>
-        <td id="L1184" class="blob-num js-line-number" data-line-number="1184"></td>
-        <td id="LC1184" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param target_bucket: The bucket to log to.</span></td>
-      </tr>
-      <tr>
-        <td id="L1185" class="blob-num js-line-number" data-line-number="1185"></td>
-        <td id="LC1185" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1186" class="blob-num js-line-number" data-line-number="1186"></td>
-        <td id="LC1186" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type target_prefix: string</span></td>
-      </tr>
-      <tr>
-        <td id="L1187" class="blob-num js-line-number" data-line-number="1187"></td>
-        <td id="LC1187" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param target_prefix: The prefix which should be prepended to the</span></td>
-      </tr>
-      <tr>
-        <td id="L1188" class="blob-num js-line-number" data-line-number="1188"></td>
-        <td id="LC1188" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            generated log files written to the target_bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1189" class="blob-num js-line-number" data-line-number="1189"></td>
-        <td id="LC1189" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1190" class="blob-num js-line-number" data-line-number="1190"></td>
-        <td id="LC1190" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type grants: list of Grant objects</span></td>
-      </tr>
-      <tr>
-        <td id="L1191" class="blob-num js-line-number" data-line-number="1191"></td>
-        <td id="LC1191" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param grants: A list of extra permissions which will be granted on</span></td>
-      </tr>
-      <tr>
-        <td id="L1192" class="blob-num js-line-number" data-line-number="1192"></td>
-        <td id="LC1192" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the log files which are created.</span></td>
-      </tr>
-      <tr>
-        <td id="L1193" class="blob-num js-line-number" data-line-number="1193"></td>
-        <td id="LC1193" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1194" class="blob-num js-line-number" data-line-number="1194"></td>
-        <td id="LC1194" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: bool</span></td>
-      </tr>
-      <tr>
-        <td id="L1195" class="blob-num js-line-number" data-line-number="1195"></td>
-        <td id="LC1195" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: True if ok or raises an exception.</span></td>
-      </tr>
-      <tr>
-        <td id="L1196" class="blob-num js-line-number" data-line-number="1196"></td>
-        <td id="LC1196" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1197" class="blob-num js-line-number" data-line-number="1197"></td>
-        <td id="LC1197" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-c1">isinstance</span>(target_bucket, Bucket):</td>
-      </tr>
-      <tr>
-        <td id="L1198" class="blob-num js-line-number" data-line-number="1198"></td>
-        <td id="LC1198" class="blob-code blob-code-inner js-file-line">            target_bucket <span class="pl-k">=</span> target_bucket.name</td>
-      </tr>
-      <tr>
-        <td id="L1199" class="blob-num js-line-number" data-line-number="1199"></td>
-        <td id="LC1199" class="blob-code blob-code-inner js-file-line">        blogging <span class="pl-k">=</span> BucketLogging(<span class="pl-v">target</span><span class="pl-k">=</span>target_bucket, <span class="pl-v">prefix</span><span class="pl-k">=</span>target_prefix,</td>
-      </tr>
-      <tr>
-        <td id="L1200" class="blob-num js-line-number" data-line-number="1200"></td>
-        <td id="LC1200" class="blob-code blob-code-inner js-file-line">                                 <span class="pl-v">grants</span><span class="pl-k">=</span>grants)</td>
-      </tr>
-      <tr>
-        <td id="L1201" class="blob-num js-line-number" data-line-number="1201"></td>
-        <td id="LC1201" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.set_xml_logging(blogging.to_xml(), <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1202" class="blob-num js-line-number" data-line-number="1202"></td>
-        <td id="LC1202" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1203" class="blob-num js-line-number" data-line-number="1203"></td>
-        <td id="LC1203" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">disable_logging</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1204" class="blob-num js-line-number" data-line-number="1204"></td>
-        <td id="LC1204" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1205" class="blob-num js-line-number" data-line-number="1205"></td>
-        <td id="LC1205" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Disable logging on a bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1206" class="blob-num js-line-number" data-line-number="1206"></td>
-        <td id="LC1206" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1207" class="blob-num js-line-number" data-line-number="1207"></td>
-        <td id="LC1207" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: bool</span></td>
-      </tr>
-      <tr>
-        <td id="L1208" class="blob-num js-line-number" data-line-number="1208"></td>
-        <td id="LC1208" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: True if ok or raises an exception.</span></td>
-      </tr>
-      <tr>
-        <td id="L1209" class="blob-num js-line-number" data-line-number="1209"></td>
-        <td id="LC1209" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1210" class="blob-num js-line-number" data-line-number="1210"></td>
-        <td id="LC1210" class="blob-code blob-code-inner js-file-line">        blogging <span class="pl-k">=</span> BucketLogging()</td>
-      </tr>
-      <tr>
-        <td id="L1211" class="blob-num js-line-number" data-line-number="1211"></td>
-        <td id="LC1211" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.set_xml_logging(blogging.to_xml(), <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1212" class="blob-num js-line-number" data-line-number="1212"></td>
-        <td id="LC1212" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1213" class="blob-num js-line-number" data-line-number="1213"></td>
-        <td id="LC1213" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_logging_status</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1214" class="blob-num js-line-number" data-line-number="1214"></td>
-        <td id="LC1214" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1215" class="blob-num js-line-number" data-line-number="1215"></td>
-        <td id="LC1215" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Get the logging status for this bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1216" class="blob-num js-line-number" data-line-number="1216"></td>
-        <td id="LC1216" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1217" class="blob-num js-line-number" data-line-number="1217"></td>
-        <td id="LC1217" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.bucketlogging.BucketLogging`</span></td>
-      </tr>
-      <tr>
-        <td id="L1218" class="blob-num js-line-number" data-line-number="1218"></td>
-        <td id="LC1218" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :return: A BucketLogging object for this bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1219" class="blob-num js-line-number" data-line-number="1219"></td>
-        <td id="LC1219" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1220" class="blob-num js-line-number" data-line-number="1220"></td>
-        <td id="LC1220" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1221" class="blob-num js-line-number" data-line-number="1221"></td>
-        <td id="LC1221" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>logging<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1222" class="blob-num js-line-number" data-line-number="1222"></td>
-        <td id="LC1222" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1223" class="blob-num js-line-number" data-line-number="1223"></td>
-        <td id="LC1223" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1224" class="blob-num js-line-number" data-line-number="1224"></td>
-        <td id="LC1224" class="blob-code blob-code-inner js-file-line">            blogging <span class="pl-k">=</span> BucketLogging()</td>
-      </tr>
-      <tr>
-        <td id="L1225" class="blob-num js-line-number" data-line-number="1225"></td>
-        <td id="LC1225" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(blogging, <span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L1226" class="blob-num js-line-number" data-line-number="1226"></td>
-        <td id="LC1226" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1227" class="blob-num js-line-number" data-line-number="1227"></td>
-        <td id="LC1227" class="blob-code blob-code-inner js-file-line">                body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L1228" class="blob-num js-line-number" data-line-number="1228"></td>
-        <td id="LC1228" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
-      </tr>
-      <tr>
-        <td id="L1229" class="blob-num js-line-number" data-line-number="1229"></td>
-        <td id="LC1229" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> blogging</td>
-      </tr>
-      <tr>
-        <td id="L1230" class="blob-num js-line-number" data-line-number="1230"></td>
-        <td id="LC1230" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1231" class="blob-num js-line-number" data-line-number="1231"></td>
-        <td id="LC1231" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1232" class="blob-num js-line-number" data-line-number="1232"></td>
-        <td id="LC1232" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1233" class="blob-num js-line-number" data-line-number="1233"></td>
-        <td id="LC1233" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1234" class="blob-num js-line-number" data-line-number="1234"></td>
-        <td id="LC1234" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_as_logging_target</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1235" class="blob-num js-line-number" data-line-number="1235"></td>
-        <td id="LC1235" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1236" class="blob-num js-line-number" data-line-number="1236"></td>
-        <td id="LC1236" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Setup the current bucket as a logging target by granting the necessary</span></td>
-      </tr>
-      <tr>
-        <td id="L1237" class="blob-num js-line-number" data-line-number="1237"></td>
-        <td id="LC1237" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        permissions to the LogDelivery group to write log files to this bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1238" class="blob-num js-line-number" data-line-number="1238"></td>
-        <td id="LC1238" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1239" class="blob-num js-line-number" data-line-number="1239"></td>
-        <td id="LC1239" class="blob-code blob-code-inner js-file-line">        policy <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_acl(<span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1240" class="blob-num js-line-number" data-line-number="1240"></td>
-        <td id="LC1240" class="blob-code blob-code-inner js-file-line">        g1 <span class="pl-k">=</span> Grant(<span class="pl-v">permission</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>WRITE<span class="pl-pds">&#39;</span></span>, <span class="pl-v">type</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>Group<span class="pl-pds">&#39;</span></span>, <span class="pl-v">uri</span><span class="pl-k">=</span><span class="pl-c1">self</span>.LoggingGroup)</td>
-      </tr>
-      <tr>
-        <td id="L1241" class="blob-num js-line-number" data-line-number="1241"></td>
-        <td id="LC1241" class="blob-code blob-code-inner js-file-line">        g2 <span class="pl-k">=</span> Grant(<span class="pl-v">permission</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>READ_ACP<span class="pl-pds">&#39;</span></span>, <span class="pl-v">type</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>Group<span class="pl-pds">&#39;</span></span>, <span class="pl-v">uri</span><span class="pl-k">=</span><span class="pl-c1">self</span>.LoggingGroup)</td>
-      </tr>
-      <tr>
-        <td id="L1242" class="blob-num js-line-number" data-line-number="1242"></td>
-        <td id="LC1242" class="blob-code blob-code-inner js-file-line">        policy.acl.add_grant(g1)</td>
-      </tr>
-      <tr>
-        <td id="L1243" class="blob-num js-line-number" data-line-number="1243"></td>
-        <td id="LC1243" class="blob-code blob-code-inner js-file-line">        policy.acl.add_grant(g2)</td>
-      </tr>
-      <tr>
-        <td id="L1244" class="blob-num js-line-number" data-line-number="1244"></td>
-        <td id="LC1244" class="blob-code blob-code-inner js-file-line">        <span class="pl-c1">self</span>.set_acl(policy, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1245" class="blob-num js-line-number" data-line-number="1245"></td>
-        <td id="LC1245" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1246" class="blob-num js-line-number" data-line-number="1246"></td>
-        <td id="LC1246" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_request_payment</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1247" class="blob-num js-line-number" data-line-number="1247"></td>
-        <td id="LC1247" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1248" class="blob-num js-line-number" data-line-number="1248"></td>
-        <td id="LC1248" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>requestPayment<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1249" class="blob-num js-line-number" data-line-number="1249"></td>
-        <td id="LC1249" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1250" class="blob-num js-line-number" data-line-number="1250"></td>
-        <td id="LC1250" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1251" class="blob-num js-line-number" data-line-number="1251"></td>
-        <td id="LC1251" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> body</td>
-      </tr>
-      <tr>
-        <td id="L1252" class="blob-num js-line-number" data-line-number="1252"></td>
-        <td id="LC1252" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1253" class="blob-num js-line-number" data-line-number="1253"></td>
-        <td id="LC1253" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1254" class="blob-num js-line-number" data-line-number="1254"></td>
-        <td id="LC1254" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1255" class="blob-num js-line-number" data-line-number="1255"></td>
-        <td id="LC1255" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1256" class="blob-num js-line-number" data-line-number="1256"></td>
-        <td id="LC1256" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_request_payment</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">payer</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>BucketOwner<span class="pl-pds">&#39;</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1257" class="blob-num js-line-number" data-line-number="1257"></td>
-        <td id="LC1257" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> <span class="pl-c1">self</span>.BucketPaymentBody <span class="pl-k">%</span> payer</td>
-      </tr>
-      <tr>
-        <td id="L1258" class="blob-num js-line-number" data-line-number="1258"></td>
-        <td id="LC1258" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, <span class="pl-v">data</span><span class="pl-k">=</span>body,</td>
-      </tr>
-      <tr>
-        <td id="L1259" class="blob-num js-line-number" data-line-number="1259"></td>
-        <td id="LC1259" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>requestPayment<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1260" class="blob-num js-line-number" data-line-number="1260"></td>
-        <td id="LC1260" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1261" class="blob-num js-line-number" data-line-number="1261"></td>
-        <td id="LC1261" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1262" class="blob-num js-line-number" data-line-number="1262"></td>
-        <td id="LC1262" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
-      </tr>
-      <tr>
-        <td id="L1263" class="blob-num js-line-number" data-line-number="1263"></td>
-        <td id="LC1263" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1264" class="blob-num js-line-number" data-line-number="1264"></td>
-        <td id="LC1264" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1265" class="blob-num js-line-number" data-line-number="1265"></td>
-        <td id="LC1265" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1266" class="blob-num js-line-number" data-line-number="1266"></td>
-        <td id="LC1266" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1267" class="blob-num js-line-number" data-line-number="1267"></td>
-        <td id="LC1267" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">configure_versioning</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">versioning</span>, <span class="pl-smi">mfa_delete</span><span class="pl-k">=</span><span class="pl-c1">False</span>,</td>
-      </tr>
-      <tr>
-        <td id="L1268" class="blob-num js-line-number" data-line-number="1268"></td>
-        <td id="LC1268" class="blob-code blob-code-inner js-file-line">                             <span class="pl-smi">mfa_token</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1269" class="blob-num js-line-number" data-line-number="1269"></td>
-        <td id="LC1269" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1270" class="blob-num js-line-number" data-line-number="1270"></td>
-        <td id="LC1270" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Configure versioning for this bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1271" class="blob-num js-line-number" data-line-number="1271"></td>
-        <td id="LC1271" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1272" class="blob-num js-line-number" data-line-number="1272"></td>
-        <td id="LC1272" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        ..note:: This feature is currently in beta.</span></td>
-      </tr>
-      <tr>
-        <td id="L1273" class="blob-num js-line-number" data-line-number="1273"></td>
-        <td id="LC1273" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1274" class="blob-num js-line-number" data-line-number="1274"></td>
-        <td id="LC1274" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type versioning: bool</span></td>
-      </tr>
-      <tr>
-        <td id="L1275" class="blob-num js-line-number" data-line-number="1275"></td>
-        <td id="LC1275" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param versioning: A boolean indicating whether version is</span></td>
-      </tr>
-      <tr>
-        <td id="L1276" class="blob-num js-line-number" data-line-number="1276"></td>
-        <td id="LC1276" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            enabled (True) or disabled (False).</span></td>
-      </tr>
-      <tr>
-        <td id="L1277" class="blob-num js-line-number" data-line-number="1277"></td>
-        <td id="LC1277" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1278" class="blob-num js-line-number" data-line-number="1278"></td>
-        <td id="LC1278" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type mfa_delete: bool</span></td>
-      </tr>
-      <tr>
-        <td id="L1279" class="blob-num js-line-number" data-line-number="1279"></td>
-        <td id="LC1279" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param mfa_delete: A boolean indicating whether the</span></td>
-      </tr>
-      <tr>
-        <td id="L1280" class="blob-num js-line-number" data-line-number="1280"></td>
-        <td id="LC1280" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Multi-Factor Authentication Delete feature is enabled</span></td>
-      </tr>
-      <tr>
-        <td id="L1281" class="blob-num js-line-number" data-line-number="1281"></td>
-        <td id="LC1281" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            (True) or disabled (False).  If mfa_delete is enabled then</span></td>
-      </tr>
-      <tr>
-        <td id="L1282" class="blob-num js-line-number" data-line-number="1282"></td>
-        <td id="LC1282" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            all Delete operations will require the token from your MFA</span></td>
-      </tr>
-      <tr>
-        <td id="L1283" class="blob-num js-line-number" data-line-number="1283"></td>
-        <td id="LC1283" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            device to be passed in the request.</span></td>
-      </tr>
-      <tr>
-        <td id="L1284" class="blob-num js-line-number" data-line-number="1284"></td>
-        <td id="LC1284" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1285" class="blob-num js-line-number" data-line-number="1285"></td>
-        <td id="LC1285" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type mfa_token: tuple or list of strings</span></td>
-      </tr>
-      <tr>
-        <td id="L1286" class="blob-num js-line-number" data-line-number="1286"></td>
-        <td id="LC1286" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param mfa_token: A tuple or list consisting of the serial</span></td>
-      </tr>
-      <tr>
-        <td id="L1287" class="blob-num js-line-number" data-line-number="1287"></td>
-        <td id="LC1287" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            number from the MFA device and the current value of the</span></td>
-      </tr>
-      <tr>
-        <td id="L1288" class="blob-num js-line-number" data-line-number="1288"></td>
-        <td id="LC1288" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            six-digit token associated with the device.  This value is</span></td>
-      </tr>
-      <tr>
-        <td id="L1289" class="blob-num js-line-number" data-line-number="1289"></td>
-        <td id="LC1289" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            required when you are changing the status of the MfaDelete</span></td>
-      </tr>
-      <tr>
-        <td id="L1290" class="blob-num js-line-number" data-line-number="1290"></td>
-        <td id="LC1290" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            property of the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1291" class="blob-num js-line-number" data-line-number="1291"></td>
-        <td id="LC1291" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1292" class="blob-num js-line-number" data-line-number="1292"></td>
-        <td id="LC1292" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> versioning:</td>
-      </tr>
-      <tr>
-        <td id="L1293" class="blob-num js-line-number" data-line-number="1293"></td>
-        <td id="LC1293" class="blob-code blob-code-inner js-file-line">            ver <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>Enabled<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1294" class="blob-num js-line-number" data-line-number="1294"></td>
-        <td id="LC1294" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1295" class="blob-num js-line-number" data-line-number="1295"></td>
-        <td id="LC1295" class="blob-code blob-code-inner js-file-line">            ver <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>Suspended<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1296" class="blob-num js-line-number" data-line-number="1296"></td>
-        <td id="LC1296" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> mfa_delete:</td>
-      </tr>
-      <tr>
-        <td id="L1297" class="blob-num js-line-number" data-line-number="1297"></td>
-        <td id="LC1297" class="blob-code blob-code-inner js-file-line">            mfa <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>Enabled<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1298" class="blob-num js-line-number" data-line-number="1298"></td>
-        <td id="LC1298" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1299" class="blob-num js-line-number" data-line-number="1299"></td>
-        <td id="LC1299" class="blob-code blob-code-inner js-file-line">            mfa <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>Disabled<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1300" class="blob-num js-line-number" data-line-number="1300"></td>
-        <td id="LC1300" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> <span class="pl-c1">self</span>.VersioningBody <span class="pl-k">%</span> (ver, mfa)</td>
-      </tr>
-      <tr>
-        <td id="L1301" class="blob-num js-line-number" data-line-number="1301"></td>
-        <td id="LC1301" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> mfa_token:</td>
-      </tr>
-      <tr>
-        <td id="L1302" class="blob-num js-line-number" data-line-number="1302"></td>
-        <td id="LC1302" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> headers:</td>
-      </tr>
-      <tr>
-        <td id="L1303" class="blob-num js-line-number" data-line-number="1303"></td>
-        <td id="LC1303" class="blob-code blob-code-inner js-file-line">                headers <span class="pl-k">=</span> {}</td>
-      </tr>
-      <tr>
-        <td id="L1304" class="blob-num js-line-number" data-line-number="1304"></td>
-        <td id="LC1304" class="blob-code blob-code-inner js-file-line">            provider <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.provider</td>
-      </tr>
-      <tr>
-        <td id="L1305" class="blob-num js-line-number" data-line-number="1305"></td>
-        <td id="LC1305" class="blob-code blob-code-inner js-file-line">            headers[provider.mfa_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span> <span class="pl-pds">&#39;</span></span>.join(mfa_token)</td>
-      </tr>
-      <tr>
-        <td id="L1306" class="blob-num js-line-number" data-line-number="1306"></td>
-        <td id="LC1306" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, <span class="pl-v">data</span><span class="pl-k">=</span>body,</td>
-      </tr>
-      <tr>
-        <td id="L1307" class="blob-num js-line-number" data-line-number="1307"></td>
-        <td id="LC1307" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>versioning<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1308" class="blob-num js-line-number" data-line-number="1308"></td>
-        <td id="LC1308" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1309" class="blob-num js-line-number" data-line-number="1309"></td>
-        <td id="LC1309" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1310" class="blob-num js-line-number" data-line-number="1310"></td>
-        <td id="LC1310" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
-      </tr>
-      <tr>
-        <td id="L1311" class="blob-num js-line-number" data-line-number="1311"></td>
-        <td id="LC1311" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1312" class="blob-num js-line-number" data-line-number="1312"></td>
-        <td id="LC1312" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1313" class="blob-num js-line-number" data-line-number="1313"></td>
-        <td id="LC1313" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1314" class="blob-num js-line-number" data-line-number="1314"></td>
-        <td id="LC1314" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1315" class="blob-num js-line-number" data-line-number="1315"></td>
-        <td id="LC1315" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_versioning_status</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1316" class="blob-num js-line-number" data-line-number="1316"></td>
-        <td id="LC1316" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1317" class="blob-num js-line-number" data-line-number="1317"></td>
-        <td id="LC1317" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the current status of versioning on the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1318" class="blob-num js-line-number" data-line-number="1318"></td>
-        <td id="LC1318" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1319" class="blob-num js-line-number" data-line-number="1319"></td>
-        <td id="LC1319" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: dict</span></td>
-      </tr>
-      <tr>
-        <td id="L1320" class="blob-num js-line-number" data-line-number="1320"></td>
-        <td id="LC1320" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: A dictionary containing a key named &#39;Versioning&#39;</span></td>
-      </tr>
-      <tr>
-        <td id="L1321" class="blob-num js-line-number" data-line-number="1321"></td>
-        <td id="LC1321" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            that can have a value of either Enabled, Disabled, or</span></td>
-      </tr>
-      <tr>
-        <td id="L1322" class="blob-num js-line-number" data-line-number="1322"></td>
-        <td id="LC1322" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Suspended. Also, if MFADelete has ever been enabled on the</span></td>
-      </tr>
-      <tr>
-        <td id="L1323" class="blob-num js-line-number" data-line-number="1323"></td>
-        <td id="LC1323" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            bucket, the dictionary will contain a key named</span></td>
-      </tr>
-      <tr>
-        <td id="L1324" class="blob-num js-line-number" data-line-number="1324"></td>
-        <td id="LC1324" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            &#39;MFADelete&#39; which will have a value of either Enabled or</span></td>
-      </tr>
-      <tr>
-        <td id="L1325" class="blob-num js-line-number" data-line-number="1325"></td>
-        <td id="LC1325" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Suspended.</span></td>
-      </tr>
-      <tr>
-        <td id="L1326" class="blob-num js-line-number" data-line-number="1326"></td>
-        <td id="LC1326" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1327" class="blob-num js-line-number" data-line-number="1327"></td>
-        <td id="LC1327" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1328" class="blob-num js-line-number" data-line-number="1328"></td>
-        <td id="LC1328" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>versioning<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1329" class="blob-num js-line-number" data-line-number="1329"></td>
-        <td id="LC1329" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1330" class="blob-num js-line-number" data-line-number="1330"></td>
-        <td id="LC1330" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, six.string_types):</td>
-      </tr>
-      <tr>
-        <td id="L1331" class="blob-num js-line-number" data-line-number="1331"></td>
-        <td id="LC1331" class="blob-code blob-code-inner js-file-line">            body <span class="pl-k">=</span> body.decode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L1332" class="blob-num js-line-number" data-line-number="1332"></td>
-        <td id="LC1332" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
-      </tr>
-      <tr>
-        <td id="L1333" class="blob-num js-line-number" data-line-number="1333"></td>
-        <td id="LC1333" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1334" class="blob-num js-line-number" data-line-number="1334"></td>
-        <td id="LC1334" class="blob-code blob-code-inner js-file-line">            d <span class="pl-k">=</span> {}</td>
-      </tr>
-      <tr>
-        <td id="L1335" class="blob-num js-line-number" data-line-number="1335"></td>
-        <td id="LC1335" class="blob-code blob-code-inner js-file-line">            ver <span class="pl-k">=</span> re.search(<span class="pl-c1">self</span>.VersionRE, body)</td>
-      </tr>
-      <tr>
-        <td id="L1336" class="blob-num js-line-number" data-line-number="1336"></td>
-        <td id="LC1336" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> ver:</td>
-      </tr>
-      <tr>
-        <td id="L1337" class="blob-num js-line-number" data-line-number="1337"></td>
-        <td id="LC1337" class="blob-code blob-code-inner js-file-line">                d[<span class="pl-s"><span class="pl-pds">&#39;</span>Versioning<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> ver.group(<span class="pl-c1">1</span>)</td>
-      </tr>
-      <tr>
-        <td id="L1338" class="blob-num js-line-number" data-line-number="1338"></td>
-        <td id="LC1338" class="blob-code blob-code-inner js-file-line">            mfa <span class="pl-k">=</span> re.search(<span class="pl-c1">self</span>.MFADeleteRE, body)</td>
-      </tr>
-      <tr>
-        <td id="L1339" class="blob-num js-line-number" data-line-number="1339"></td>
-        <td id="LC1339" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> mfa:</td>
-      </tr>
-      <tr>
-        <td id="L1340" class="blob-num js-line-number" data-line-number="1340"></td>
-        <td id="LC1340" class="blob-code blob-code-inner js-file-line">                d[<span class="pl-s"><span class="pl-pds">&#39;</span>MfaDelete<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> mfa.group(<span class="pl-c1">1</span>)</td>
-      </tr>
-      <tr>
-        <td id="L1341" class="blob-num js-line-number" data-line-number="1341"></td>
-        <td id="LC1341" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> d</td>
-      </tr>
-      <tr>
-        <td id="L1342" class="blob-num js-line-number" data-line-number="1342"></td>
-        <td id="LC1342" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1343" class="blob-num js-line-number" data-line-number="1343"></td>
-        <td id="LC1343" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1344" class="blob-num js-line-number" data-line-number="1344"></td>
-        <td id="LC1344" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1345" class="blob-num js-line-number" data-line-number="1345"></td>
-        <td id="LC1345" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1346" class="blob-num js-line-number" data-line-number="1346"></td>
-        <td id="LC1346" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">configure_lifecycle</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">lifecycle_config</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1347" class="blob-num js-line-number" data-line-number="1347"></td>
-        <td id="LC1347" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1348" class="blob-num js-line-number" data-line-number="1348"></td>
-        <td id="LC1348" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Configure lifecycle for this bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1349" class="blob-num js-line-number" data-line-number="1349"></td>
-        <td id="LC1349" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1350" class="blob-num js-line-number" data-line-number="1350"></td>
-        <td id="LC1350" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type lifecycle_config: :class:`boto.s3.lifecycle.Lifecycle`</span></td>
-      </tr>
-      <tr>
-        <td id="L1351" class="blob-num js-line-number" data-line-number="1351"></td>
-        <td id="LC1351" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param lifecycle_config: The lifecycle configuration you want</span></td>
-      </tr>
-      <tr>
-        <td id="L1352" class="blob-num js-line-number" data-line-number="1352"></td>
-        <td id="LC1352" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            to configure for this bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1353" class="blob-num js-line-number" data-line-number="1353"></td>
-        <td id="LC1353" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1354" class="blob-num js-line-number" data-line-number="1354"></td>
-        <td id="LC1354" class="blob-code blob-code-inner js-file-line">        xml <span class="pl-k">=</span> lifecycle_config.to_xml()</td>
-      </tr>
-      <tr>
-        <td id="L1355" class="blob-num js-line-number" data-line-number="1355"></td>
-        <td id="LC1355" class="blob-code blob-code-inner js-file-line">        <span class="pl-c"><span class="pl-c">#</span>xml = xml.encode(&#39;utf-8&#39;)</span></td>
-      </tr>
-      <tr>
-        <td id="L1356" class="blob-num js-line-number" data-line-number="1356"></td>
-        <td id="LC1356" class="blob-code blob-code-inner js-file-line">        fp <span class="pl-k">=</span> StringIO(xml)</td>
-      </tr>
-      <tr>
-        <td id="L1357" class="blob-num js-line-number" data-line-number="1357"></td>
-        <td id="LC1357" class="blob-code blob-code-inner js-file-line">        md5 <span class="pl-k">=</span> boto.utils.compute_md5(fp)</td>
-      </tr>
-      <tr>
-        <td id="L1358" class="blob-num js-line-number" data-line-number="1358"></td>
-        <td id="LC1358" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> headers <span class="pl-k">is</span> <span class="pl-c1">None</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1359" class="blob-num js-line-number" data-line-number="1359"></td>
-        <td id="LC1359" class="blob-code blob-code-inner js-file-line">            headers <span class="pl-k">=</span> {}</td>
-      </tr>
-      <tr>
-        <td id="L1360" class="blob-num js-line-number" data-line-number="1360"></td>
-        <td id="LC1360" class="blob-code blob-code-inner js-file-line">        headers[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-MD5<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> md5[<span class="pl-c1">1</span>]</td>
-      </tr>
-      <tr>
-        <td id="L1361" class="blob-num js-line-number" data-line-number="1361"></td>
-        <td id="LC1361" class="blob-code blob-code-inner js-file-line">        headers[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-Type<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>text/xml<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1362" class="blob-num js-line-number" data-line-number="1362"></td>
-        <td id="LC1362" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1363" class="blob-num js-line-number" data-line-number="1363"></td>
-        <td id="LC1363" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">data</span><span class="pl-k">=</span>fp.getvalue(),</td>
-      </tr>
-      <tr>
-        <td id="L1364" class="blob-num js-line-number" data-line-number="1364"></td>
-        <td id="LC1364" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>lifecycle<span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L1365" class="blob-num js-line-number" data-line-number="1365"></td>
-        <td id="LC1365" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1366" class="blob-num js-line-number" data-line-number="1366"></td>
-        <td id="LC1366" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1367" class="blob-num js-line-number" data-line-number="1367"></td>
-        <td id="LC1367" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1368" class="blob-num js-line-number" data-line-number="1368"></td>
-        <td id="LC1368" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
-      </tr>
-      <tr>
-        <td id="L1369" class="blob-num js-line-number" data-line-number="1369"></td>
-        <td id="LC1369" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1370" class="blob-num js-line-number" data-line-number="1370"></td>
-        <td id="LC1370" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1371" class="blob-num js-line-number" data-line-number="1371"></td>
-        <td id="LC1371" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1372" class="blob-num js-line-number" data-line-number="1372"></td>
-        <td id="LC1372" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1373" class="blob-num js-line-number" data-line-number="1373"></td>
-        <td id="LC1373" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_lifecycle_config</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1374" class="blob-num js-line-number" data-line-number="1374"></td>
-        <td id="LC1374" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1375" class="blob-num js-line-number" data-line-number="1375"></td>
-        <td id="LC1375" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the current lifecycle configuration on the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1376" class="blob-num js-line-number" data-line-number="1376"></td>
-        <td id="LC1376" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1377" class="blob-num js-line-number" data-line-number="1377"></td>
-        <td id="LC1377" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.lifecycle.Lifecycle`</span></td>
-      </tr>
-      <tr>
-        <td id="L1378" class="blob-num js-line-number" data-line-number="1378"></td>
-        <td id="LC1378" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: A LifecycleConfig object that describes all current</span></td>
-      </tr>
-      <tr>
-        <td id="L1379" class="blob-num js-line-number" data-line-number="1379"></td>
-        <td id="LC1379" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            lifecycle rules in effect for the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1380" class="blob-num js-line-number" data-line-number="1380"></td>
-        <td id="LC1380" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1381" class="blob-num js-line-number" data-line-number="1381"></td>
-        <td id="LC1381" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1382" class="blob-num js-line-number" data-line-number="1382"></td>
-        <td id="LC1382" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>lifecycle<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1383" class="blob-num js-line-number" data-line-number="1383"></td>
-        <td id="LC1383" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1384" class="blob-num js-line-number" data-line-number="1384"></td>
-        <td id="LC1384" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
-      </tr>
-      <tr>
-        <td id="L1385" class="blob-num js-line-number" data-line-number="1385"></td>
-        <td id="LC1385" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1386" class="blob-num js-line-number" data-line-number="1386"></td>
-        <td id="LC1386" class="blob-code blob-code-inner js-file-line">            lifecycle <span class="pl-k">=</span> Lifecycle()</td>
-      </tr>
-      <tr>
-        <td id="L1387" class="blob-num js-line-number" data-line-number="1387"></td>
-        <td id="LC1387" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(lifecycle, <span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L1388" class="blob-num js-line-number" data-line-number="1388"></td>
-        <td id="LC1388" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1389" class="blob-num js-line-number" data-line-number="1389"></td>
-        <td id="LC1389" class="blob-code blob-code-inner js-file-line">                body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L1390" class="blob-num js-line-number" data-line-number="1390"></td>
-        <td id="LC1390" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
-      </tr>
-      <tr>
-        <td id="L1391" class="blob-num js-line-number" data-line-number="1391"></td>
-        <td id="LC1391" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> lifecycle</td>
-      </tr>
-      <tr>
-        <td id="L1392" class="blob-num js-line-number" data-line-number="1392"></td>
-        <td id="LC1392" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1393" class="blob-num js-line-number" data-line-number="1393"></td>
-        <td id="LC1393" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1394" class="blob-num js-line-number" data-line-number="1394"></td>
-        <td id="LC1394" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1395" class="blob-num js-line-number" data-line-number="1395"></td>
-        <td id="LC1395" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1396" class="blob-num js-line-number" data-line-number="1396"></td>
-        <td id="LC1396" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete_lifecycle_configuration</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1397" class="blob-num js-line-number" data-line-number="1397"></td>
-        <td id="LC1397" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1398" class="blob-num js-line-number" data-line-number="1398"></td>
-        <td id="LC1398" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Removes all lifecycle configuration from the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1399" class="blob-num js-line-number" data-line-number="1399"></td>
-        <td id="LC1399" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1400" class="blob-num js-line-number" data-line-number="1400"></td>
-        <td id="LC1400" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>DELETE<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1401" class="blob-num js-line-number" data-line-number="1401"></td>
-        <td id="LC1401" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>lifecycle<span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L1402" class="blob-num js-line-number" data-line-number="1402"></td>
-        <td id="LC1402" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1403" class="blob-num js-line-number" data-line-number="1403"></td>
-        <td id="LC1403" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1404" class="blob-num js-line-number" data-line-number="1404"></td>
-        <td id="LC1404" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
-      </tr>
-      <tr>
-        <td id="L1405" class="blob-num js-line-number" data-line-number="1405"></td>
-        <td id="LC1405" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">204</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1406" class="blob-num js-line-number" data-line-number="1406"></td>
-        <td id="LC1406" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
-      </tr>
-      <tr>
-        <td id="L1407" class="blob-num js-line-number" data-line-number="1407"></td>
-        <td id="LC1407" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1408" class="blob-num js-line-number" data-line-number="1408"></td>
-        <td id="LC1408" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1409" class="blob-num js-line-number" data-line-number="1409"></td>
-        <td id="LC1409" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1410" class="blob-num js-line-number" data-line-number="1410"></td>
-        <td id="LC1410" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1411" class="blob-num js-line-number" data-line-number="1411"></td>
-        <td id="LC1411" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">configure_website</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">suffix</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">error_key</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
-      </tr>
-      <tr>
-        <td id="L1412" class="blob-num js-line-number" data-line-number="1412"></td>
-        <td id="LC1412" class="blob-code blob-code-inner js-file-line">                          <span class="pl-smi">redirect_all_requests_to</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
-      </tr>
-      <tr>
-        <td id="L1413" class="blob-num js-line-number" data-line-number="1413"></td>
-        <td id="LC1413" class="blob-code blob-code-inner js-file-line">                          <span class="pl-smi">routing_rules</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
-      </tr>
-      <tr>
-        <td id="L1414" class="blob-num js-line-number" data-line-number="1414"></td>
-        <td id="LC1414" class="blob-code blob-code-inner js-file-line">                          <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1415" class="blob-num js-line-number" data-line-number="1415"></td>
-        <td id="LC1415" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1416" class="blob-num js-line-number" data-line-number="1416"></td>
-        <td id="LC1416" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Configure this bucket to act as a website</span></td>
-      </tr>
-      <tr>
-        <td id="L1417" class="blob-num js-line-number" data-line-number="1417"></td>
-        <td id="LC1417" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1418" class="blob-num js-line-number" data-line-number="1418"></td>
-        <td id="LC1418" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type suffix: str</span></td>
-      </tr>
-      <tr>
-        <td id="L1419" class="blob-num js-line-number" data-line-number="1419"></td>
-        <td id="LC1419" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param suffix: Suffix that is appended to a request that is for a</span></td>
-      </tr>
-      <tr>
-        <td id="L1420" class="blob-num js-line-number" data-line-number="1420"></td>
-        <td id="LC1420" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            &quot;directory&quot; on the website endpoint (e.g. if the suffix is</span></td>
-      </tr>
-      <tr>
-        <td id="L1421" class="blob-num js-line-number" data-line-number="1421"></td>
-        <td id="LC1421" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            index.html and you make a request to samplebucket/images/</span></td>
-      </tr>
-      <tr>
-        <td id="L1422" class="blob-num js-line-number" data-line-number="1422"></td>
-        <td id="LC1422" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            the data that is returned will be for the object with the</span></td>
-      </tr>
-      <tr>
-        <td id="L1423" class="blob-num js-line-number" data-line-number="1423"></td>
-        <td id="LC1423" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            key name images/index.html).  The suffix must not be empty</span></td>
-      </tr>
-      <tr>
-        <td id="L1424" class="blob-num js-line-number" data-line-number="1424"></td>
-        <td id="LC1424" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            and must not include a slash character.</span></td>
-      </tr>
-      <tr>
-        <td id="L1425" class="blob-num js-line-number" data-line-number="1425"></td>
-        <td id="LC1425" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1426" class="blob-num js-line-number" data-line-number="1426"></td>
-        <td id="LC1426" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type error_key: str</span></td>
-      </tr>
-      <tr>
-        <td id="L1427" class="blob-num js-line-number" data-line-number="1427"></td>
-        <td id="LC1427" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param error_key: The object key name to use when a 4XX class</span></td>
-      </tr>
-      <tr>
-        <td id="L1428" class="blob-num js-line-number" data-line-number="1428"></td>
-        <td id="LC1428" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            error occurs.  This is optional.</span></td>
-      </tr>
-      <tr>
-        <td id="L1429" class="blob-num js-line-number" data-line-number="1429"></td>
-        <td id="LC1429" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1430" class="blob-num js-line-number" data-line-number="1430"></td>
-        <td id="LC1430" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type redirect_all_requests_to: :class:`boto.s3.website.RedirectLocation`</span></td>
-      </tr>
-      <tr>
-        <td id="L1431" class="blob-num js-line-number" data-line-number="1431"></td>
-        <td id="LC1431" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param redirect_all_requests_to: Describes the redirect behavior for</span></td>
-      </tr>
-      <tr>
-        <td id="L1432" class="blob-num js-line-number" data-line-number="1432"></td>
-        <td id="LC1432" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            every request to this bucket&#39;s website endpoint. If this value is</span></td>
-      </tr>
-      <tr>
-        <td id="L1433" class="blob-num js-line-number" data-line-number="1433"></td>
-        <td id="LC1433" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            non None, no other values are considered when configuring the</span></td>
-      </tr>
-      <tr>
-        <td id="L1434" class="blob-num js-line-number" data-line-number="1434"></td>
-        <td id="LC1434" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            website configuration for the bucket. This is an instance of</span></td>
-      </tr>
-      <tr>
-        <td id="L1435" class="blob-num js-line-number" data-line-number="1435"></td>
-        <td id="LC1435" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            ``RedirectLocation``.</span></td>
-      </tr>
-      <tr>
-        <td id="L1436" class="blob-num js-line-number" data-line-number="1436"></td>
-        <td id="LC1436" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1437" class="blob-num js-line-number" data-line-number="1437"></td>
-        <td id="LC1437" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type routing_rules: :class:`boto.s3.website.RoutingRules`</span></td>
-      </tr>
-      <tr>
-        <td id="L1438" class="blob-num js-line-number" data-line-number="1438"></td>
-        <td id="LC1438" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param routing_rules: Object which specifies conditions</span></td>
-      </tr>
-      <tr>
-        <td id="L1439" class="blob-num js-line-number" data-line-number="1439"></td>
-        <td id="LC1439" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            and redirects that apply when the conditions are met.</span></td>
-      </tr>
-      <tr>
-        <td id="L1440" class="blob-num js-line-number" data-line-number="1440"></td>
-        <td id="LC1440" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1441" class="blob-num js-line-number" data-line-number="1441"></td>
-        <td id="LC1441" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1442" class="blob-num js-line-number" data-line-number="1442"></td>
-        <td id="LC1442" class="blob-code blob-code-inner js-file-line">        config <span class="pl-k">=</span> website.WebsiteConfiguration(</td>
-      </tr>
-      <tr>
-        <td id="L1443" class="blob-num js-line-number" data-line-number="1443"></td>
-        <td id="LC1443" class="blob-code blob-code-inner js-file-line">                suffix, error_key, redirect_all_requests_to,</td>
-      </tr>
-      <tr>
-        <td id="L1444" class="blob-num js-line-number" data-line-number="1444"></td>
-        <td id="LC1444" class="blob-code blob-code-inner js-file-line">                routing_rules)</td>
-      </tr>
-      <tr>
-        <td id="L1445" class="blob-num js-line-number" data-line-number="1445"></td>
-        <td id="LC1445" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.set_website_configuration(config, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1446" class="blob-num js-line-number" data-line-number="1446"></td>
-        <td id="LC1446" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1447" class="blob-num js-line-number" data-line-number="1447"></td>
-        <td id="LC1447" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_website_configuration</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">config</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1448" class="blob-num js-line-number" data-line-number="1448"></td>
-        <td id="LC1448" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1449" class="blob-num js-line-number" data-line-number="1449"></td>
-        <td id="LC1449" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type config: boto.s3.website.WebsiteConfiguration</span></td>
-      </tr>
-      <tr>
-        <td id="L1450" class="blob-num js-line-number" data-line-number="1450"></td>
-        <td id="LC1450" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param config: Configuration data</span></td>
-      </tr>
-      <tr>
-        <td id="L1451" class="blob-num js-line-number" data-line-number="1451"></td>
-        <td id="LC1451" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1452" class="blob-num js-line-number" data-line-number="1452"></td>
-        <td id="LC1452" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.set_website_configuration_xml(config.to_xml(),</td>
-      </tr>
-      <tr>
-        <td id="L1453" class="blob-num js-line-number" data-line-number="1453"></td>
-        <td id="LC1453" class="blob-code blob-code-inner js-file-line">          <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1454" class="blob-num js-line-number" data-line-number="1454"></td>
-        <td id="LC1454" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1455" class="blob-num js-line-number" data-line-number="1455"></td>
-        <td id="LC1455" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1456" class="blob-num js-line-number" data-line-number="1456"></td>
-        <td id="LC1456" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_website_configuration_xml</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">xml</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1457" class="blob-num js-line-number" data-line-number="1457"></td>
-        <td id="LC1457" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span>Upload xml website configuration<span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1458" class="blob-num js-line-number" data-line-number="1458"></td>
-        <td id="LC1458" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, <span class="pl-v">data</span><span class="pl-k">=</span>xml,</td>
-      </tr>
-      <tr>
-        <td id="L1459" class="blob-num js-line-number" data-line-number="1459"></td>
-        <td id="LC1459" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>website<span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L1460" class="blob-num js-line-number" data-line-number="1460"></td>
-        <td id="LC1460" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1461" class="blob-num js-line-number" data-line-number="1461"></td>
-        <td id="LC1461" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1462" class="blob-num js-line-number" data-line-number="1462"></td>
-        <td id="LC1462" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1463" class="blob-num js-line-number" data-line-number="1463"></td>
-        <td id="LC1463" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
-      </tr>
-      <tr>
-        <td id="L1464" class="blob-num js-line-number" data-line-number="1464"></td>
-        <td id="LC1464" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1465" class="blob-num js-line-number" data-line-number="1465"></td>
-        <td id="LC1465" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1466" class="blob-num js-line-number" data-line-number="1466"></td>
-        <td id="LC1466" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1467" class="blob-num js-line-number" data-line-number="1467"></td>
-        <td id="LC1467" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1468" class="blob-num js-line-number" data-line-number="1468"></td>
-        <td id="LC1468" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_website_configuration</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1469" class="blob-num js-line-number" data-line-number="1469"></td>
-        <td id="LC1469" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1470" class="blob-num js-line-number" data-line-number="1470"></td>
-        <td id="LC1470" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the current status of website configuration on the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1471" class="blob-num js-line-number" data-line-number="1471"></td>
-        <td id="LC1471" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1472" class="blob-num js-line-number" data-line-number="1472"></td>
-        <td id="LC1472" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: dict</span></td>
-      </tr>
-      <tr>
-        <td id="L1473" class="blob-num js-line-number" data-line-number="1473"></td>
-        <td id="LC1473" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: A dictionary containing a Python representation</span></td>
-      </tr>
-      <tr>
-        <td id="L1474" class="blob-num js-line-number" data-line-number="1474"></td>
-        <td id="LC1474" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            of the XML response from S3. The overall structure is:</span></td>
-      </tr>
-      <tr>
-        <td id="L1475" class="blob-num js-line-number" data-line-number="1475"></td>
-        <td id="LC1475" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1476" class="blob-num js-line-number" data-line-number="1476"></td>
-        <td id="LC1476" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        * WebsiteConfiguration</span></td>
-      </tr>
-      <tr>
-        <td id="L1477" class="blob-num js-line-number" data-line-number="1477"></td>
-        <td id="LC1477" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1478" class="blob-num js-line-number" data-line-number="1478"></td>
-        <td id="LC1478" class="blob-code blob-code-inner js-file-line"><span class="pl-s">          * IndexDocument</span></td>
-      </tr>
-      <tr>
-        <td id="L1479" class="blob-num js-line-number" data-line-number="1479"></td>
-        <td id="LC1479" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1480" class="blob-num js-line-number" data-line-number="1480"></td>
-        <td id="LC1480" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            * Suffix : suffix that is appended to request that</span></td>
-      </tr>
-      <tr>
-        <td id="L1481" class="blob-num js-line-number" data-line-number="1481"></td>
-        <td id="LC1481" class="blob-code blob-code-inner js-file-line"><span class="pl-s">              is for a &quot;directory&quot; on the website endpoint</span></td>
-      </tr>
-      <tr>
-        <td id="L1482" class="blob-num js-line-number" data-line-number="1482"></td>
-        <td id="LC1482" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            * ErrorDocument</span></td>
-      </tr>
-      <tr>
-        <td id="L1483" class="blob-num js-line-number" data-line-number="1483"></td>
-        <td id="LC1483" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1484" class="blob-num js-line-number" data-line-number="1484"></td>
-        <td id="LC1484" class="blob-code blob-code-inner js-file-line"><span class="pl-s">              * Key : name of object to serve when an error occurs</span></td>
-      </tr>
-      <tr>
-        <td id="L1485" class="blob-num js-line-number" data-line-number="1485"></td>
-        <td id="LC1485" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1486" class="blob-num js-line-number" data-line-number="1486"></td>
-        <td id="LC1486" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1487" class="blob-num js-line-number" data-line-number="1487"></td>
-        <td id="LC1487" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.get_website_configuration_with_xml(headers)[<span class="pl-c1">0</span>]</td>
-      </tr>
-      <tr>
-        <td id="L1488" class="blob-num js-line-number" data-line-number="1488"></td>
-        <td id="LC1488" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1489" class="blob-num js-line-number" data-line-number="1489"></td>
-        <td id="LC1489" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_website_configuration_obj</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1490" class="blob-num js-line-number" data-line-number="1490"></td>
-        <td id="LC1490" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span>Get the website configuration as a</span></td>
-      </tr>
-      <tr>
-        <td id="L1491" class="blob-num js-line-number" data-line-number="1491"></td>
-        <td id="LC1491" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :class:`boto.s3.website.WebsiteConfiguration` object.</span></td>
-      </tr>
-      <tr>
-        <td id="L1492" class="blob-num js-line-number" data-line-number="1492"></td>
-        <td id="LC1492" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1493" class="blob-num js-line-number" data-line-number="1493"></td>
-        <td id="LC1493" class="blob-code blob-code-inner js-file-line">        config_xml <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_website_configuration_xml(<span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1494" class="blob-num js-line-number" data-line-number="1494"></td>
-        <td id="LC1494" class="blob-code blob-code-inner js-file-line">        config <span class="pl-k">=</span> website.WebsiteConfiguration()</td>
-      </tr>
-      <tr>
-        <td id="L1495" class="blob-num js-line-number" data-line-number="1495"></td>
-        <td id="LC1495" class="blob-code blob-code-inner js-file-line">        h <span class="pl-k">=</span> handler.XmlHandler(config, <span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L1496" class="blob-num js-line-number" data-line-number="1496"></td>
-        <td id="LC1496" class="blob-code blob-code-inner js-file-line">        xml.sax.parseString(config_xml, h)</td>
-      </tr>
-      <tr>
-        <td id="L1497" class="blob-num js-line-number" data-line-number="1497"></td>
-        <td id="LC1497" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> config</td>
-      </tr>
-      <tr>
-        <td id="L1498" class="blob-num js-line-number" data-line-number="1498"></td>
-        <td id="LC1498" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1499" class="blob-num js-line-number" data-line-number="1499"></td>
-        <td id="LC1499" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_website_configuration_with_xml</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1500" class="blob-num js-line-number" data-line-number="1500"></td>
-        <td id="LC1500" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1501" class="blob-num js-line-number" data-line-number="1501"></td>
-        <td id="LC1501" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the current status of website configuration on the bucket as</span></td>
-      </tr>
-      <tr>
-        <td id="L1502" class="blob-num js-line-number" data-line-number="1502"></td>
-        <td id="LC1502" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        unparsed XML.</span></td>
-      </tr>
-      <tr>
-        <td id="L1503" class="blob-num js-line-number" data-line-number="1503"></td>
-        <td id="LC1503" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1504" class="blob-num js-line-number" data-line-number="1504"></td>
-        <td id="LC1504" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: 2-Tuple</span></td>
-      </tr>
-      <tr>
-        <td id="L1505" class="blob-num js-line-number" data-line-number="1505"></td>
-        <td id="LC1505" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: 2-tuple containing:</span></td>
-      </tr>
-      <tr>
-        <td id="L1506" class="blob-num js-line-number" data-line-number="1506"></td>
-        <td id="LC1506" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1507" class="blob-num js-line-number" data-line-number="1507"></td>
-        <td id="LC1507" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            1) A dictionary containing a Python representation <span class="pl-c1">\</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1508" class="blob-num js-line-number" data-line-number="1508"></td>
-        <td id="LC1508" class="blob-code blob-code-inner js-file-line"><span class="pl-s">                of the XML response. The overall structure is:</span></td>
-      </tr>
-      <tr>
-        <td id="L1509" class="blob-num js-line-number" data-line-number="1509"></td>
-        <td id="LC1509" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1510" class="blob-num js-line-number" data-line-number="1510"></td>
-        <td id="LC1510" class="blob-code blob-code-inner js-file-line"><span class="pl-s">              * WebsiteConfiguration</span></td>
-      </tr>
-      <tr>
-        <td id="L1511" class="blob-num js-line-number" data-line-number="1511"></td>
-        <td id="LC1511" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1512" class="blob-num js-line-number" data-line-number="1512"></td>
-        <td id="LC1512" class="blob-code blob-code-inner js-file-line"><span class="pl-s">                * IndexDocument</span></td>
-      </tr>
-      <tr>
-        <td id="L1513" class="blob-num js-line-number" data-line-number="1513"></td>
-        <td id="LC1513" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1514" class="blob-num js-line-number" data-line-number="1514"></td>
-        <td id="LC1514" class="blob-code blob-code-inner js-file-line"><span class="pl-s">                  * Suffix : suffix that is appended to request that <span class="pl-c1">\</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1515" class="blob-num js-line-number" data-line-number="1515"></td>
-        <td id="LC1515" class="blob-code blob-code-inner js-file-line"><span class="pl-s">                    is for a &quot;directory&quot; on the website endpoint</span></td>
-      </tr>
-      <tr>
-        <td id="L1516" class="blob-num js-line-number" data-line-number="1516"></td>
-        <td id="LC1516" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1517" class="blob-num js-line-number" data-line-number="1517"></td>
-        <td id="LC1517" class="blob-code blob-code-inner js-file-line"><span class="pl-s">                  * ErrorDocument</span></td>
-      </tr>
-      <tr>
-        <td id="L1518" class="blob-num js-line-number" data-line-number="1518"></td>
-        <td id="LC1518" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1519" class="blob-num js-line-number" data-line-number="1519"></td>
-        <td id="LC1519" class="blob-code blob-code-inner js-file-line"><span class="pl-s">                    * Key : name of object to serve when an error occurs</span></td>
-      </tr>
-      <tr>
-        <td id="L1520" class="blob-num js-line-number" data-line-number="1520"></td>
-        <td id="LC1520" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1521" class="blob-num js-line-number" data-line-number="1521"></td>
-        <td id="LC1521" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1522" class="blob-num js-line-number" data-line-number="1522"></td>
-        <td id="LC1522" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            2) unparsed XML describing the bucket&#39;s website configuration</span></td>
-      </tr>
-      <tr>
-        <td id="L1523" class="blob-num js-line-number" data-line-number="1523"></td>
-        <td id="LC1523" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1524" class="blob-num js-line-number" data-line-number="1524"></td>
-        <td id="LC1524" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1525" class="blob-num js-line-number" data-line-number="1525"></td>
-        <td id="LC1525" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1526" class="blob-num js-line-number" data-line-number="1526"></td>
-        <td id="LC1526" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_website_configuration_xml(<span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1527" class="blob-num js-line-number" data-line-number="1527"></td>
-        <td id="LC1527" class="blob-code blob-code-inner js-file-line">        e <span class="pl-k">=</span> boto.jsonresponse.Element()</td>
-      </tr>
-      <tr>
-        <td id="L1528" class="blob-num js-line-number" data-line-number="1528"></td>
-        <td id="LC1528" class="blob-code blob-code-inner js-file-line">        h <span class="pl-k">=</span> boto.jsonresponse.XmlHandler(e, <span class="pl-c1">None</span>)</td>
-      </tr>
-      <tr>
-        <td id="L1529" class="blob-num js-line-number" data-line-number="1529"></td>
-        <td id="LC1529" class="blob-code blob-code-inner js-file-line">        h.parse(body)</td>
-      </tr>
-      <tr>
-        <td id="L1530" class="blob-num js-line-number" data-line-number="1530"></td>
-        <td id="LC1530" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> e, body</td>
-      </tr>
-      <tr>
-        <td id="L1531" class="blob-num js-line-number" data-line-number="1531"></td>
-        <td id="LC1531" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1532" class="blob-num js-line-number" data-line-number="1532"></td>
-        <td id="LC1532" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_website_configuration_xml</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1533" class="blob-num js-line-number" data-line-number="1533"></td>
-        <td id="LC1533" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span>Get raw website configuration xml<span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1534" class="blob-num js-line-number" data-line-number="1534"></td>
-        <td id="LC1534" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1535" class="blob-num js-line-number" data-line-number="1535"></td>
-        <td id="LC1535" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>website<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1536" class="blob-num js-line-number" data-line-number="1536"></td>
-        <td id="LC1536" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read().decode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L1537" class="blob-num js-line-number" data-line-number="1537"></td>
-        <td id="LC1537" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
-      </tr>
-      <tr>
-        <td id="L1538" class="blob-num js-line-number" data-line-number="1538"></td>
-        <td id="LC1538" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1539" class="blob-num js-line-number" data-line-number="1539"></td>
-        <td id="LC1539" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1540" class="blob-num js-line-number" data-line-number="1540"></td>
-        <td id="LC1540" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1541" class="blob-num js-line-number" data-line-number="1541"></td>
-        <td id="LC1541" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1542" class="blob-num js-line-number" data-line-number="1542"></td>
-        <td id="LC1542" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> body</td>
-      </tr>
-      <tr>
-        <td id="L1543" class="blob-num js-line-number" data-line-number="1543"></td>
-        <td id="LC1543" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1544" class="blob-num js-line-number" data-line-number="1544"></td>
-        <td id="LC1544" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete_website_configuration</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1545" class="blob-num js-line-number" data-line-number="1545"></td>
-        <td id="LC1545" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1546" class="blob-num js-line-number" data-line-number="1546"></td>
-        <td id="LC1546" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Removes all website configuration from the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1547" class="blob-num js-line-number" data-line-number="1547"></td>
-        <td id="LC1547" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1548" class="blob-num js-line-number" data-line-number="1548"></td>
-        <td id="LC1548" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>DELETE<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1549" class="blob-num js-line-number" data-line-number="1549"></td>
-        <td id="LC1549" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>website<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1550" class="blob-num js-line-number" data-line-number="1550"></td>
-        <td id="LC1550" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1551" class="blob-num js-line-number" data-line-number="1551"></td>
-        <td id="LC1551" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
-      </tr>
-      <tr>
-        <td id="L1552" class="blob-num js-line-number" data-line-number="1552"></td>
-        <td id="LC1552" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">204</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1553" class="blob-num js-line-number" data-line-number="1553"></td>
-        <td id="LC1553" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
-      </tr>
-      <tr>
-        <td id="L1554" class="blob-num js-line-number" data-line-number="1554"></td>
-        <td id="LC1554" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1555" class="blob-num js-line-number" data-line-number="1555"></td>
-        <td id="LC1555" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1556" class="blob-num js-line-number" data-line-number="1556"></td>
-        <td id="LC1556" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1557" class="blob-num js-line-number" data-line-number="1557"></td>
-        <td id="LC1557" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1558" class="blob-num js-line-number" data-line-number="1558"></td>
-        <td id="LC1558" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_website_endpoint</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>):</td>
-      </tr>
-      <tr>
-        <td id="L1559" class="blob-num js-line-number" data-line-number="1559"></td>
-        <td id="LC1559" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1560" class="blob-num js-line-number" data-line-number="1560"></td>
-        <td id="LC1560" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the fully qualified hostname to use is you want to access this</span></td>
-      </tr>
-      <tr>
-        <td id="L1561" class="blob-num js-line-number" data-line-number="1561"></td>
-        <td id="LC1561" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        bucket as a website.  This doesn&#39;t validate whether the bucket has</span></td>
-      </tr>
-      <tr>
-        <td id="L1562" class="blob-num js-line-number" data-line-number="1562"></td>
-        <td id="LC1562" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        been correctly configured as a website or not.</span></td>
-      </tr>
-      <tr>
-        <td id="L1563" class="blob-num js-line-number" data-line-number="1563"></td>
-        <td id="LC1563" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1564" class="blob-num js-line-number" data-line-number="1564"></td>
-        <td id="LC1564" class="blob-code blob-code-inner js-file-line">        l <span class="pl-k">=</span> [<span class="pl-c1">self</span>.name]</td>
-      </tr>
-      <tr>
-        <td id="L1565" class="blob-num js-line-number" data-line-number="1565"></td>
-        <td id="LC1565" class="blob-code blob-code-inner js-file-line">        l.append(S3WebsiteEndpointTranslate.translate_region(<span class="pl-c1">self</span>.get_location()))</td>
-      </tr>
-      <tr>
-        <td id="L1566" class="blob-num js-line-number" data-line-number="1566"></td>
-        <td id="LC1566" class="blob-code blob-code-inner js-file-line">        l.append(<span class="pl-s"><span class="pl-pds">&#39;</span>.<span class="pl-pds">&#39;</span></span>.join(<span class="pl-c1">self</span>.connection.host.split(<span class="pl-s"><span class="pl-pds">&#39;</span>.<span class="pl-pds">&#39;</span></span>)[<span class="pl-k">-</span><span class="pl-c1">2</span>:]))</td>
-      </tr>
-      <tr>
-        <td id="L1567" class="blob-num js-line-number" data-line-number="1567"></td>
-        <td id="LC1567" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-s"><span class="pl-pds">&#39;</span>.<span class="pl-pds">&#39;</span></span>.join(l)</td>
-      </tr>
-      <tr>
-        <td id="L1568" class="blob-num js-line-number" data-line-number="1568"></td>
-        <td id="LC1568" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1569" class="blob-num js-line-number" data-line-number="1569"></td>
-        <td id="LC1569" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_policy</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1570" class="blob-num js-line-number" data-line-number="1570"></td>
-        <td id="LC1570" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1571" class="blob-num js-line-number" data-line-number="1571"></td>
-        <td id="LC1571" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the JSON policy associated with the bucket.  The policy</span></td>
-      </tr>
-      <tr>
-        <td id="L1572" class="blob-num js-line-number" data-line-number="1572"></td>
-        <td id="LC1572" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        is returned as an uninterpreted JSON string.</span></td>
-      </tr>
-      <tr>
-        <td id="L1573" class="blob-num js-line-number" data-line-number="1573"></td>
-        <td id="LC1573" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1574" class="blob-num js-line-number" data-line-number="1574"></td>
-        <td id="LC1574" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1575" class="blob-num js-line-number" data-line-number="1575"></td>
-        <td id="LC1575" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>policy<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1576" class="blob-num js-line-number" data-line-number="1576"></td>
-        <td id="LC1576" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1577" class="blob-num js-line-number" data-line-number="1577"></td>
-        <td id="LC1577" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1578" class="blob-num js-line-number" data-line-number="1578"></td>
-        <td id="LC1578" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> body</td>
-      </tr>
-      <tr>
-        <td id="L1579" class="blob-num js-line-number" data-line-number="1579"></td>
-        <td id="LC1579" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1580" class="blob-num js-line-number" data-line-number="1580"></td>
-        <td id="LC1580" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1581" class="blob-num js-line-number" data-line-number="1581"></td>
-        <td id="LC1581" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1582" class="blob-num js-line-number" data-line-number="1582"></td>
-        <td id="LC1582" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1583" class="blob-num js-line-number" data-line-number="1583"></td>
-        <td id="LC1583" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_policy</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">policy</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1584" class="blob-num js-line-number" data-line-number="1584"></td>
-        <td id="LC1584" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1585" class="blob-num js-line-number" data-line-number="1585"></td>
-        <td id="LC1585" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Add or replace the JSON policy associated with the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1586" class="blob-num js-line-number" data-line-number="1586"></td>
-        <td id="LC1586" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1587" class="blob-num js-line-number" data-line-number="1587"></td>
-        <td id="LC1587" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type policy: str</span></td>
-      </tr>
-      <tr>
-        <td id="L1588" class="blob-num js-line-number" data-line-number="1588"></td>
-        <td id="LC1588" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param policy: The JSON policy as a string.</span></td>
-      </tr>
-      <tr>
-        <td id="L1589" class="blob-num js-line-number" data-line-number="1589"></td>
-        <td id="LC1589" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1590" class="blob-num js-line-number" data-line-number="1590"></td>
-        <td id="LC1590" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1591" class="blob-num js-line-number" data-line-number="1591"></td>
-        <td id="LC1591" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">data</span><span class="pl-k">=</span>policy,</td>
-      </tr>
-      <tr>
-        <td id="L1592" class="blob-num js-line-number" data-line-number="1592"></td>
-        <td id="LC1592" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>policy<span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L1593" class="blob-num js-line-number" data-line-number="1593"></td>
-        <td id="LC1593" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1594" class="blob-num js-line-number" data-line-number="1594"></td>
-        <td id="LC1594" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1595" class="blob-num js-line-number" data-line-number="1595"></td>
-        <td id="LC1595" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">&gt;=</span> <span class="pl-c1">200</span> <span class="pl-k">and</span> response.status <span class="pl-k">&lt;=</span> <span class="pl-c1">204</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1596" class="blob-num js-line-number" data-line-number="1596"></td>
-        <td id="LC1596" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
-      </tr>
-      <tr>
-        <td id="L1597" class="blob-num js-line-number" data-line-number="1597"></td>
-        <td id="LC1597" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1598" class="blob-num js-line-number" data-line-number="1598"></td>
-        <td id="LC1598" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1599" class="blob-num js-line-number" data-line-number="1599"></td>
-        <td id="LC1599" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1600" class="blob-num js-line-number" data-line-number="1600"></td>
-        <td id="LC1600" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1601" class="blob-num js-line-number" data-line-number="1601"></td>
-        <td id="LC1601" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete_policy</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1602" class="blob-num js-line-number" data-line-number="1602"></td>
-        <td id="LC1602" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>DELETE<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1603" class="blob-num js-line-number" data-line-number="1603"></td>
-        <td id="LC1603" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">data</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>/?policy<span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L1604" class="blob-num js-line-number" data-line-number="1604"></td>
-        <td id="LC1604" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>policy<span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L1605" class="blob-num js-line-number" data-line-number="1605"></td>
-        <td id="LC1605" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1606" class="blob-num js-line-number" data-line-number="1606"></td>
-        <td id="LC1606" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1607" class="blob-num js-line-number" data-line-number="1607"></td>
-        <td id="LC1607" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">&gt;=</span> <span class="pl-c1">200</span> <span class="pl-k">and</span> response.status <span class="pl-k">&lt;=</span> <span class="pl-c1">204</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1608" class="blob-num js-line-number" data-line-number="1608"></td>
-        <td id="LC1608" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
-      </tr>
-      <tr>
-        <td id="L1609" class="blob-num js-line-number" data-line-number="1609"></td>
-        <td id="LC1609" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1610" class="blob-num js-line-number" data-line-number="1610"></td>
-        <td id="LC1610" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1611" class="blob-num js-line-number" data-line-number="1611"></td>
-        <td id="LC1611" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1612" class="blob-num js-line-number" data-line-number="1612"></td>
-        <td id="LC1612" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1613" class="blob-num js-line-number" data-line-number="1613"></td>
-        <td id="LC1613" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_cors_xml</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">cors_xml</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1614" class="blob-num js-line-number" data-line-number="1614"></td>
-        <td id="LC1614" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1615" class="blob-num js-line-number" data-line-number="1615"></td>
-        <td id="LC1615" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Set the CORS (Cross-Origin Resource Sharing) for a bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1616" class="blob-num js-line-number" data-line-number="1616"></td>
-        <td id="LC1616" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1617" class="blob-num js-line-number" data-line-number="1617"></td>
-        <td id="LC1617" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type cors_xml: str</span></td>
-      </tr>
-      <tr>
-        <td id="L1618" class="blob-num js-line-number" data-line-number="1618"></td>
-        <td id="LC1618" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param cors_xml: The XML document describing your desired</span></td>
-      </tr>
-      <tr>
-        <td id="L1619" class="blob-num js-line-number" data-line-number="1619"></td>
-        <td id="LC1619" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            CORS configuration.  See the S3 documentation for details</span></td>
-      </tr>
-      <tr>
-        <td id="L1620" class="blob-num js-line-number" data-line-number="1620"></td>
-        <td id="LC1620" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            of the exact syntax required.</span></td>
-      </tr>
-      <tr>
-        <td id="L1621" class="blob-num js-line-number" data-line-number="1621"></td>
-        <td id="LC1621" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1622" class="blob-num js-line-number" data-line-number="1622"></td>
-        <td id="LC1622" class="blob-code blob-code-inner js-file-line">        fp <span class="pl-k">=</span> StringIO(cors_xml)</td>
-      </tr>
-      <tr>
-        <td id="L1623" class="blob-num js-line-number" data-line-number="1623"></td>
-        <td id="LC1623" class="blob-code blob-code-inner js-file-line">        md5 <span class="pl-k">=</span> boto.utils.compute_md5(fp)</td>
-      </tr>
-      <tr>
-        <td id="L1624" class="blob-num js-line-number" data-line-number="1624"></td>
-        <td id="LC1624" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> headers <span class="pl-k">is</span> <span class="pl-c1">None</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1625" class="blob-num js-line-number" data-line-number="1625"></td>
-        <td id="LC1625" class="blob-code blob-code-inner js-file-line">            headers <span class="pl-k">=</span> {}</td>
-      </tr>
-      <tr>
-        <td id="L1626" class="blob-num js-line-number" data-line-number="1626"></td>
-        <td id="LC1626" class="blob-code blob-code-inner js-file-line">        headers[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-MD5<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> md5[<span class="pl-c1">1</span>]</td>
-      </tr>
-      <tr>
-        <td id="L1627" class="blob-num js-line-number" data-line-number="1627"></td>
-        <td id="LC1627" class="blob-code blob-code-inner js-file-line">        headers[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-Type<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>text/xml<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1628" class="blob-num js-line-number" data-line-number="1628"></td>
-        <td id="LC1628" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1629" class="blob-num js-line-number" data-line-number="1629"></td>
-        <td id="LC1629" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">data</span><span class="pl-k">=</span>fp.getvalue(),</td>
-      </tr>
-      <tr>
-        <td id="L1630" class="blob-num js-line-number" data-line-number="1630"></td>
-        <td id="LC1630" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>cors<span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L1631" class="blob-num js-line-number" data-line-number="1631"></td>
-        <td id="LC1631" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1632" class="blob-num js-line-number" data-line-number="1632"></td>
-        <td id="LC1632" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1633" class="blob-num js-line-number" data-line-number="1633"></td>
-        <td id="LC1633" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1634" class="blob-num js-line-number" data-line-number="1634"></td>
-        <td id="LC1634" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
-      </tr>
-      <tr>
-        <td id="L1635" class="blob-num js-line-number" data-line-number="1635"></td>
-        <td id="LC1635" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1636" class="blob-num js-line-number" data-line-number="1636"></td>
-        <td id="LC1636" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1637" class="blob-num js-line-number" data-line-number="1637"></td>
-        <td id="LC1637" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1638" class="blob-num js-line-number" data-line-number="1638"></td>
-        <td id="LC1638" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1639" class="blob-num js-line-number" data-line-number="1639"></td>
-        <td id="LC1639" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_cors</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">cors_config</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1640" class="blob-num js-line-number" data-line-number="1640"></td>
-        <td id="LC1640" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1641" class="blob-num js-line-number" data-line-number="1641"></td>
-        <td id="LC1641" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Set the CORS for this bucket given a boto CORSConfiguration</span></td>
-      </tr>
-      <tr>
-        <td id="L1642" class="blob-num js-line-number" data-line-number="1642"></td>
-        <td id="LC1642" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        object.</span></td>
-      </tr>
-      <tr>
-        <td id="L1643" class="blob-num js-line-number" data-line-number="1643"></td>
-        <td id="LC1643" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1644" class="blob-num js-line-number" data-line-number="1644"></td>
-        <td id="LC1644" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type cors_config: :class:`boto.s3.cors.CORSConfiguration`</span></td>
-      </tr>
-      <tr>
-        <td id="L1645" class="blob-num js-line-number" data-line-number="1645"></td>
-        <td id="LC1645" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param cors_config: The CORS configuration you want</span></td>
-      </tr>
-      <tr>
-        <td id="L1646" class="blob-num js-line-number" data-line-number="1646"></td>
-        <td id="LC1646" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            to configure for this bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1647" class="blob-num js-line-number" data-line-number="1647"></td>
-        <td id="LC1647" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1648" class="blob-num js-line-number" data-line-number="1648"></td>
-        <td id="LC1648" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.set_cors_xml(cors_config.to_xml())</td>
-      </tr>
-      <tr>
-        <td id="L1649" class="blob-num js-line-number" data-line-number="1649"></td>
-        <td id="LC1649" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1650" class="blob-num js-line-number" data-line-number="1650"></td>
-        <td id="LC1650" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_cors_xml</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1651" class="blob-num js-line-number" data-line-number="1651"></td>
-        <td id="LC1651" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1652" class="blob-num js-line-number" data-line-number="1652"></td>
-        <td id="LC1652" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the current CORS configuration on the bucket as an</span></td>
-      </tr>
-      <tr>
-        <td id="L1653" class="blob-num js-line-number" data-line-number="1653"></td>
-        <td id="LC1653" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        XML document.</span></td>
-      </tr>
-      <tr>
-        <td id="L1654" class="blob-num js-line-number" data-line-number="1654"></td>
-        <td id="LC1654" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1655" class="blob-num js-line-number" data-line-number="1655"></td>
-        <td id="LC1655" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1656" class="blob-num js-line-number" data-line-number="1656"></td>
-        <td id="LC1656" class="blob-code blob-code-inner js-file-line">                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>cors<span class="pl-pds">&#39;</span></span>, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1657" class="blob-num js-line-number" data-line-number="1657"></td>
-        <td id="LC1657" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1658" class="blob-num js-line-number" data-line-number="1658"></td>
-        <td id="LC1658" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
-      </tr>
-      <tr>
-        <td id="L1659" class="blob-num js-line-number" data-line-number="1659"></td>
-        <td id="LC1659" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1660" class="blob-num js-line-number" data-line-number="1660"></td>
-        <td id="LC1660" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> body</td>
-      </tr>
-      <tr>
-        <td id="L1661" class="blob-num js-line-number" data-line-number="1661"></td>
-        <td id="LC1661" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1662" class="blob-num js-line-number" data-line-number="1662"></td>
-        <td id="LC1662" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1663" class="blob-num js-line-number" data-line-number="1663"></td>
-        <td id="LC1663" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1664" class="blob-num js-line-number" data-line-number="1664"></td>
-        <td id="LC1664" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1665" class="blob-num js-line-number" data-line-number="1665"></td>
-        <td id="LC1665" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_cors</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1666" class="blob-num js-line-number" data-line-number="1666"></td>
-        <td id="LC1666" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1667" class="blob-num js-line-number" data-line-number="1667"></td>
-        <td id="LC1667" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Returns the current CORS configuration on the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1668" class="blob-num js-line-number" data-line-number="1668"></td>
-        <td id="LC1668" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1669" class="blob-num js-line-number" data-line-number="1669"></td>
-        <td id="LC1669" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :rtype: :class:`boto.s3.cors.CORSConfiguration`</span></td>
-      </tr>
-      <tr>
-        <td id="L1670" class="blob-num js-line-number" data-line-number="1670"></td>
-        <td id="LC1670" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :returns: A CORSConfiguration object that describes all current</span></td>
-      </tr>
-      <tr>
-        <td id="L1671" class="blob-num js-line-number" data-line-number="1671"></td>
-        <td id="LC1671" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            CORS rules in effect for the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1672" class="blob-num js-line-number" data-line-number="1672"></td>
-        <td id="LC1672" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1673" class="blob-num js-line-number" data-line-number="1673"></td>
-        <td id="LC1673" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_cors_xml(headers)</td>
-      </tr>
-      <tr>
-        <td id="L1674" class="blob-num js-line-number" data-line-number="1674"></td>
-        <td id="LC1674" class="blob-code blob-code-inner js-file-line">        cors <span class="pl-k">=</span> CORSConfiguration()</td>
-      </tr>
-      <tr>
-        <td id="L1675" class="blob-num js-line-number" data-line-number="1675"></td>
-        <td id="LC1675" class="blob-code blob-code-inner js-file-line">        h <span class="pl-k">=</span> handler.XmlHandler(cors, <span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L1676" class="blob-num js-line-number" data-line-number="1676"></td>
-        <td id="LC1676" class="blob-code blob-code-inner js-file-line">        xml.sax.parseString(body, h)</td>
-      </tr>
-      <tr>
-        <td id="L1677" class="blob-num js-line-number" data-line-number="1677"></td>
-        <td id="LC1677" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> cors</td>
-      </tr>
-      <tr>
-        <td id="L1678" class="blob-num js-line-number" data-line-number="1678"></td>
-        <td id="LC1678" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1679" class="blob-num js-line-number" data-line-number="1679"></td>
-        <td id="LC1679" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete_cors</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1680" class="blob-num js-line-number" data-line-number="1680"></td>
-        <td id="LC1680" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1681" class="blob-num js-line-number" data-line-number="1681"></td>
-        <td id="LC1681" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Removes all CORS configuration from the bucket.</span></td>
-      </tr>
-      <tr>
-        <td id="L1682" class="blob-num js-line-number" data-line-number="1682"></td>
-        <td id="LC1682" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1683" class="blob-num js-line-number" data-line-number="1683"></td>
-        <td id="LC1683" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>DELETE<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1684" class="blob-num js-line-number" data-line-number="1684"></td>
-        <td id="LC1684" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>cors<span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L1685" class="blob-num js-line-number" data-line-number="1685"></td>
-        <td id="LC1685" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1686" class="blob-num js-line-number" data-line-number="1686"></td>
-        <td id="LC1686" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1687" class="blob-num js-line-number" data-line-number="1687"></td>
-        <td id="LC1687" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
-      </tr>
-      <tr>
-        <td id="L1688" class="blob-num js-line-number" data-line-number="1688"></td>
-        <td id="LC1688" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">204</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1689" class="blob-num js-line-number" data-line-number="1689"></td>
-        <td id="LC1689" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
-      </tr>
-      <tr>
-        <td id="L1690" class="blob-num js-line-number" data-line-number="1690"></td>
-        <td id="LC1690" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1691" class="blob-num js-line-number" data-line-number="1691"></td>
-        <td id="LC1691" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1692" class="blob-num js-line-number" data-line-number="1692"></td>
-        <td id="LC1692" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1693" class="blob-num js-line-number" data-line-number="1693"></td>
-        <td id="LC1693" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1694" class="blob-num js-line-number" data-line-number="1694"></td>
-        <td id="LC1694" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">initiate_multipart_upload</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>,</td>
-      </tr>
-      <tr>
-        <td id="L1695" class="blob-num js-line-number" data-line-number="1695"></td>
-        <td id="LC1695" class="blob-code blob-code-inner js-file-line">                                  <span class="pl-smi">reduced_redundancy</span><span class="pl-k">=</span><span class="pl-c1">False</span>,</td>
-      </tr>
-      <tr>
-        <td id="L1696" class="blob-num js-line-number" data-line-number="1696"></td>
-        <td id="LC1696" class="blob-code blob-code-inner js-file-line">                                  <span class="pl-smi">metadata</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">encrypt_key</span><span class="pl-k">=</span><span class="pl-c1">False</span>,</td>
-      </tr>
-      <tr>
-        <td id="L1697" class="blob-num js-line-number" data-line-number="1697"></td>
-        <td id="LC1697" class="blob-code blob-code-inner js-file-line">                                  <span class="pl-smi">policy</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1698" class="blob-num js-line-number" data-line-number="1698"></td>
-        <td id="LC1698" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1699" class="blob-num js-line-number" data-line-number="1699"></td>
-        <td id="LC1699" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Start a multipart upload operation.</span></td>
-      </tr>
-      <tr>
-        <td id="L1700" class="blob-num js-line-number" data-line-number="1700"></td>
-        <td id="LC1700" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1701" class="blob-num js-line-number" data-line-number="1701"></td>
-        <td id="LC1701" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        .. note::</span></td>
-      </tr>
-      <tr>
-        <td id="L1702" class="blob-num js-line-number" data-line-number="1702"></td>
-        <td id="LC1702" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1703" class="blob-num js-line-number" data-line-number="1703"></td>
-        <td id="LC1703" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            Note: After you initiate multipart upload and upload one or more</span></td>
-      </tr>
-      <tr>
-        <td id="L1704" class="blob-num js-line-number" data-line-number="1704"></td>
-        <td id="LC1704" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            parts, you must either complete or abort multipart upload in order</span></td>
-      </tr>
-      <tr>
-        <td id="L1705" class="blob-num js-line-number" data-line-number="1705"></td>
-        <td id="LC1705" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            to stop getting charged for storage of the uploaded parts. Only</span></td>
-      </tr>
-      <tr>
-        <td id="L1706" class="blob-num js-line-number" data-line-number="1706"></td>
-        <td id="LC1706" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            after you either complete or abort multipart upload, Amazon S3</span></td>
-      </tr>
-      <tr>
-        <td id="L1707" class="blob-num js-line-number" data-line-number="1707"></td>
-        <td id="LC1707" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            frees up the parts storage and stops charging you for the parts</span></td>
-      </tr>
-      <tr>
-        <td id="L1708" class="blob-num js-line-number" data-line-number="1708"></td>
-        <td id="LC1708" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            storage.</span></td>
-      </tr>
-      <tr>
-        <td id="L1709" class="blob-num js-line-number" data-line-number="1709"></td>
-        <td id="LC1709" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1710" class="blob-num js-line-number" data-line-number="1710"></td>
-        <td id="LC1710" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type key_name: string</span></td>
-      </tr>
-      <tr>
-        <td id="L1711" class="blob-num js-line-number" data-line-number="1711"></td>
-        <td id="LC1711" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param key_name: The name of the key that will ultimately</span></td>
-      </tr>
-      <tr>
-        <td id="L1712" class="blob-num js-line-number" data-line-number="1712"></td>
-        <td id="LC1712" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            result from this multipart upload operation.  This will be</span></td>
-      </tr>
-      <tr>
-        <td id="L1713" class="blob-num js-line-number" data-line-number="1713"></td>
-        <td id="LC1713" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            exactly as the key appears in the bucket after the upload</span></td>
-      </tr>
-      <tr>
-        <td id="L1714" class="blob-num js-line-number" data-line-number="1714"></td>
-        <td id="LC1714" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            process has been completed.</span></td>
-      </tr>
-      <tr>
-        <td id="L1715" class="blob-num js-line-number" data-line-number="1715"></td>
-        <td id="LC1715" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1716" class="blob-num js-line-number" data-line-number="1716"></td>
-        <td id="LC1716" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type headers: dict</span></td>
-      </tr>
-      <tr>
-        <td id="L1717" class="blob-num js-line-number" data-line-number="1717"></td>
-        <td id="LC1717" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param headers: Additional HTTP headers to send and store with the</span></td>
-      </tr>
-      <tr>
-        <td id="L1718" class="blob-num js-line-number" data-line-number="1718"></td>
-        <td id="LC1718" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            resulting key in S3.</span></td>
-      </tr>
-      <tr>
-        <td id="L1719" class="blob-num js-line-number" data-line-number="1719"></td>
-        <td id="LC1719" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1720" class="blob-num js-line-number" data-line-number="1720"></td>
-        <td id="LC1720" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type reduced_redundancy: boolean</span></td>
-      </tr>
-      <tr>
-        <td id="L1721" class="blob-num js-line-number" data-line-number="1721"></td>
-        <td id="LC1721" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param reduced_redundancy: In multipart uploads, the storage</span></td>
-      </tr>
-      <tr>
-        <td id="L1722" class="blob-num js-line-number" data-line-number="1722"></td>
-        <td id="LC1722" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            class is specified when initiating the upload, not when</span></td>
-      </tr>
-      <tr>
-        <td id="L1723" class="blob-num js-line-number" data-line-number="1723"></td>
-        <td id="LC1723" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            uploading individual parts.  So if you want the resulting</span></td>
-      </tr>
-      <tr>
-        <td id="L1724" class="blob-num js-line-number" data-line-number="1724"></td>
-        <td id="LC1724" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            key to use the reduced redundancy storage class set this</span></td>
-      </tr>
-      <tr>
-        <td id="L1725" class="blob-num js-line-number" data-line-number="1725"></td>
-        <td id="LC1725" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            flag when you initiate the upload.</span></td>
-      </tr>
-      <tr>
-        <td id="L1726" class="blob-num js-line-number" data-line-number="1726"></td>
-        <td id="LC1726" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1727" class="blob-num js-line-number" data-line-number="1727"></td>
-        <td id="LC1727" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type metadata: dict</span></td>
-      </tr>
-      <tr>
-        <td id="L1728" class="blob-num js-line-number" data-line-number="1728"></td>
-        <td id="LC1728" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param metadata: Any metadata that you would like to set on the key</span></td>
-      </tr>
-      <tr>
-        <td id="L1729" class="blob-num js-line-number" data-line-number="1729"></td>
-        <td id="LC1729" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            that results from the multipart upload.</span></td>
-      </tr>
-      <tr>
-        <td id="L1730" class="blob-num js-line-number" data-line-number="1730"></td>
-        <td id="LC1730" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1731" class="blob-num js-line-number" data-line-number="1731"></td>
-        <td id="LC1731" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type encrypt_key: bool</span></td>
-      </tr>
-      <tr>
-        <td id="L1732" class="blob-num js-line-number" data-line-number="1732"></td>
-        <td id="LC1732" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param encrypt_key: If True, the new copy of the object will</span></td>
-      </tr>
-      <tr>
-        <td id="L1733" class="blob-num js-line-number" data-line-number="1733"></td>
-        <td id="LC1733" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            be encrypted on the server-side by S3 and will be stored</span></td>
-      </tr>
-      <tr>
-        <td id="L1734" class="blob-num js-line-number" data-line-number="1734"></td>
-        <td id="LC1734" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            in an encrypted form while at rest in S3.</span></td>
-      </tr>
-      <tr>
-        <td id="L1735" class="blob-num js-line-number" data-line-number="1735"></td>
-        <td id="LC1735" class="blob-code blob-code-inner js-file-line"><span class="pl-s"></span></td>
-      </tr>
-      <tr>
-        <td id="L1736" class="blob-num js-line-number" data-line-number="1736"></td>
-        <td id="LC1736" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :type policy: :class:`boto.s3.acl.CannedACLStrings`</span></td>
-      </tr>
-      <tr>
-        <td id="L1737" class="blob-num js-line-number" data-line-number="1737"></td>
-        <td id="LC1737" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        :param policy: A canned ACL policy that will be applied to the</span></td>
-      </tr>
-      <tr>
-        <td id="L1738" class="blob-num js-line-number" data-line-number="1738"></td>
-        <td id="LC1738" class="blob-code blob-code-inner js-file-line"><span class="pl-s">            new key (once completed) in S3.</span></td>
-      </tr>
-      <tr>
-        <td id="L1739" class="blob-num js-line-number" data-line-number="1739"></td>
-        <td id="LC1739" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1740" class="blob-num js-line-number" data-line-number="1740"></td>
-        <td id="LC1740" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>uploads<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1741" class="blob-num js-line-number" data-line-number="1741"></td>
-        <td id="LC1741" class="blob-code blob-code-inner js-file-line">        provider <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.provider</td>
-      </tr>
-      <tr>
-        <td id="L1742" class="blob-num js-line-number" data-line-number="1742"></td>
-        <td id="LC1742" class="blob-code blob-code-inner js-file-line">        headers <span class="pl-k">=</span> headers <span class="pl-k">or</span> {}</td>
-      </tr>
-      <tr>
-        <td id="L1743" class="blob-num js-line-number" data-line-number="1743"></td>
-        <td id="LC1743" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> policy:</td>
-      </tr>
-      <tr>
-        <td id="L1744" class="blob-num js-line-number" data-line-number="1744"></td>
-        <td id="LC1744" class="blob-code blob-code-inner js-file-line">            headers[provider.acl_header] <span class="pl-k">=</span> policy</td>
-      </tr>
-      <tr>
-        <td id="L1745" class="blob-num js-line-number" data-line-number="1745"></td>
-        <td id="LC1745" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> reduced_redundancy:</td>
-      </tr>
-      <tr>
-        <td id="L1746" class="blob-num js-line-number" data-line-number="1746"></td>
-        <td id="LC1746" class="blob-code blob-code-inner js-file-line">            storage_class_header <span class="pl-k">=</span> provider.storage_class_header</td>
-      </tr>
-      <tr>
-        <td id="L1747" class="blob-num js-line-number" data-line-number="1747"></td>
-        <td id="LC1747" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> storage_class_header:</td>
-      </tr>
-      <tr>
-        <td id="L1748" class="blob-num js-line-number" data-line-number="1748"></td>
-        <td id="LC1748" class="blob-code blob-code-inner js-file-line">                headers[storage_class_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>REDUCED_REDUNDANCY<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1749" class="blob-num js-line-number" data-line-number="1749"></td>
-        <td id="LC1749" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> <span class="pl-k">TODO</span>: what if the provider doesn&#39;t support reduced redundancy?</span></td>
-      </tr>
-      <tr>
-        <td id="L1750" class="blob-num js-line-number" data-line-number="1750"></td>
-        <td id="LC1750" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> (see boto.s3.key.Key.set_contents_from_file)</span></td>
-      </tr>
-      <tr>
-        <td id="L1751" class="blob-num js-line-number" data-line-number="1751"></td>
-        <td id="LC1751" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> encrypt_key:</td>
-      </tr>
-      <tr>
-        <td id="L1752" class="blob-num js-line-number" data-line-number="1752"></td>
-        <td id="LC1752" class="blob-code blob-code-inner js-file-line">            headers[provider.server_side_encryption_header] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>AES256<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1753" class="blob-num js-line-number" data-line-number="1753"></td>
-        <td id="LC1753" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> metadata <span class="pl-k">is</span> <span class="pl-c1">None</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1754" class="blob-num js-line-number" data-line-number="1754"></td>
-        <td id="LC1754" class="blob-code blob-code-inner js-file-line">            metadata <span class="pl-k">=</span> {}</td>
-      </tr>
-      <tr>
-        <td id="L1755" class="blob-num js-line-number" data-line-number="1755"></td>
-        <td id="LC1755" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1756" class="blob-num js-line-number" data-line-number="1756"></td>
-        <td id="LC1756" class="blob-code blob-code-inner js-file-line">        headers <span class="pl-k">=</span> boto.utils.merge_meta(headers, metadata,</td>
-      </tr>
-      <tr>
-        <td id="L1757" class="blob-num js-line-number" data-line-number="1757"></td>
-        <td id="LC1757" class="blob-code blob-code-inner js-file-line">                <span class="pl-c1">self</span>.connection.provider)</td>
-      </tr>
-      <tr>
-        <td id="L1758" class="blob-num js-line-number" data-line-number="1758"></td>
-        <td id="LC1758" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>POST<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
-      </tr>
-      <tr>
-        <td id="L1759" class="blob-num js-line-number" data-line-number="1759"></td>
-        <td id="LC1759" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
-      </tr>
-      <tr>
-        <td id="L1760" class="blob-num js-line-number" data-line-number="1760"></td>
-        <td id="LC1760" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1761" class="blob-num js-line-number" data-line-number="1761"></td>
-        <td id="LC1761" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1762" class="blob-num js-line-number" data-line-number="1762"></td>
-        <td id="LC1762" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
-      </tr>
-      <tr>
-        <td id="L1763" class="blob-num js-line-number" data-line-number="1763"></td>
-        <td id="LC1763" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1764" class="blob-num js-line-number" data-line-number="1764"></td>
-        <td id="LC1764" class="blob-code blob-code-inner js-file-line">            resp <span class="pl-k">=</span> MultiPartUpload(<span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L1765" class="blob-num js-line-number" data-line-number="1765"></td>
-        <td id="LC1765" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(resp, <span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L1766" class="blob-num js-line-number" data-line-number="1766"></td>
-        <td id="LC1766" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1767" class="blob-num js-line-number" data-line-number="1767"></td>
-        <td id="LC1767" class="blob-code blob-code-inner js-file-line">                body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L1768" class="blob-num js-line-number" data-line-number="1768"></td>
-        <td id="LC1768" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
-      </tr>
-      <tr>
-        <td id="L1769" class="blob-num js-line-number" data-line-number="1769"></td>
-        <td id="LC1769" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> resp</td>
-      </tr>
-      <tr>
-        <td id="L1770" class="blob-num js-line-number" data-line-number="1770"></td>
-        <td id="LC1770" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1771" class="blob-num js-line-number" data-line-number="1771"></td>
-        <td id="LC1771" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1772" class="blob-num js-line-number" data-line-number="1772"></td>
-        <td id="LC1772" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1773" class="blob-num js-line-number" data-line-number="1773"></td>
-        <td id="LC1773" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1774" class="blob-num js-line-number" data-line-number="1774"></td>
-        <td id="LC1774" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">complete_multipart_upload</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">upload_id</span>,</td>
-      </tr>
-      <tr>
-        <td id="L1775" class="blob-num js-line-number" data-line-number="1775"></td>
-        <td id="LC1775" class="blob-code blob-code-inner js-file-line">                                  <span class="pl-smi">xml_body</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1776" class="blob-num js-line-number" data-line-number="1776"></td>
-        <td id="LC1776" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1777" class="blob-num js-line-number" data-line-number="1777"></td>
-        <td id="LC1777" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        Complete a multipart upload operation.</span></td>
-      </tr>
-      <tr>
-        <td id="L1778" class="blob-num js-line-number" data-line-number="1778"></td>
-        <td id="LC1778" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1779" class="blob-num js-line-number" data-line-number="1779"></td>
-        <td id="LC1779" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>uploadId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> upload_id</td>
-      </tr>
-      <tr>
-        <td id="L1780" class="blob-num js-line-number" data-line-number="1780"></td>
-        <td id="LC1780" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> headers <span class="pl-k">is</span> <span class="pl-c1">None</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1781" class="blob-num js-line-number" data-line-number="1781"></td>
-        <td id="LC1781" class="blob-code blob-code-inner js-file-line">            headers <span class="pl-k">=</span> {}</td>
-      </tr>
-      <tr>
-        <td id="L1782" class="blob-num js-line-number" data-line-number="1782"></td>
-        <td id="LC1782" class="blob-code blob-code-inner js-file-line">        headers[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-Type<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>text/xml<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1783" class="blob-num js-line-number" data-line-number="1783"></td>
-        <td id="LC1783" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>POST<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
-      </tr>
-      <tr>
-        <td id="L1784" class="blob-num js-line-number" data-line-number="1784"></td>
-        <td id="LC1784" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
-      </tr>
-      <tr>
-        <td id="L1785" class="blob-num js-line-number" data-line-number="1785"></td>
-        <td id="LC1785" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers, <span class="pl-v">data</span><span class="pl-k">=</span>xml_body)</td>
-      </tr>
-      <tr>
-        <td id="L1786" class="blob-num js-line-number" data-line-number="1786"></td>
-        <td id="LC1786" class="blob-code blob-code-inner js-file-line">        contains_error <span class="pl-k">=</span> <span class="pl-c1">False</span></td>
-      </tr>
-      <tr>
-        <td id="L1787" class="blob-num js-line-number" data-line-number="1787"></td>
-        <td id="LC1787" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read().decode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L1788" class="blob-num js-line-number" data-line-number="1788"></td>
-        <td id="LC1788" class="blob-code blob-code-inner js-file-line">        <span class="pl-c"><span class="pl-c">#</span> Some errors will be reported in the body of the response</span></td>
-      </tr>
-      <tr>
-        <td id="L1789" class="blob-num js-line-number" data-line-number="1789"></td>
-        <td id="LC1789" class="blob-code blob-code-inner js-file-line">        <span class="pl-c"><span class="pl-c">#</span> even though the HTTP response code is 200.  This check</span></td>
-      </tr>
-      <tr>
-        <td id="L1790" class="blob-num js-line-number" data-line-number="1790"></td>
-        <td id="LC1790" class="blob-code blob-code-inner js-file-line">        <span class="pl-c"><span class="pl-c">#</span> does a quick and dirty peek in the body for an error element.</span></td>
-      </tr>
-      <tr>
-        <td id="L1791" class="blob-num js-line-number" data-line-number="1791"></td>
-        <td id="LC1791" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> body.find(<span class="pl-s"><span class="pl-pds">&#39;</span>&lt;Error&gt;<span class="pl-pds">&#39;</span></span>) <span class="pl-k">&gt;</span> <span class="pl-c1">0</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1792" class="blob-num js-line-number" data-line-number="1792"></td>
-        <td id="LC1792" class="blob-code blob-code-inner js-file-line">            contains_error <span class="pl-k">=</span> <span class="pl-c1">True</span></td>
-      </tr>
-      <tr>
-        <td id="L1793" class="blob-num js-line-number" data-line-number="1793"></td>
-        <td id="LC1793" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
-      </tr>
-      <tr>
-        <td id="L1794" class="blob-num js-line-number" data-line-number="1794"></td>
-        <td id="LC1794" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span> <span class="pl-k">and</span> <span class="pl-k">not</span> contains_error:</td>
-      </tr>
-      <tr>
-        <td id="L1795" class="blob-num js-line-number" data-line-number="1795"></td>
-        <td id="LC1795" class="blob-code blob-code-inner js-file-line">            resp <span class="pl-k">=</span> CompleteMultiPartUpload(<span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L1796" class="blob-num js-line-number" data-line-number="1796"></td>
-        <td id="LC1796" class="blob-code blob-code-inner js-file-line">            h <span class="pl-k">=</span> handler.XmlHandler(resp, <span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L1797" class="blob-num js-line-number" data-line-number="1797"></td>
-        <td id="LC1797" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(body, <span class="pl-c1">bytes</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1798" class="blob-num js-line-number" data-line-number="1798"></td>
-        <td id="LC1798" class="blob-code blob-code-inner js-file-line">                body <span class="pl-k">=</span> body.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L1799" class="blob-num js-line-number" data-line-number="1799"></td>
-        <td id="LC1799" class="blob-code blob-code-inner js-file-line">            xml.sax.parseString(body, h)</td>
-      </tr>
-      <tr>
-        <td id="L1800" class="blob-num js-line-number" data-line-number="1800"></td>
-        <td id="LC1800" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> Use a dummy key to parse various response headers</span></td>
-      </tr>
-      <tr>
-        <td id="L1801" class="blob-num js-line-number" data-line-number="1801"></td>
-        <td id="LC1801" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> for versioning, encryption info and then explicitly</span></td>
-      </tr>
-      <tr>
-        <td id="L1802" class="blob-num js-line-number" data-line-number="1802"></td>
-        <td id="LC1802" class="blob-code blob-code-inner js-file-line">            <span class="pl-c"><span class="pl-c">#</span> set the completed MPU object values from key.</span></td>
-      </tr>
-      <tr>
-        <td id="L1803" class="blob-num js-line-number" data-line-number="1803"></td>
-        <td id="LC1803" class="blob-code blob-code-inner js-file-line">            k <span class="pl-k">=</span> <span class="pl-c1">self</span>.key_class(<span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L1804" class="blob-num js-line-number" data-line-number="1804"></td>
-        <td id="LC1804" class="blob-code blob-code-inner js-file-line">            k.handle_version_headers(response)</td>
-      </tr>
-      <tr>
-        <td id="L1805" class="blob-num js-line-number" data-line-number="1805"></td>
-        <td id="LC1805" class="blob-code blob-code-inner js-file-line">            k.handle_encryption_headers(response)</td>
-      </tr>
-      <tr>
-        <td id="L1806" class="blob-num js-line-number" data-line-number="1806"></td>
-        <td id="LC1806" class="blob-code blob-code-inner js-file-line">            resp.version_id <span class="pl-k">=</span> k.version_id</td>
-      </tr>
-      <tr>
-        <td id="L1807" class="blob-num js-line-number" data-line-number="1807"></td>
-        <td id="LC1807" class="blob-code blob-code-inner js-file-line">            resp.encrypted <span class="pl-k">=</span> k.encrypted</td>
-      </tr>
-      <tr>
-        <td id="L1808" class="blob-num js-line-number" data-line-number="1808"></td>
-        <td id="LC1808" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> resp</td>
-      </tr>
-      <tr>
-        <td id="L1809" class="blob-num js-line-number" data-line-number="1809"></td>
-        <td id="LC1809" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1810" class="blob-num js-line-number" data-line-number="1810"></td>
-        <td id="LC1810" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1811" class="blob-num js-line-number" data-line-number="1811"></td>
-        <td id="LC1811" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1812" class="blob-num js-line-number" data-line-number="1812"></td>
-        <td id="LC1812" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1813" class="blob-num js-line-number" data-line-number="1813"></td>
-        <td id="LC1813" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">cancel_multipart_upload</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">key_name</span>, <span class="pl-smi">upload_id</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1814" class="blob-num js-line-number" data-line-number="1814"></td>
-        <td id="LC1814" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1815" class="blob-num js-line-number" data-line-number="1815"></td>
-        <td id="LC1815" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        To verify that all parts have been removed, so you don&#39;t get charged</span></td>
-      </tr>
-      <tr>
-        <td id="L1816" class="blob-num js-line-number" data-line-number="1816"></td>
-        <td id="LC1816" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        for the part storage, you should call the List Parts operation and</span></td>
-      </tr>
-      <tr>
-        <td id="L1817" class="blob-num js-line-number" data-line-number="1817"></td>
-        <td id="LC1817" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        ensure the parts list is empty.</span></td>
-      </tr>
-      <tr>
-        <td id="L1818" class="blob-num js-line-number" data-line-number="1818"></td>
-        <td id="LC1818" class="blob-code blob-code-inner js-file-line"><span class="pl-s">        <span class="pl-pds">&quot;&quot;&quot;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1819" class="blob-num js-line-number" data-line-number="1819"></td>
-        <td id="LC1819" class="blob-code blob-code-inner js-file-line">        query_args <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>uploadId=<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> upload_id</td>
-      </tr>
-      <tr>
-        <td id="L1820" class="blob-num js-line-number" data-line-number="1820"></td>
-        <td id="LC1820" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>DELETE<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name, key_name,</td>
-      </tr>
-      <tr>
-        <td id="L1821" class="blob-num js-line-number" data-line-number="1821"></td>
-        <td id="LC1821" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
-      </tr>
-      <tr>
-        <td id="L1822" class="blob-num js-line-number" data-line-number="1822"></td>
-        <td id="LC1822" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1823" class="blob-num js-line-number" data-line-number="1823"></td>
-        <td id="LC1823" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1824" class="blob-num js-line-number" data-line-number="1824"></td>
-        <td id="LC1824" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
-      </tr>
-      <tr>
-        <td id="L1825" class="blob-num js-line-number" data-line-number="1825"></td>
-        <td id="LC1825" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">204</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1826" class="blob-num js-line-number" data-line-number="1826"></td>
-        <td id="LC1826" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1827" class="blob-num js-line-number" data-line-number="1827"></td>
-        <td id="LC1827" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1828" class="blob-num js-line-number" data-line-number="1828"></td>
-        <td id="LC1828" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1829" class="blob-num js-line-number" data-line-number="1829"></td>
-        <td id="LC1829" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1830" class="blob-num js-line-number" data-line-number="1830"></td>
-        <td id="LC1830" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.connection.delete_bucket(<span class="pl-c1">self</span>.name, <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1831" class="blob-num js-line-number" data-line-number="1831"></td>
-        <td id="LC1831" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1832" class="blob-num js-line-number" data-line-number="1832"></td>
-        <td id="LC1832" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_tags</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1833" class="blob-num js-line-number" data-line-number="1833"></td>
-        <td id="LC1833" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.get_xml_tags(headers)</td>
-      </tr>
-      <tr>
-        <td id="L1834" class="blob-num js-line-number" data-line-number="1834"></td>
-        <td id="LC1834" class="blob-code blob-code-inner js-file-line">        tags <span class="pl-k">=</span> Tags()</td>
-      </tr>
-      <tr>
-        <td id="L1835" class="blob-num js-line-number" data-line-number="1835"></td>
-        <td id="LC1835" class="blob-code blob-code-inner js-file-line">        h <span class="pl-k">=</span> handler.XmlHandler(tags, <span class="pl-c1">self</span>)</td>
-      </tr>
-      <tr>
-        <td id="L1836" class="blob-num js-line-number" data-line-number="1836"></td>
-        <td id="LC1836" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(response, <span class="pl-c1">bytes</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1837" class="blob-num js-line-number" data-line-number="1837"></td>
-        <td id="LC1837" class="blob-code blob-code-inner js-file-line">            response <span class="pl-k">=</span> response.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L1838" class="blob-num js-line-number" data-line-number="1838"></td>
-        <td id="LC1838" class="blob-code blob-code-inner js-file-line">        xml.sax.parseString(response, h)</td>
-      </tr>
-      <tr>
-        <td id="L1839" class="blob-num js-line-number" data-line-number="1839"></td>
-        <td id="LC1839" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> tags</td>
-      </tr>
-      <tr>
-        <td id="L1840" class="blob-num js-line-number" data-line-number="1840"></td>
-        <td id="LC1840" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1841" class="blob-num js-line-number" data-line-number="1841"></td>
-        <td id="LC1841" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">get_xml_tags</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1842" class="blob-num js-line-number" data-line-number="1842"></td>
-        <td id="LC1842" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>GET<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1843" class="blob-num js-line-number" data-line-number="1843"></td>
-        <td id="LC1843" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>tagging<span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L1844" class="blob-num js-line-number" data-line-number="1844"></td>
-        <td id="LC1844" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1845" class="blob-num js-line-number" data-line-number="1845"></td>
-        <td id="LC1845" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1846" class="blob-num js-line-number" data-line-number="1846"></td>
-        <td id="LC1846" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">200</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1847" class="blob-num js-line-number" data-line-number="1847"></td>
-        <td id="LC1847" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> body</td>
-      </tr>
-      <tr>
-        <td id="L1848" class="blob-num js-line-number" data-line-number="1848"></td>
-        <td id="LC1848" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1849" class="blob-num js-line-number" data-line-number="1849"></td>
-        <td id="LC1849" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1850" class="blob-num js-line-number" data-line-number="1850"></td>
-        <td id="LC1850" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1851" class="blob-num js-line-number" data-line-number="1851"></td>
-        <td id="LC1851" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1852" class="blob-num js-line-number" data-line-number="1852"></td>
-        <td id="LC1852" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_xml_tags</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">tag_str</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>, <span class="pl-smi">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>tagging<span class="pl-pds">&#39;</span></span>):</td>
-      </tr>
-      <tr>
-        <td id="L1853" class="blob-num js-line-number" data-line-number="1853"></td>
-        <td id="LC1853" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> headers <span class="pl-k">is</span> <span class="pl-c1">None</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1854" class="blob-num js-line-number" data-line-number="1854"></td>
-        <td id="LC1854" class="blob-code blob-code-inner js-file-line">            headers <span class="pl-k">=</span> {}</td>
-      </tr>
-      <tr>
-        <td id="L1855" class="blob-num js-line-number" data-line-number="1855"></td>
-        <td id="LC1855" class="blob-code blob-code-inner js-file-line">        md5 <span class="pl-k">=</span> boto.utils.compute_md5(StringIO(tag_str))</td>
-      </tr>
-      <tr>
-        <td id="L1856" class="blob-num js-line-number" data-line-number="1856"></td>
-        <td id="LC1856" class="blob-code blob-code-inner js-file-line">        headers[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-MD5<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> md5[<span class="pl-c1">1</span>]</td>
-      </tr>
-      <tr>
-        <td id="L1857" class="blob-num js-line-number" data-line-number="1857"></td>
-        <td id="LC1857" class="blob-code blob-code-inner js-file-line">        headers[<span class="pl-s"><span class="pl-pds">&#39;</span>Content-Type<span class="pl-pds">&#39;</span></span>] <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>text/xml<span class="pl-pds">&#39;</span></span></td>
-      </tr>
-      <tr>
-        <td id="L1858" class="blob-num js-line-number" data-line-number="1858"></td>
-        <td id="LC1858" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> <span class="pl-k">not</span> <span class="pl-c1">isinstance</span>(tag_str, <span class="pl-c1">bytes</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1859" class="blob-num js-line-number" data-line-number="1859"></td>
-        <td id="LC1859" class="blob-code blob-code-inner js-file-line">            tag_str <span class="pl-k">=</span> tag_str.encode(<span class="pl-s"><span class="pl-pds">&#39;</span>utf-8<span class="pl-pds">&#39;</span></span>)</td>
-      </tr>
-      <tr>
-        <td id="L1860" class="blob-num js-line-number" data-line-number="1860"></td>
-        <td id="LC1860" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>PUT<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1861" class="blob-num js-line-number" data-line-number="1861"></td>
-        <td id="LC1861" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">data</span><span class="pl-k">=</span>tag_str,</td>
-      </tr>
-      <tr>
-        <td id="L1862" class="blob-num js-line-number" data-line-number="1862"></td>
-        <td id="LC1862" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span>query_args,</td>
-      </tr>
-      <tr>
-        <td id="L1863" class="blob-num js-line-number" data-line-number="1863"></td>
-        <td id="LC1863" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1864" class="blob-num js-line-number" data-line-number="1864"></td>
-        <td id="LC1864" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1865" class="blob-num js-line-number" data-line-number="1865"></td>
-        <td id="LC1865" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">!=</span> <span class="pl-c1">204</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1866" class="blob-num js-line-number" data-line-number="1866"></td>
-        <td id="LC1866" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1867" class="blob-num js-line-number" data-line-number="1867"></td>
-        <td id="LC1867" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-      <tr>
-        <td id="L1868" class="blob-num js-line-number" data-line-number="1868"></td>
-        <td id="LC1868" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
-      </tr>
-      <tr>
-        <td id="L1869" class="blob-num js-line-number" data-line-number="1869"></td>
-        <td id="LC1869" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1870" class="blob-num js-line-number" data-line-number="1870"></td>
-        <td id="LC1870" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">set_tags</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">tags</span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1871" class="blob-num js-line-number" data-line-number="1871"></td>
-        <td id="LC1871" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">return</span> <span class="pl-c1">self</span>.set_xml_tags(tags.to_xml(), <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1872" class="blob-num js-line-number" data-line-number="1872"></td>
-        <td id="LC1872" class="blob-code blob-code-inner js-file-line">
-</td>
-      </tr>
-      <tr>
-        <td id="L1873" class="blob-num js-line-number" data-line-number="1873"></td>
-        <td id="LC1873" class="blob-code blob-code-inner js-file-line">    <span class="pl-k">def</span> <span class="pl-en">delete_tags</span>(<span class="pl-smi"><span class="pl-smi">self</span></span>, <span class="pl-smi">headers</span><span class="pl-k">=</span><span class="pl-c1">None</span>):</td>
-      </tr>
-      <tr>
-        <td id="L1874" class="blob-num js-line-number" data-line-number="1874"></td>
-        <td id="LC1874" class="blob-code blob-code-inner js-file-line">        response <span class="pl-k">=</span> <span class="pl-c1">self</span>.connection.make_request(<span class="pl-s"><span class="pl-pds">&#39;</span>DELETE<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">self</span>.name,</td>
-      </tr>
-      <tr>
-        <td id="L1875" class="blob-num js-line-number" data-line-number="1875"></td>
-        <td id="LC1875" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">query_args</span><span class="pl-k">=</span><span class="pl-s"><span class="pl-pds">&#39;</span>tagging<span class="pl-pds">&#39;</span></span>,</td>
-      </tr>
-      <tr>
-        <td id="L1876" class="blob-num js-line-number" data-line-number="1876"></td>
-        <td id="LC1876" class="blob-code blob-code-inner js-file-line">                                                <span class="pl-v">headers</span><span class="pl-k">=</span>headers)</td>
-      </tr>
-      <tr>
-        <td id="L1877" class="blob-num js-line-number" data-line-number="1877"></td>
-        <td id="LC1877" class="blob-code blob-code-inner js-file-line">        body <span class="pl-k">=</span> response.read()</td>
-      </tr>
-      <tr>
-        <td id="L1878" class="blob-num js-line-number" data-line-number="1878"></td>
-        <td id="LC1878" class="blob-code blob-code-inner js-file-line">        boto.log.debug(body)</td>
-      </tr>
-      <tr>
-        <td id="L1879" class="blob-num js-line-number" data-line-number="1879"></td>
-        <td id="LC1879" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">if</span> response.status <span class="pl-k">==</span> <span class="pl-c1">204</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1880" class="blob-num js-line-number" data-line-number="1880"></td>
-        <td id="LC1880" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">return</span> <span class="pl-c1">True</span></td>
-      </tr>
-      <tr>
-        <td id="L1881" class="blob-num js-line-number" data-line-number="1881"></td>
-        <td id="LC1881" class="blob-code blob-code-inner js-file-line">        <span class="pl-k">else</span>:</td>
-      </tr>
-      <tr>
-        <td id="L1882" class="blob-num js-line-number" data-line-number="1882"></td>
-        <td id="LC1882" class="blob-code blob-code-inner js-file-line">            <span class="pl-k">raise</span> <span class="pl-c1">self</span>.connection.provider.storage_response_error(</td>
-      </tr>
-      <tr>
-        <td id="L1883" class="blob-num js-line-number" data-line-number="1883"></td>
-        <td id="LC1883" class="blob-code blob-code-inner js-file-line">                response.status, response.reason, body)</td>
-      </tr>
-</table>
-
-  <details class="details-reset details-overlay BlobToolbar position-absolute js-file-line-actions dropdown d-none" aria-hidden="true">
-    <summary class="btn-octicon ml-0 px-2 p-0 bg-white border border-gray-dark rounded-1" aria-label="Inline file action toolbar">
-      <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/></svg>
-    </summary>
-    <details-menu>
-      <ul class="BlobToolbar-dropdown dropdown-menu dropdown-menu-se mt-2" style="width:185px">
-        <li><clipboard-copy role="menuitem" class="dropdown-item" id="js-copy-lines" style="cursor:pointer;" data-original-text="Copy lines">Copy lines</clipboard-copy></li>
-        <li><clipboard-copy role="menuitem" class="dropdown-item" id="js-copy-permalink" style="cursor:pointer;" data-original-text="Copy permalink">Copy permalink</clipboard-copy></li>
-        <li><a class="dropdown-item js-update-url-with-hash" id="js-view-git-blame" role="menuitem" href="/boto/boto/blame/603d3ce3f3f3ee9ecf452772814a7231f9ef81e3/boto/s3/bucket.py">View git blame</a></li>
-          <li><a class="dropdown-item" id="js-new-issue" role="menuitem" href="/boto/boto/issues/new">Reference in new issue</a></li>
-      </ul>
-    </details-menu>
-  </details>
-
-  </div>
-
-    </div>
-
-  
-
-  <details class="details-reset details-overlay details-overlay-dark">
-    <summary data-hotkey="l" aria-label="Jump to line"></summary>
-    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast linejump" aria-label="Jump to line">
-      <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-jump-to-line-form Box-body d-flex" action="" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
-        <input class="form-control flex-auto mr-3 linejump-input js-jump-to-line-field" type="text" placeholder="Jump to line&hellip;" aria-label="Jump to line" autofocus>
-        <button type="submit" class="btn" data-close-dialog>Go</button>
-</form>    </details-dialog>
-  </details>
-
-
-
-  </div>
-  <div class="modal-backdrop js-touch-events"></div>
-</div>
-
-    </main>
-  </div>
-  
-
-  </div>
-
-        
-<div class="footer container-lg width-full px-3" role="contentinfo">
-  <div class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light ">
-    <ul class="list-style-none d-flex flex-wrap ">
-      <li class="mr-3">&copy; 2019 <span title="0.20016s from unicorn-6fd48d577-fmjln">GitHub</span>, Inc.</li>
-        <li class="mr-3"><a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms">Terms</a></li>
-        <li class="mr-3"><a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy">Privacy</a></li>
-        <li class="mr-3"><a data-ga-click="Footer, go to security, text:security" href="https://github.com/security">Security</a></li>
-        <li class="mr-3"><a href="https://githubstatus.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
-        <li><a data-ga-click="Footer, go to help, text:help" href="https://help.github.com">Help</a></li>
-    </ul>
-
-    <a aria-label="Homepage" title="GitHub" class="footer-octicon mx-lg-4" href="https://github.com">
-      <svg height="24" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
-</a>
-   <ul class="list-style-none d-flex flex-wrap ">
-        <li class="mr-3"><a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact">Contact GitHub</a></li>
-        <li class="mr-3"><a href="https://github.com/pricing" data-ga-click="Footer, go to Pricing, text:Pricing">Pricing</a></li>
-      <li class="mr-3"><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
-      <li class="mr-3"><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
-        <li class="mr-3"><a href="https://github.blog" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
-        <li><a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a></li>
-
-    </ul>
-  </div>
-  <div class="d-flex flex-justify-center pb-6">
-    <span class="f6 text-gray-light"></span>
-  </div>
-</div>
-
-
-
-  <div id="ajax-error-message" class="ajax-error-message flash flash-error">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>
-    <button type="button" class="flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
-      <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
-    </button>
-    You can’t perform that action at this time.
-  </div>
-
-
-    <script crossorigin="anonymous" integrity="sha512-jFuNBkwlIX73xJbI2nTCs01W/xjwP+Ccc0gEdkD4d/tQBv4xIZx4dZLnkYhzawWhnxjJbvkHsxSXQffNs0Ce4Q==" type="application/javascript" src="https://github.githubassets.com/assets/compat-bootstrap-8102d067.js"></script>
-    <script crossorigin="anonymous" integrity="sha512-HjenL0te0b2HT4WuEaue96gj0ht0TK52tVMNn4UDKQUIzoS8xbMBkyLnLudpSjJTb9sQUx6NZyVnwtb+d7zZjA==" type="application/javascript" src="https://github.githubassets.com/assets/frameworks-440b8182.js"></script>
-    
-    <script crossorigin="anonymous" async="async" integrity="sha512-VGEzKV4XNZ4Y48OsUH9YpmW7epTsL5aOvJGwrISO+G5jW7CxCsiUX6PzFS5AIf02bGVBUuHCMMWNGDqpssrX4g==" type="application/javascript" src="https://github.githubassets.com/assets/github-bootstrap-827e2f91.js"></script>
-    
-    
-    
-  <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner" hidden
-    >
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>
-    <span class="signed-in-tab-flash">You signed in with another tab or window. <a href="">Reload</a> to refresh your session.</span>
-    <span class="signed-out-tab-flash">You signed out in another tab or window. <a href="">Reload</a> to refresh your session.</span>
-  </div>
-  <template id="site-details-dialog">
-  <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark" open>
-    <summary aria-haspopup="dialog" aria-label="Close dialog"></summary>
-    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast">
-      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
-        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
-      </button>
-      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
-    </details-dialog>
-  </details>
-</template>
-
-  <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
-  <div class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large" style="width:360px;">
-  </div>
-</div>
-
-  <div aria-live="polite" class="js-global-screen-reader-notice sr-only"></div>
-
-  </body>
-</html>
-
+# Copyright (c) 2006-2010 Mitch Garnaat http://garnaat.org/
+# Copyright (c) 2010, Eucalyptus Systems, Inc.
+# All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+from __future__ import division
+
+import boto
+from boto import handler
+from boto.resultset import ResultSet
+from boto.exception import BotoClientError
+from boto.s3.acl import Policy, CannedACLStrings, Grant
+from boto.s3.key import Key
+from boto.s3.prefix import Prefix
+from boto.s3.deletemarker import DeleteMarker
+from boto.s3.multipart import MultiPartUpload
+from boto.s3.multipart import CompleteMultiPartUpload
+from boto.s3.multidelete import MultiDeleteResult
+from boto.s3.multidelete import Error
+from boto.s3.bucketlistresultset import BucketListResultSet
+from boto.s3.bucketlistresultset import VersionedBucketListResultSet
+from boto.s3.bucketlistresultset import MultiPartUploadListResultSet
+from boto.s3.lifecycle import Lifecycle
+from boto.s3.tagging import Tags
+from boto.s3.cors import CORSConfiguration
+from boto.s3.bucketlogging import BucketLogging
+from boto.s3 import website
+import boto.jsonresponse
+import boto.utils
+import xml.sax
+import xml.sax.saxutils
+import re
+import base64
+from collections import defaultdict
+from boto.compat import BytesIO, six, StringIO, urllib
+
+# as per http://goo.gl/BDuud (02/19/2011)
+
+
+class S3WebsiteEndpointTranslate(object):
+
+    trans_region = defaultdict(lambda: 's3-website-us-east-1')
+    trans_region['eu-west-1'] = 's3-website-eu-west-1'
+    trans_region['eu-central-1'] = 's3-website.eu-central-1'
+    trans_region['us-west-1'] = 's3-website-us-west-1'
+    trans_region['us-west-2'] = 's3-website-us-west-2'
+    trans_region['sa-east-1'] = 's3-website-sa-east-1'
+    trans_region['ap-northeast-1'] = 's3-website-ap-northeast-1'
+    trans_region['ap-southeast-1'] = 's3-website-ap-southeast-1'
+    trans_region['ap-southeast-2'] = 's3-website-ap-southeast-2'
+    trans_region['cn-north-1'] = 's3-website.cn-north-1'
+
+    @classmethod
+    def translate_region(self, reg):
+        return self.trans_region[reg]
+
+S3Permissions = ['READ', 'WRITE', 'READ_ACP', 'WRITE_ACP', 'FULL_CONTROL']
+
+
+class Bucket(object):
+
+    LoggingGroup = 'http://acs.amazonaws.com/groups/s3/LogDelivery'
+
+    BucketPaymentBody = """<?xml version="1.0" encoding="UTF-8"?>
+       <RequestPaymentConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+         <Payer>%s</Payer>
+       </RequestPaymentConfiguration>"""
+
+    VersioningBody = """<?xml version="1.0" encoding="UTF-8"?>
+       <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+         <Status>%s</Status>
+         <MfaDelete>%s</MfaDelete>
+       </VersioningConfiguration>"""
+
+    VersionRE = '<Status>([A-Za-z]+)</Status>'
+    MFADeleteRE = '<MfaDelete>([A-Za-z]+)</MfaDelete>'
+
+    def __init__(self, connection=None, name=None, key_class=Key):
+        self.name = name
+        self.connection = connection
+        self.key_class = key_class
+
+    def __repr__(self):
+        return '<Bucket: %s>' % self.name
+
+    def __iter__(self):
+        return iter(BucketListResultSet(self))
+
+    def __contains__(self, key_name):
+        return not (self.get_key(key_name) is None)
+
+    def startElement(self, name, attrs, connection):
+        return None
+
+    def endElement(self, name, value, connection):
+        if name == 'Name':
+            self.name = value
+        elif name == 'CreationDate':
+            self.creation_date = value
+        else:
+            setattr(self, name, value)
+
+    def set_key_class(self, key_class):
+        """
+        Set the Key class associated with this bucket.  By default, this
+        would be the boto.s3.key.Key class but if you want to subclass that
+        for some reason this allows you to associate your new class with a
+        bucket so that when you call bucket.new_key() or when you get a listing
+        of keys in the bucket you will get an instances of your key class
+        rather than the default.
+
+        :type key_class: class
+        :param key_class: A subclass of Key that can be more specific
+        """
+        self.key_class = key_class
+
+    def lookup(self, key_name, headers=None):
+        """
+        Deprecated: Please use get_key method.
+
+        :type key_name: string
+        :param key_name: The name of the key to retrieve
+
+        :rtype: :class:`boto.s3.key.Key`
+        :returns: A Key object from this bucket.
+        """
+        return self.get_key(key_name, headers=headers)
+
+    def get_key(self, key_name, headers=None, version_id=None,
+                response_headers=None, validate=True):
+        """
+        Check to see if a particular key exists within the bucket.  This
+        method uses a HEAD request to check for the existence of the key.
+        Returns: An instance of a Key object or None
+
+        :param key_name: The name of the key to retrieve
+        :type key_name: string
+
+        :param headers: The headers to send when retrieving the key
+        :type headers: dict
+
+        :param version_id:
+        :type version_id: string
+
+        :param response_headers: A dictionary containing HTTP
+            headers/values that will override any headers associated
+            with the stored object in the response.  See
+            http://goo.gl/EWOPb for details.
+        :type response_headers: dict
+
+        :param validate: Verifies whether the key exists. If ``False``, this
+            will not hit the service, constructing an in-memory object.
+            Default is ``True``.
+        :type validate: bool
+
+        :rtype: :class:`boto.s3.key.Key`
+        :returns: A Key object from this bucket.
+        """
+        if validate is False:
+            if headers or version_id or response_headers:
+                raise BotoClientError(
+                    "When providing 'validate=False', no other params " + \
+                    "are allowed."
+                )
+
+            # This leans on the default behavior of ``new_key`` (not hitting
+            # the service). If that changes, that behavior should migrate here.
+            return self.new_key(key_name)
+
+        query_args_l = []
+        if version_id:
+            query_args_l.append('versionId=%s' % version_id)
+        if response_headers:
+            for rk, rv in six.iteritems(response_headers):
+                query_args_l.append('%s=%s' % (rk, urllib.parse.quote(rv)))
+
+        key, resp = self._get_key_internal(key_name, headers, query_args_l)
+        return key
+
+    def _get_key_internal(self, key_name, headers, query_args_l):
+        query_args = '&'.join(query_args_l) or None
+        response = self.connection.make_request('HEAD', self.name, key_name,
+                                                headers=headers,
+                                                query_args=query_args)
+        response.read()
+        # Allow any success status (2xx) - for example this lets us
+        # support Range gets, which return status 206:
+        if response.status // 100 == 2:
+            k = self.key_class(self)
+            provider = self.connection.provider
+            k.metadata = boto.utils.get_aws_metadata(response.msg, provider)
+            for field in Key.base_fields:
+                k.__dict__[field.lower().replace('-', '_')] = \
+                    response.getheader(field)
+            # the following machinations are a workaround to the fact that
+            # apache/fastcgi omits the content-length header on HEAD
+            # requests when the content-length is zero.
+            # See http://goo.gl/0Tdax for more details.
+            clen = response.getheader('content-length')
+            if clen:
+                k.size = int(response.getheader('content-length'))
+            else:
+                k.size = 0
+            k.name = key_name
+            k.handle_version_headers(response)
+            k.handle_encryption_headers(response)
+            k.handle_restore_headers(response)
+            k.handle_storage_class_header(response)
+            k.handle_addl_headers(response.getheaders())
+            return k, response
+        else:
+            if response.status == 404:
+                return None, response
+            else:
+                raise self.connection.provider.storage_response_error(
+                    response.status, response.reason, '')
+
+    def list(self, prefix='', delimiter='', marker='', headers=None,
+             encoding_type=None):
+        """
+        List key objects within a bucket.  This returns an instance of an
+        BucketListResultSet that automatically handles all of the result
+        paging, etc. from S3.  You just need to keep iterating until
+        there are no more results.
+
+        Called with no arguments, this will return an iterator object across
+        all keys within the bucket.
+
+        The Key objects returned by the iterator are obtained by parsing
+        the results of a GET on the bucket, also known as the List Objects
+        request.  The XML returned by this request contains only a subset
+        of the information about each key.  Certain metadata fields such
+        as Content-Type and user metadata are not available in the XML.
+        Therefore, if you want these additional metadata fields you will
+        have to do a HEAD request on the Key in the bucket.
+
+        :type prefix: string
+        :param prefix: allows you to limit the listing to a particular
+            prefix.  For example, if you call the method with
+            prefix='/foo/' then the iterator will only cycle through
+            the keys that begin with the string '/foo/'.
+
+        :type delimiter: string
+        :param delimiter: can be used in conjunction with the prefix
+            to allow you to organize and browse your keys
+            hierarchically. See http://goo.gl/Xx63h for more details.
+
+        :type marker: string
+        :param marker: The "marker" of where you are in the result set
+
+        :param encoding_type: Requests Amazon S3 to encode the response and
+            specifies the encoding method to use.
+
+            An object key can contain any Unicode character; however, XML 1.0
+            parser cannot parse some characters, such as characters with an
+            ASCII value from 0 to 10. For characters that are not supported in
+            XML 1.0, you can add this parameter to request that Amazon S3
+            encode the keys in the response.
+
+            Valid options: ``url``
+        :type encoding_type: string
+
+        :rtype: :class:`boto.s3.bucketlistresultset.BucketListResultSet`
+        :return: an instance of a BucketListResultSet that handles paging, etc
+        """
+        return BucketListResultSet(self, prefix, delimiter, marker, headers,
+                                   encoding_type=encoding_type)
+
+    def list_versions(self, prefix='', delimiter='', key_marker='',
+                      version_id_marker='', headers=None, encoding_type=None):
+        """
+        List version objects within a bucket.  This returns an
+        instance of an VersionedBucketListResultSet that automatically
+        handles all of the result paging, etc. from S3.  You just need
+        to keep iterating until there are no more results.  Called
+        with no arguments, this will return an iterator object across
+        all keys within the bucket.
+
+        :type prefix: string
+        :param prefix: allows you to limit the listing to a particular
+            prefix.  For example, if you call the method with
+            prefix='/foo/' then the iterator will only cycle through
+            the keys that begin with the string '/foo/'.
+
+        :type delimiter: string
+        :param delimiter: can be used in conjunction with the prefix
+            to allow you to organize and browse your keys
+            hierarchically. See:
+
+            http://aws.amazon.com/releasenotes/Amazon-S3/213
+
+            for more details.
+
+        :type key_marker: string
+        :param key_marker: The "marker" of where you are in the result set
+
+        :param encoding_type: Requests Amazon S3 to encode the response and
+            specifies the encoding method to use.
+
+            An object key can contain any Unicode character; however, XML 1.0
+            parser cannot parse some characters, such as characters with an
+            ASCII value from 0 to 10. For characters that are not supported in
+            XML 1.0, you can add this parameter to request that Amazon S3
+            encode the keys in the response.
+
+            Valid options: ``url``
+        :type encoding_type: string
+
+        :rtype: :class:`boto.s3.bucketlistresultset.BucketListResultSet`
+        :return: an instance of a BucketListResultSet that handles paging, etc
+        """
+        return VersionedBucketListResultSet(self, prefix, delimiter,
+                                            key_marker, version_id_marker,
+                                            headers,
+                                            encoding_type=encoding_type)
+
+    def list_multipart_uploads(self, key_marker='',
+                               upload_id_marker='',
+                               headers=None, encoding_type=None):
+        """
+        List multipart upload objects within a bucket.  This returns an
+        instance of an MultiPartUploadListResultSet that automatically
+        handles all of the result paging, etc. from S3.  You just need
+        to keep iterating until there are no more results.
+
+        :type key_marker: string
+        :param key_marker: The "marker" of where you are in the result set
+
+        :type upload_id_marker: string
+        :param upload_id_marker: The upload identifier
+
+        :param encoding_type: Requests Amazon S3 to encode the response and
+            specifies the encoding method to use.
+
+            An object key can contain any Unicode character; however, XML 1.0
+            parser cannot parse some characters, such as characters with an
+            ASCII value from 0 to 10. For characters that are not supported in
+            XML 1.0, you can add this parameter to request that Amazon S3
+            encode the keys in the response.
+
+            Valid options: ``url``
+        :type encoding_type: string
+
+        :rtype: :class:`boto.s3.bucketlistresultset.MultiPartUploadListResultSet`
+        :return: an instance of a BucketListResultSet that handles paging, etc
+        """
+        return MultiPartUploadListResultSet(self, key_marker,
+                                            upload_id_marker,
+                                            headers,
+                                            encoding_type=encoding_type)
+
+    def _get_all_query_args(self, params, initial_query_string=''):
+        pairs = []
+
+        if initial_query_string:
+            pairs.append(initial_query_string)
+
+        for key, value in sorted(params.items(), key=lambda x: x[0]):
+            if value is None:
+                continue
+            key = key.replace('_', '-')
+            if key == 'maxkeys':
+                key = 'max-keys'
+            if not isinstance(value, six.string_types + (six.binary_type,)):
+                value = six.text_type(value)
+            if not isinstance(value, six.binary_type):
+                value = value.encode('utf-8')
+            if value:
+                pairs.append(u'%s=%s' % (
+                    urllib.parse.quote(key),
+                    urllib.parse.quote(value)
+                ))
+
+        return '&'.join(pairs)
+
+    def _get_all(self, element_map, initial_query_string='',
+                 headers=None, **params):
+        query_args = self._get_all_query_args(
+            params,
+            initial_query_string=initial_query_string
+        )
+        response = self.connection.make_request('GET', self.name,
+                                                headers=headers,
+                                                query_args=query_args)
+        body = response.read()
+        boto.log.debug(body)
+        if response.status == 200:
+            rs = ResultSet(element_map)
+            h = handler.XmlHandler(rs, self)
+            if not isinstance(body, bytes):
+                body = body.encode('utf-8')
+            xml.sax.parseString(body, h)
+            return rs
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def validate_kwarg_names(self, kwargs, names):
+        """
+        Checks that all named arguments are in the specified list of names.
+
+        :type kwargs: dict
+        :param kwargs: Dictionary of kwargs to validate.
+
+        :type names: list
+        :param names: List of possible named arguments.
+        """
+        for kwarg in kwargs:
+            if kwarg not in names:
+                raise TypeError('Invalid argument "%s"!' % kwarg)
+
+    def get_all_keys(self, headers=None, **params):
+        """
+        A lower-level method for listing contents of a bucket.  This
+        closely models the actual S3 API and requires you to manually
+        handle the paging of results.  For a higher-level method that
+        handles the details of paging for you, you can use the list
+        method.
+
+        :type max_keys: int
+        :param max_keys: The maximum number of keys to retrieve
+
+        :type prefix: string
+        :param prefix: The prefix of the keys you want to retrieve
+
+        :type marker: string
+        :param marker: The "marker" of where you are in the result set
+
+        :type delimiter: string
+        :param delimiter: If this optional, Unicode string parameter
+            is included with your request, then keys that contain the
+            same string between the prefix and the first occurrence of
+            the delimiter will be rolled up into a single result
+            element in the CommonPrefixes collection. These rolled-up
+            keys are not returned elsewhere in the response.
+
+        :param encoding_type: Requests Amazon S3 to encode the response and
+            specifies the encoding method to use.
+
+            An object key can contain any Unicode character; however, XML 1.0
+            parser cannot parse some characters, such as characters with an
+            ASCII value from 0 to 10. For characters that are not supported in
+            XML 1.0, you can add this parameter to request that Amazon S3
+            encode the keys in the response.
+
+            Valid options: ``url``
+        :type encoding_type: string
+
+        :rtype: ResultSet
+        :return: The result from S3 listing the keys requested
+
+        """
+        self.validate_kwarg_names(params, ['maxkeys', 'max_keys', 'prefix',
+                                           'marker', 'delimiter',
+                                           'encoding_type'])
+        return self._get_all([('Contents', self.key_class),
+                              ('CommonPrefixes', Prefix)],
+                             '', headers, **params)
+
+    def get_all_versions(self, headers=None, **params):
+        """
+        A lower-level, version-aware method for listing contents of a
+        bucket.  This closely models the actual S3 API and requires
+        you to manually handle the paging of results.  For a
+        higher-level method that handles the details of paging for
+        you, you can use the list method.
+
+        :type max_keys: int
+        :param max_keys: The maximum number of keys to retrieve
+
+        :type prefix: string
+        :param prefix: The prefix of the keys you want to retrieve
+
+        :type key_marker: string
+        :param key_marker: The "marker" of where you are in the result set
+            with respect to keys.
+
+        :type version_id_marker: string
+        :param version_id_marker: The "marker" of where you are in the result
+            set with respect to version-id's.
+
+        :type delimiter: string
+        :param delimiter: If this optional, Unicode string parameter
+            is included with your request, then keys that contain the
+            same string between the prefix and the first occurrence of
+            the delimiter will be rolled up into a single result
+            element in the CommonPrefixes collection. These rolled-up
+            keys are not returned elsewhere in the response.
+
+        :param encoding_type: Requests Amazon S3 to encode the response and
+            specifies the encoding method to use.
+
+            An object key can contain any Unicode character; however, XML 1.0
+            parser cannot parse some characters, such as characters with an
+            ASCII value from 0 to 10. For characters that are not supported in
+            XML 1.0, you can add this parameter to request that Amazon S3
+            encode the keys in the response.
+
+            Valid options: ``url``
+        :type encoding_type: string
+
+        :rtype: ResultSet
+        :return: The result from S3 listing the keys requested
+        """
+        self.validate_get_all_versions_params(params)
+        return self._get_all([('Version', self.key_class),
+                              ('CommonPrefixes', Prefix),
+                              ('DeleteMarker', DeleteMarker)],
+                             'versions', headers, **params)
+
+    def validate_get_all_versions_params(self, params):
+        """
+        Validate that the parameters passed to get_all_versions are valid.
+        Overridden by subclasses that allow a different set of parameters.
+
+        :type params: dict
+        :param params: Parameters to validate.
+        """
+        self.validate_kwarg_names(
+                params, ['maxkeys', 'max_keys', 'prefix', 'key_marker',
+                         'version_id_marker', 'delimiter', 'encoding_type'])
+
+    def get_all_multipart_uploads(self, headers=None, **params):
+        """
+        A lower-level, version-aware method for listing active
+        MultiPart uploads for a bucket.  This closely models the
+        actual S3 API and requires you to manually handle the paging
+        of results.  For a higher-level method that handles the
+        details of paging for you, you can use the list method.
+
+        :type max_uploads: int
+        :param max_uploads: The maximum number of uploads to retrieve.
+            Default value is 1000.
+
+        :type key_marker: string
+        :param key_marker: Together with upload_id_marker, this
+            parameter specifies the multipart upload after which
+            listing should begin.  If upload_id_marker is not
+            specified, only the keys lexicographically greater than
+            the specified key_marker will be included in the list.
+
+            If upload_id_marker is specified, any multipart uploads
+            for a key equal to the key_marker might also be included,
+            provided those multipart uploads have upload IDs
+            lexicographically greater than the specified
+            upload_id_marker.
+
+        :type upload_id_marker: string
+        :param upload_id_marker: Together with key-marker, specifies
+            the multipart upload after which listing should begin. If
+            key_marker is not specified, the upload_id_marker
+            parameter is ignored.  Otherwise, any multipart uploads
+            for a key equal to the key_marker might be included in the
+            list only if they have an upload ID lexicographically
+            greater than the specified upload_id_marker.
+
+        :type encoding_type: string
+        :param encoding_type: Requests Amazon S3 to encode the response and
+            specifies the encoding method to use.
+
+            An object key can contain any Unicode character; however, XML 1.0
+            parser cannot parse some characters, such as characters with an
+            ASCII value from 0 to 10. For characters that are not supported in
+            XML 1.0, you can add this parameter to request that Amazon S3
+            encode the keys in the response.
+
+            Valid options: ``url``
+
+        :type delimiter: string
+        :param delimiter: Character you use to group keys.
+            All keys that contain the same string between the prefix, if
+            specified, and the first occurrence of the delimiter after the
+            prefix are grouped under a single result element, CommonPrefixes.
+            If you don't specify the prefix parameter, then the substring
+            starts at the beginning of the key. The keys that are grouped
+            under CommonPrefixes result element are not returned elsewhere
+            in the response.
+
+        :type prefix: string
+        :param prefix: Lists in-progress uploads only for those keys that
+            begin with the specified prefix. You can use prefixes to separate
+            a bucket into different grouping of keys. (You can think of using
+            prefix to make groups in the same way you'd use a folder in a
+            file system.)
+
+        :rtype: ResultSet
+        :return: The result from S3 listing the uploads requested
+
+        """
+        self.validate_kwarg_names(params, ['max_uploads', 'key_marker',
+                                           'upload_id_marker', 'encoding_type',
+                                           'delimiter', 'prefix'])
+        return self._get_all([('Upload', MultiPartUpload),
+                              ('CommonPrefixes', Prefix)],
+                             'uploads', headers, **params)
+
+    def new_key(self, key_name=None):
+        """
+        Creates a new key
+
+        :type key_name: string
+        :param key_name: The name of the key to create
+
+        :rtype: :class:`boto.s3.key.Key` or subclass
+        :returns: An instance of the newly created key object
+        """
+        if not key_name:
+            raise ValueError('Empty key names are not allowed')
+        return self.key_class(self, key_name)
+
+    def generate_url(self, expires_in, method='GET', headers=None,
+                     force_http=False, response_headers=None,
+                     expires_in_absolute=False):
+        return self.connection.generate_url(expires_in, method, self.name,
+                                            headers=headers,
+                                            force_http=force_http,
+                                            response_headers=response_headers,
+                                            expires_in_absolute=expires_in_absolute)
+
+    def delete_keys(self, keys, quiet=False, mfa_token=None, headers=None):
+        """
+        Deletes a set of keys using S3's Multi-object delete API. If a
+        VersionID is specified for that key then that version is removed.
+        Returns a MultiDeleteResult Object, which contains Deleted
+        and Error elements for each key you ask to delete.
+
+        :type keys: list
+        :param keys: A list of either key_names or (key_name, versionid) pairs
+            or a list of Key instances.
+
+        :type quiet: boolean
+        :param quiet: In quiet mode the response includes only keys
+            where the delete operation encountered an error. For a
+            successful deletion, the operation does not return any
+            information about the delete in the response body.
+
+        :type mfa_token: tuple or list of strings
+        :param mfa_token: A tuple or list consisting of the serial
+            number from the MFA device and the current value of the
+            six-digit token associated with the device.  This value is
+            required anytime you are deleting versioned objects from a
+            bucket that has the MFADelete option on the bucket.
+
+        :returns: An instance of MultiDeleteResult
+        """
+        ikeys = iter(keys)
+        result = MultiDeleteResult(self)
+        provider = self.connection.provider
+        query_args = 'delete'
+
+        def delete_keys2(hdrs):
+            hdrs = hdrs or {}
+            data = u"""<?xml version="1.0" encoding="UTF-8"?>"""
+            data += u"<Delete>"
+            if quiet:
+                data += u"<Quiet>true</Quiet>"
+            count = 0
+            while count < 1000:
+                try:
+                    key = next(ikeys)
+                except StopIteration:
+                    break
+                if isinstance(key, six.string_types):
+                    key_name = key
+                    version_id = None
+                elif isinstance(key, tuple) and len(key) == 2:
+                    key_name, version_id = key
+                elif (isinstance(key, Key) or isinstance(key, DeleteMarker)) and key.name:
+                    key_name = key.name
+                    version_id = key.version_id
+                else:
+                    if isinstance(key, Prefix):
+                        key_name = key.name
+                        code = 'PrefixSkipped'   # Don't delete Prefix
+                    else:
+                        key_name = repr(key)   # try get a string
+                        code = 'InvalidArgument'  # other unknown type
+                    message = 'Invalid. No delete action taken for this object.'
+                    error = Error(key_name, code=code, message=message)
+                    result.errors.append(error)
+                    continue
+                count += 1
+                data += u"<Object><Key>%s</Key>" % xml.sax.saxutils.escape(key_name)
+                if version_id:
+                    data += u"<VersionId>%s</VersionId>" % version_id
+                data += u"</Object>"
+            data += u"</Delete>"
+            if count <= 0:
+                return False  # no more
+            data = data.encode('utf-8')
+            fp = BytesIO(data)
+            md5 = boto.utils.compute_md5(fp)
+            hdrs['Content-MD5'] = md5[1]
+            hdrs['Content-Type'] = 'text/xml'
+            if mfa_token:
+                hdrs[provider.mfa_header] = ' '.join(mfa_token)
+            response = self.connection.make_request('POST', self.name,
+                                                    headers=hdrs,
+                                                    query_args=query_args,
+                                                    data=data)
+            body = response.read()
+            if response.status == 200:
+                h = handler.XmlHandler(result, self)
+                if not isinstance(body, bytes):
+                    body = body.encode('utf-8')
+                xml.sax.parseString(body, h)
+                return count >= 1000  # more?
+            else:
+                raise provider.storage_response_error(response.status,
+                                                      response.reason,
+                                                      body)
+        while delete_keys2(headers):
+            pass
+        return result
+
+    def delete_key(self, key_name, headers=None, version_id=None,
+                   mfa_token=None):
+        """
+        Deletes a key from the bucket.  If a version_id is provided,
+        only that version of the key will be deleted.
+
+        :type key_name: string
+        :param key_name: The key name to delete
+
+        :type version_id: string
+        :param version_id: The version ID (optional)
+
+        :type mfa_token: tuple or list of strings
+        :param mfa_token: A tuple or list consisting of the serial
+            number from the MFA device and the current value of the
+            six-digit token associated with the device.  This value is
+            required anytime you are deleting versioned objects from a
+            bucket that has the MFADelete option on the bucket.
+
+        :rtype: :class:`boto.s3.key.Key` or subclass
+        :returns: A key object holding information on what was
+            deleted.  The Caller can see if a delete_marker was
+            created or removed and what version_id the delete created
+            or removed.
+        """
+        if not key_name:
+            raise ValueError('Empty key names are not allowed')
+        return self._delete_key_internal(key_name, headers=headers,
+                                         version_id=version_id,
+                                         mfa_token=mfa_token,
+                                         query_args_l=None)
+
+    def _delete_key_internal(self, key_name, headers=None, version_id=None,
+                             mfa_token=None, query_args_l=None):
+        query_args_l = query_args_l or []
+        provider = self.connection.provider
+        if version_id:
+            query_args_l.append('versionId=%s' % version_id)
+        query_args = '&'.join(query_args_l) or None
+        if mfa_token:
+            if not headers:
+                headers = {}
+            headers[provider.mfa_header] = ' '.join(mfa_token)
+        response = self.connection.make_request('DELETE', self.name, key_name,
+                                                headers=headers,
+                                                query_args=query_args)
+        body = response.read()
+        if response.status != 204:
+            raise provider.storage_response_error(response.status,
+                                                  response.reason, body)
+        else:
+            # return a key object with information on what was deleted.
+            k = self.key_class(self)
+            k.name = key_name
+            k.handle_version_headers(response)
+            k.handle_addl_headers(response.getheaders())
+            return k
+
+    def copy_key(self, new_key_name, src_bucket_name,
+                 src_key_name, metadata=None, src_version_id=None,
+                 storage_class='STANDARD', preserve_acl=False,
+                 encrypt_key=False, headers=None, query_args=None):
+        """
+        Create a new key in the bucket by copying another existing key.
+
+        :type new_key_name: string
+        :param new_key_name: The name of the new key
+
+        :type src_bucket_name: string
+        :param src_bucket_name: The name of the source bucket
+
+        :type src_key_name: string
+        :param src_key_name: The name of the source key
+
+        :type src_version_id: string
+        :param src_version_id: The version id for the key.  This param
+            is optional.  If not specified, the newest version of the
+            key will be copied.
+
+        :type metadata: dict
+        :param metadata: Metadata to be associated with new key.  If
+            metadata is supplied, it will replace the metadata of the
+            source key being copied.  If no metadata is supplied, the
+            source key's metadata will be copied to the new key.
+
+        :type storage_class: string
+        :param storage_class: The storage class of the new key.  By
+            default, the new key will use the standard storage class.
+            Possible values are: STANDARD | REDUCED_REDUNDANCY
+
+        :type preserve_acl: bool
+        :param preserve_acl: If True, the ACL from the source key will
+            be copied to the destination key.  If False, the
+            destination key will have the default ACL.  Note that
+            preserving the ACL in the new key object will require two
+            additional API calls to S3, one to retrieve the current
+            ACL and one to set that ACL on the new object.  If you
+            don't care about the ACL, a value of False will be
+            significantly more efficient.
+
+        :type encrypt_key: bool
+        :param encrypt_key: If True, the new copy of the object will
+            be encrypted on the server-side by S3 and will be stored
+            in an encrypted form while at rest in S3.
+
+        :type headers: dict
+        :param headers: A dictionary of header name/value pairs.
+
+        :type query_args: string
+        :param query_args: A string of additional querystring arguments
+            to append to the request
+
+        :rtype: :class:`boto.s3.key.Key` or subclass
+        :returns: An instance of the newly created key object
+        """
+        headers = headers or {}
+        provider = self.connection.provider
+        if six.PY3:
+            if isinstance(src_key_name, bytes):
+                src_key_name = src_key_name.decode('utf-8')
+        else:
+            src_key_name = boto.utils.get_utf8_value(src_key_name)
+        if preserve_acl:
+            if self.name == src_bucket_name:
+                src_bucket = self
+            else:
+                src_bucket = self.connection.get_bucket(
+                    src_bucket_name, validate=False, headers=headers)
+            acl = src_bucket.get_xml_acl(src_key_name, headers=headers)
+        if encrypt_key:
+            headers[provider.server_side_encryption_header] = 'AES256'
+        src = '%s/%s' % (src_bucket_name, urllib.parse.quote(src_key_name))
+        if src_version_id:
+            src += '?versionId=%s' % src_version_id
+        headers[provider.copy_source_header] = str(src)
+        # make sure storage_class_header key exists before accessing it
+        if provider.storage_class_header and storage_class:
+            headers[provider.storage_class_header] = storage_class
+        if metadata is not None:
+            headers[provider.metadata_directive_header] = 'REPLACE'
+            headers = boto.utils.merge_meta(headers, metadata, provider)
+        elif not query_args:  # Can't use this header with multi-part copy.
+            headers[provider.metadata_directive_header] = 'COPY'
+        response = self.connection.make_request('PUT', self.name, new_key_name,
+                                                headers=headers,
+                                                query_args=query_args)
+        body = response.read()
+        if response.status == 200:
+            key = self.new_key(new_key_name)
+            h = handler.XmlHandler(key, self)
+            xml.sax.parseString(body, h)
+            if hasattr(key, 'Error'):
+                raise provider.storage_copy_error(key.Code, key.Message, body)
+            key.handle_version_headers(response)
+            key.handle_addl_headers(response.getheaders())
+            if preserve_acl:
+                self.set_xml_acl(acl, new_key_name)
+            return key
+        else:
+            raise provider.storage_response_error(response.status,
+                                                  response.reason, body)
+
+    def set_canned_acl(self, acl_str, key_name='', headers=None,
+                       version_id=None):
+        assert acl_str in CannedACLStrings
+
+        if headers:
+            headers[self.connection.provider.acl_header] = acl_str
+        else:
+            headers = {self.connection.provider.acl_header: acl_str}
+
+        query_args = 'acl'
+        if version_id:
+            query_args += '&versionId=%s' % version_id
+        response = self.connection.make_request('PUT', self.name, key_name,
+                headers=headers, query_args=query_args)
+        body = response.read()
+        if response.status != 200:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def get_xml_acl(self, key_name='', headers=None, version_id=None):
+        query_args = 'acl'
+        if version_id:
+            query_args += '&versionId=%s' % version_id
+        response = self.connection.make_request('GET', self.name, key_name,
+                                                query_args=query_args,
+                                                headers=headers)
+        body = response.read()
+        if response.status != 200:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+        return body
+
+    def set_xml_acl(self, acl_str, key_name='', headers=None, version_id=None,
+                    query_args='acl'):
+        if version_id:
+            query_args += '&versionId=%s' % version_id
+        if not isinstance(acl_str, bytes):
+            acl_str = acl_str.encode('utf-8')
+        response = self.connection.make_request('PUT', self.name, key_name,
+                                                data=acl_str,
+                                                query_args=query_args,
+                                                headers=headers)
+        body = response.read()
+        if response.status != 200:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def set_acl(self, acl_or_str, key_name='', headers=None, version_id=None):
+        if isinstance(acl_or_str, Policy):
+            self.set_xml_acl(acl_or_str.to_xml(), key_name,
+                             headers, version_id)
+        else:
+            self.set_canned_acl(acl_or_str, key_name,
+                                headers, version_id)
+
+    def get_acl(self, key_name='', headers=None, version_id=None):
+        query_args = 'acl'
+        if version_id:
+            query_args += '&versionId=%s' % version_id
+        response = self.connection.make_request('GET', self.name, key_name,
+                                                query_args=query_args,
+                                                headers=headers)
+        body = response.read()
+        if response.status == 200:
+            policy = Policy(self)
+            h = handler.XmlHandler(policy, self)
+            if not isinstance(body, bytes):
+                body = body.encode('utf-8')
+            xml.sax.parseString(body, h)
+            return policy
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def set_subresource(self, subresource, value, key_name='', headers=None,
+                        version_id=None):
+        """
+        Set a subresource for a bucket or key.
+
+        :type subresource: string
+        :param subresource: The subresource to set.
+
+        :type value: string
+        :param value: The value of the subresource.
+
+        :type key_name: string
+        :param key_name: The key to operate on, or None to operate on the
+            bucket.
+
+        :type headers: dict
+        :param headers: Additional HTTP headers to include in the request.
+
+        :type src_version_id: string
+        :param src_version_id: Optional. The version id of the key to
+            operate on. If not specified, operate on the newest
+            version.
+        """
+        if not subresource:
+            raise TypeError('set_subresource called with subresource=None')
+        query_args = subresource
+        if version_id:
+            query_args += '&versionId=%s' % version_id
+        if not isinstance(value, bytes):
+            value = value.encode('utf-8')
+        response = self.connection.make_request('PUT', self.name, key_name,
+                                                data=value,
+                                                query_args=query_args,
+                                                headers=headers)
+        body = response.read()
+        if response.status != 200:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def get_subresource(self, subresource, key_name='', headers=None,
+                        version_id=None):
+        """
+        Get a subresource for a bucket or key.
+
+        :type subresource: string
+        :param subresource: The subresource to get.
+
+        :type key_name: string
+        :param key_name: The key to operate on, or None to operate on the
+            bucket.
+
+        :type headers: dict
+        :param headers: Additional HTTP headers to include in the request.
+
+        :type src_version_id: string
+        :param src_version_id: Optional. The version id of the key to
+            operate on. If not specified, operate on the newest
+            version.
+
+        :rtype: string
+        :returns: The value of the subresource.
+        """
+        if not subresource:
+            raise TypeError('get_subresource called with subresource=None')
+        query_args = subresource
+        if version_id:
+            query_args += '&versionId=%s' % version_id
+        response = self.connection.make_request('GET', self.name, key_name,
+                                                query_args=query_args,
+                                                headers=headers)
+        body = response.read()
+        if response.status != 200:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+        return body
+
+    def make_public(self, recursive=False, headers=None):
+        self.set_canned_acl('public-read', headers=headers)
+        if recursive:
+            for key in self:
+                self.set_canned_acl('public-read', key.name, headers=headers)
+
+    def add_email_grant(self, permission, email_address,
+                        recursive=False, headers=None):
+        """
+        Convenience method that provides a quick way to add an email grant
+        to a bucket. This method retrieves the current ACL, creates a new
+        grant based on the parameters passed in, adds that grant to the ACL
+        and then PUT's the new ACL back to S3.
+
+        :type permission: string
+        :param permission: The permission being granted. Should be one of:
+            (READ, WRITE, READ_ACP, WRITE_ACP, FULL_CONTROL).
+
+        :type email_address: string
+        :param email_address: The email address associated with the AWS
+            account your are granting the permission to.
+
+        :type recursive: boolean
+        :param recursive: A boolean value to controls whether the
+            command will apply the grant to all keys within the bucket
+            or not.  The default value is False.  By passing a True
+            value, the call will iterate through all keys in the
+            bucket and apply the same grant to each key.  CAUTION: If
+            you have a lot of keys, this could take a long time!
+        """
+        if permission not in S3Permissions:
+            raise self.connection.provider.storage_permissions_error(
+                'Unknown Permission: %s' % permission)
+        policy = self.get_acl(headers=headers)
+        policy.acl.add_email_grant(permission, email_address)
+        self.set_acl(policy, headers=headers)
+        if recursive:
+            for key in self:
+                key.add_email_grant(permission, email_address, headers=headers)
+
+    def add_user_grant(self, permission, user_id, recursive=False,
+                       headers=None, display_name=None):
+        """
+        Convenience method that provides a quick way to add a canonical
+        user grant to a bucket.  This method retrieves the current ACL,
+        creates a new grant based on the parameters passed in, adds that
+        grant to the ACL and then PUT's the new ACL back to S3.
+
+        :type permission: string
+        :param permission: The permission being granted. Should be one of:
+            (READ, WRITE, READ_ACP, WRITE_ACP, FULL_CONTROL).
+
+        :type user_id: string
+        :param user_id:     The canonical user id associated with the AWS
+            account your are granting the permission to.
+
+        :type recursive: boolean
+        :param recursive: A boolean value to controls whether the
+            command will apply the grant to all keys within the bucket
+            or not.  The default value is False.  By passing a True
+            value, the call will iterate through all keys in the
+            bucket and apply the same grant to each key.  CAUTION: If
+            you have a lot of keys, this could take a long time!
+
+        :type display_name: string
+        :param display_name: An option string containing the user's
+            Display Name.  Only required on Walrus.
+        """
+        if permission not in S3Permissions:
+            raise self.connection.provider.storage_permissions_error(
+                'Unknown Permission: %s' % permission)
+        policy = self.get_acl(headers=headers)
+        policy.acl.add_user_grant(permission, user_id,
+                                  display_name=display_name)
+        self.set_acl(policy, headers=headers)
+        if recursive:
+            for key in self:
+                key.add_user_grant(permission, user_id, headers=headers,
+                                   display_name=display_name)
+
+    def list_grants(self, headers=None):
+        policy = self.get_acl(headers=headers)
+        return policy.acl.grants
+
+    def get_location(self, headers=None):
+        """
+        Returns the LocationConstraint for the bucket.
+
+        :rtype: str
+        :return: The LocationConstraint for the bucket or the empty
+            string if no constraint was specified when bucket was created.
+        """
+        response = self.connection.make_request('GET', self.name,
+                                                headers=headers,
+                                                query_args='location')
+        body = response.read()
+        if response.status == 200:
+            rs = ResultSet(self)
+            h = handler.XmlHandler(rs, self)
+            if not isinstance(body, bytes):
+                body = body.encode('utf-8')
+            xml.sax.parseString(body, h)
+            return rs.LocationConstraint
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def set_xml_logging(self, logging_str, headers=None):
+        """
+        Set logging on a bucket directly to the given xml string.
+
+        :type logging_str: unicode string
+        :param logging_str: The XML for the bucketloggingstatus which
+            will be set.  The string will be converted to utf-8 before
+            it is sent.  Usually, you will obtain this XML from the
+            BucketLogging object.
+
+        :rtype: bool
+        :return: True if ok or raises an exception.
+        """
+        body = logging_str
+        if not isinstance(body, bytes):
+            body = body.encode('utf-8')
+        response = self.connection.make_request('PUT', self.name, data=body,
+                query_args='logging', headers=headers)
+        body = response.read()
+        if response.status == 200:
+            return True
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def enable_logging(self, target_bucket, target_prefix='',
+                       grants=None, headers=None):
+        """
+        Enable logging on a bucket.
+
+        :type target_bucket: bucket or string
+        :param target_bucket: The bucket to log to.
+
+        :type target_prefix: string
+        :param target_prefix: The prefix which should be prepended to the
+            generated log files written to the target_bucket.
+
+        :type grants: list of Grant objects
+        :param grants: A list of extra permissions which will be granted on
+            the log files which are created.
+
+        :rtype: bool
+        :return: True if ok or raises an exception.
+        """
+        if isinstance(target_bucket, Bucket):
+            target_bucket = target_bucket.name
+        blogging = BucketLogging(target=target_bucket, prefix=target_prefix,
+                                 grants=grants)
+        return self.set_xml_logging(blogging.to_xml(), headers=headers)
+
+    def disable_logging(self, headers=None):
+        """
+        Disable logging on a bucket.
+
+        :rtype: bool
+        :return: True if ok or raises an exception.
+        """
+        blogging = BucketLogging()
+        return self.set_xml_logging(blogging.to_xml(), headers=headers)
+
+    def get_logging_status(self, headers=None):
+        """
+        Get the logging status for this bucket.
+
+        :rtype: :class:`boto.s3.bucketlogging.BucketLogging`
+        :return: A BucketLogging object for this bucket.
+        """
+        response = self.connection.make_request('GET', self.name,
+                query_args='logging', headers=headers)
+        body = response.read()
+        if response.status == 200:
+            blogging = BucketLogging()
+            h = handler.XmlHandler(blogging, self)
+            if not isinstance(body, bytes):
+                body = body.encode('utf-8')
+            xml.sax.parseString(body, h)
+            return blogging
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def set_as_logging_target(self, headers=None):
+        """
+        Setup the current bucket as a logging target by granting the necessary
+        permissions to the LogDelivery group to write log files to this bucket.
+        """
+        policy = self.get_acl(headers=headers)
+        g1 = Grant(permission='WRITE', type='Group', uri=self.LoggingGroup)
+        g2 = Grant(permission='READ_ACP', type='Group', uri=self.LoggingGroup)
+        policy.acl.add_grant(g1)
+        policy.acl.add_grant(g2)
+        self.set_acl(policy, headers=headers)
+
+    def get_request_payment(self, headers=None):
+        response = self.connection.make_request('GET', self.name,
+                query_args='requestPayment', headers=headers)
+        body = response.read()
+        if response.status == 200:
+            return body
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def set_request_payment(self, payer='BucketOwner', headers=None):
+        body = self.BucketPaymentBody % payer
+        response = self.connection.make_request('PUT', self.name, data=body,
+                query_args='requestPayment', headers=headers)
+        body = response.read()
+        if response.status == 200:
+            return True
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def configure_versioning(self, versioning, mfa_delete=False,
+                             mfa_token=None, headers=None):
+        """
+        Configure versioning for this bucket.
+
+        ..note:: This feature is currently in beta.
+
+        :type versioning: bool
+        :param versioning: A boolean indicating whether version is
+            enabled (True) or disabled (False).
+
+        :type mfa_delete: bool
+        :param mfa_delete: A boolean indicating whether the
+            Multi-Factor Authentication Delete feature is enabled
+            (True) or disabled (False).  If mfa_delete is enabled then
+            all Delete operations will require the token from your MFA
+            device to be passed in the request.
+
+        :type mfa_token: tuple or list of strings
+        :param mfa_token: A tuple or list consisting of the serial
+            number from the MFA device and the current value of the
+            six-digit token associated with the device.  This value is
+            required when you are changing the status of the MfaDelete
+            property of the bucket.
+        """
+        if versioning:
+            ver = 'Enabled'
+        else:
+            ver = 'Suspended'
+        if mfa_delete:
+            mfa = 'Enabled'
+        else:
+            mfa = 'Disabled'
+        body = self.VersioningBody % (ver, mfa)
+        if mfa_token:
+            if not headers:
+                headers = {}
+            provider = self.connection.provider
+            headers[provider.mfa_header] = ' '.join(mfa_token)
+        response = self.connection.make_request('PUT', self.name, data=body,
+                query_args='versioning', headers=headers)
+        body = response.read()
+        if response.status == 200:
+            return True
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def get_versioning_status(self, headers=None):
+        """
+        Returns the current status of versioning on the bucket.
+
+        :rtype: dict
+        :returns: A dictionary containing a key named 'Versioning'
+            that can have a value of either Enabled, Disabled, or
+            Suspended. Also, if MFADelete has ever been enabled on the
+            bucket, the dictionary will contain a key named
+            'MFADelete' which will have a value of either Enabled or
+            Suspended.
+        """
+        response = self.connection.make_request('GET', self.name,
+                query_args='versioning', headers=headers)
+        body = response.read()
+        if not isinstance(body, six.string_types):
+            body = body.decode('utf-8')
+        boto.log.debug(body)
+        if response.status == 200:
+            d = {}
+            ver = re.search(self.VersionRE, body)
+            if ver:
+                d['Versioning'] = ver.group(1)
+            mfa = re.search(self.MFADeleteRE, body)
+            if mfa:
+                d['MfaDelete'] = mfa.group(1)
+            return d
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def configure_lifecycle(self, lifecycle_config, headers=None):
+        """
+        Configure lifecycle for this bucket.
+
+        :type lifecycle_config: :class:`boto.s3.lifecycle.Lifecycle`
+        :param lifecycle_config: The lifecycle configuration you want
+            to configure for this bucket.
+        """
+        xml = lifecycle_config.to_xml()
+        #xml = xml.encode('utf-8')
+        fp = StringIO(xml)
+        md5 = boto.utils.compute_md5(fp)
+        if headers is None:
+            headers = {}
+        headers['Content-MD5'] = md5[1]
+        headers['Content-Type'] = 'text/xml'
+        response = self.connection.make_request('PUT', self.name,
+                                                data=fp.getvalue(),
+                                                query_args='lifecycle',
+                                                headers=headers)
+        body = response.read()
+        if response.status == 200:
+            return True
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def get_lifecycle_config(self, headers=None):
+        """
+        Returns the current lifecycle configuration on the bucket.
+
+        :rtype: :class:`boto.s3.lifecycle.Lifecycle`
+        :returns: A LifecycleConfig object that describes all current
+            lifecycle rules in effect for the bucket.
+        """
+        response = self.connection.make_request('GET', self.name,
+                query_args='lifecycle', headers=headers)
+        body = response.read()
+        boto.log.debug(body)
+        if response.status == 200:
+            lifecycle = Lifecycle()
+            h = handler.XmlHandler(lifecycle, self)
+            if not isinstance(body, bytes):
+                body = body.encode('utf-8')
+            xml.sax.parseString(body, h)
+            return lifecycle
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def delete_lifecycle_configuration(self, headers=None):
+        """
+        Removes all lifecycle configuration from the bucket.
+        """
+        response = self.connection.make_request('DELETE', self.name,
+                                                query_args='lifecycle',
+                                                headers=headers)
+        body = response.read()
+        boto.log.debug(body)
+        if response.status == 204:
+            return True
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def configure_website(self, suffix=None, error_key=None,
+                          redirect_all_requests_to=None,
+                          routing_rules=None,
+                          headers=None):
+        """
+        Configure this bucket to act as a website
+
+        :type suffix: str
+        :param suffix: Suffix that is appended to a request that is for a
+            "directory" on the website endpoint (e.g. if the suffix is
+            index.html and you make a request to samplebucket/images/
+            the data that is returned will be for the object with the
+            key name images/index.html).  The suffix must not be empty
+            and must not include a slash character.
+
+        :type error_key: str
+        :param error_key: The object key name to use when a 4XX class
+            error occurs.  This is optional.
+
+        :type redirect_all_requests_to: :class:`boto.s3.website.RedirectLocation`
+        :param redirect_all_requests_to: Describes the redirect behavior for
+            every request to this bucket's website endpoint. If this value is
+            non None, no other values are considered when configuring the
+            website configuration for the bucket. This is an instance of
+            ``RedirectLocation``.
+
+        :type routing_rules: :class:`boto.s3.website.RoutingRules`
+        :param routing_rules: Object which specifies conditions
+            and redirects that apply when the conditions are met.
+
+        """
+        config = website.WebsiteConfiguration(
+                suffix, error_key, redirect_all_requests_to,
+                routing_rules)
+        return self.set_website_configuration(config, headers=headers)
+
+    def set_website_configuration(self, config, headers=None):
+        """
+        :type config: boto.s3.website.WebsiteConfiguration
+        :param config: Configuration data
+        """
+        return self.set_website_configuration_xml(config.to_xml(),
+          headers=headers)
+
+
+    def set_website_configuration_xml(self, xml, headers=None):
+        """Upload xml website configuration"""
+        response = self.connection.make_request('PUT', self.name, data=xml,
+                                                query_args='website',
+                                                headers=headers)
+        body = response.read()
+        if response.status == 200:
+            return True
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def get_website_configuration(self, headers=None):
+        """
+        Returns the current status of website configuration on the bucket.
+
+        :rtype: dict
+        :returns: A dictionary containing a Python representation
+            of the XML response from S3. The overall structure is:
+
+        * WebsiteConfiguration
+
+          * IndexDocument
+
+            * Suffix : suffix that is appended to request that
+              is for a "directory" on the website endpoint
+            * ErrorDocument
+
+              * Key : name of object to serve when an error occurs
+
+        """
+        return self.get_website_configuration_with_xml(headers)[0]
+
+    def get_website_configuration_obj(self, headers=None):
+        """Get the website configuration as a
+        :class:`boto.s3.website.WebsiteConfiguration` object.
+        """
+        config_xml = self.get_website_configuration_xml(headers=headers)
+        config = website.WebsiteConfiguration()
+        h = handler.XmlHandler(config, self)
+        xml.sax.parseString(config_xml, h)
+        return config
+
+    def get_website_configuration_with_xml(self, headers=None):
+        """
+        Returns the current status of website configuration on the bucket as
+        unparsed XML.
+
+        :rtype: 2-Tuple
+        :returns: 2-tuple containing:
+
+            1) A dictionary containing a Python representation \
+                of the XML response. The overall structure is:
+
+              * WebsiteConfiguration
+
+                * IndexDocument
+
+                  * Suffix : suffix that is appended to request that \
+                    is for a "directory" on the website endpoint
+
+                  * ErrorDocument
+
+                    * Key : name of object to serve when an error occurs
+
+
+            2) unparsed XML describing the bucket's website configuration
+
+        """
+
+        body = self.get_website_configuration_xml(headers=headers)
+        e = boto.jsonresponse.Element()
+        h = boto.jsonresponse.XmlHandler(e, None)
+        h.parse(body)
+        return e, body
+
+    def get_website_configuration_xml(self, headers=None):
+        """Get raw website configuration xml"""
+        response = self.connection.make_request('GET', self.name,
+                query_args='website', headers=headers)
+        body = response.read().decode('utf-8')
+        boto.log.debug(body)
+
+        if response.status != 200:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+        return body
+
+    def delete_website_configuration(self, headers=None):
+        """
+        Removes all website configuration from the bucket.
+        """
+        response = self.connection.make_request('DELETE', self.name,
+                query_args='website', headers=headers)
+        body = response.read()
+        boto.log.debug(body)
+        if response.status == 204:
+            return True
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def get_website_endpoint(self):
+        """
+        Returns the fully qualified hostname to use is you want to access this
+        bucket as a website.  This doesn't validate whether the bucket has
+        been correctly configured as a website or not.
+        """
+        l = [self.name]
+        l.append(S3WebsiteEndpointTranslate.translate_region(self.get_location()))
+        l.append('.'.join(self.connection.host.split('.')[-2:]))
+        return '.'.join(l)
+
+    def get_policy(self, headers=None):
+        """
+        Returns the JSON policy associated with the bucket.  The policy
+        is returned as an uninterpreted JSON string.
+        """
+        response = self.connection.make_request('GET', self.name,
+                query_args='policy', headers=headers)
+        body = response.read()
+        if response.status == 200:
+            return body
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def set_policy(self, policy, headers=None):
+        """
+        Add or replace the JSON policy associated with the bucket.
+
+        :type policy: str
+        :param policy: The JSON policy as a string.
+        """
+        response = self.connection.make_request('PUT', self.name,
+                                                data=policy,
+                                                query_args='policy',
+                                                headers=headers)
+        body = response.read()
+        if response.status >= 200 and response.status <= 204:
+            return True
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def delete_policy(self, headers=None):
+        response = self.connection.make_request('DELETE', self.name,
+                                                data='/?policy',
+                                                query_args='policy',
+                                                headers=headers)
+        body = response.read()
+        if response.status >= 200 and response.status <= 204:
+            return True
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def set_cors_xml(self, cors_xml, headers=None):
+        """
+        Set the CORS (Cross-Origin Resource Sharing) for a bucket.
+
+        :type cors_xml: str
+        :param cors_xml: The XML document describing your desired
+            CORS configuration.  See the S3 documentation for details
+            of the exact syntax required.
+        """
+        fp = StringIO(cors_xml)
+        md5 = boto.utils.compute_md5(fp)
+        if headers is None:
+            headers = {}
+        headers['Content-MD5'] = md5[1]
+        headers['Content-Type'] = 'text/xml'
+        response = self.connection.make_request('PUT', self.name,
+                                                data=fp.getvalue(),
+                                                query_args='cors',
+                                                headers=headers)
+        body = response.read()
+        if response.status == 200:
+            return True
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def set_cors(self, cors_config, headers=None):
+        """
+        Set the CORS for this bucket given a boto CORSConfiguration
+        object.
+
+        :type cors_config: :class:`boto.s3.cors.CORSConfiguration`
+        :param cors_config: The CORS configuration you want
+            to configure for this bucket.
+        """
+        return self.set_cors_xml(cors_config.to_xml())
+
+    def get_cors_xml(self, headers=None):
+        """
+        Returns the current CORS configuration on the bucket as an
+        XML document.
+        """
+        response = self.connection.make_request('GET', self.name,
+                query_args='cors', headers=headers)
+        body = response.read()
+        boto.log.debug(body)
+        if response.status == 200:
+            return body
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def get_cors(self, headers=None):
+        """
+        Returns the current CORS configuration on the bucket.
+
+        :rtype: :class:`boto.s3.cors.CORSConfiguration`
+        :returns: A CORSConfiguration object that describes all current
+            CORS rules in effect for the bucket.
+        """
+        body = self.get_cors_xml(headers)
+        cors = CORSConfiguration()
+        h = handler.XmlHandler(cors, self)
+        xml.sax.parseString(body, h)
+        return cors
+
+    def delete_cors(self, headers=None):
+        """
+        Removes all CORS configuration from the bucket.
+        """
+        response = self.connection.make_request('DELETE', self.name,
+                                                query_args='cors',
+                                                headers=headers)
+        body = response.read()
+        boto.log.debug(body)
+        if response.status == 204:
+            return True
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def initiate_multipart_upload(self, key_name, headers=None,
+                                  reduced_redundancy=False,
+                                  metadata=None, encrypt_key=False,
+                                  policy=None):
+        """
+        Start a multipart upload operation.
+
+        .. note::
+
+            Note: After you initiate multipart upload and upload one or more
+            parts, you must either complete or abort multipart upload in order
+            to stop getting charged for storage of the uploaded parts. Only
+            after you either complete or abort multipart upload, Amazon S3
+            frees up the parts storage and stops charging you for the parts
+            storage.
+
+        :type key_name: string
+        :param key_name: The name of the key that will ultimately
+            result from this multipart upload operation.  This will be
+            exactly as the key appears in the bucket after the upload
+            process has been completed.
+
+        :type headers: dict
+        :param headers: Additional HTTP headers to send and store with the
+            resulting key in S3.
+
+        :type reduced_redundancy: boolean
+        :param reduced_redundancy: In multipart uploads, the storage
+            class is specified when initiating the upload, not when
+            uploading individual parts.  So if you want the resulting
+            key to use the reduced redundancy storage class set this
+            flag when you initiate the upload.
+
+        :type metadata: dict
+        :param metadata: Any metadata that you would like to set on the key
+            that results from the multipart upload.
+
+        :type encrypt_key: bool
+        :param encrypt_key: If True, the new copy of the object will
+            be encrypted on the server-side by S3 and will be stored
+            in an encrypted form while at rest in S3.
+
+        :type policy: :class:`boto.s3.acl.CannedACLStrings`
+        :param policy: A canned ACL policy that will be applied to the
+            new key (once completed) in S3.
+        """
+        query_args = 'uploads'
+        provider = self.connection.provider
+        headers = headers or {}
+        if policy:
+            headers[provider.acl_header] = policy
+        if reduced_redundancy:
+            storage_class_header = provider.storage_class_header
+            if storage_class_header:
+                headers[storage_class_header] = 'REDUCED_REDUNDANCY'
+            # TODO: what if the provider doesn't support reduced redundancy?
+            # (see boto.s3.key.Key.set_contents_from_file)
+        if encrypt_key:
+            headers[provider.server_side_encryption_header] = 'AES256'
+        if metadata is None:
+            metadata = {}
+
+        headers = boto.utils.merge_meta(headers, metadata,
+                self.connection.provider)
+        response = self.connection.make_request('POST', self.name, key_name,
+                                                query_args=query_args,
+                                                headers=headers)
+        body = response.read()
+        boto.log.debug(body)
+        if response.status == 200:
+            resp = MultiPartUpload(self)
+            h = handler.XmlHandler(resp, self)
+            if not isinstance(body, bytes):
+                body = body.encode('utf-8')
+            xml.sax.parseString(body, h)
+            return resp
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def complete_multipart_upload(self, key_name, upload_id,
+                                  xml_body, headers=None):
+        """
+        Complete a multipart upload operation.
+        """
+        query_args = 'uploadId=%s' % upload_id
+        if headers is None:
+            headers = {}
+        headers['Content-Type'] = 'text/xml'
+        response = self.connection.make_request('POST', self.name, key_name,
+                                                query_args=query_args,
+                                                headers=headers, data=xml_body)
+        contains_error = False
+        body = response.read().decode('utf-8')
+        # Some errors will be reported in the body of the response
+        # even though the HTTP response code is 200.  This check
+        # does a quick and dirty peek in the body for an error element.
+        if body.find('<Error>') > 0:
+            contains_error = True
+        boto.log.debug(body)
+        if response.status == 200 and not contains_error:
+            resp = CompleteMultiPartUpload(self)
+            h = handler.XmlHandler(resp, self)
+            if not isinstance(body, bytes):
+                body = body.encode('utf-8')
+            xml.sax.parseString(body, h)
+            # Use a dummy key to parse various response headers
+            # for versioning, encryption info and then explicitly
+            # set the completed MPU object values from key.
+            k = self.key_class(self)
+            k.handle_version_headers(response)
+            k.handle_encryption_headers(response)
+            resp.version_id = k.version_id
+            resp.encrypted = k.encrypted
+            return resp
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def cancel_multipart_upload(self, key_name, upload_id, headers=None):
+        """
+        To verify that all parts have been removed, so you don't get charged
+        for the part storage, you should call the List Parts operation and
+        ensure the parts list is empty.
+        """
+        query_args = 'uploadId=%s' % upload_id
+        response = self.connection.make_request('DELETE', self.name, key_name,
+                                                query_args=query_args,
+                                                headers=headers)
+        body = response.read()
+        boto.log.debug(body)
+        if response.status != 204:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def delete(self, headers=None):
+        return self.connection.delete_bucket(self.name, headers=headers)
+
+    def get_tags(self, headers=None):
+        response = self.get_xml_tags(headers)
+        tags = Tags()
+        h = handler.XmlHandler(tags, self)
+        if not isinstance(response, bytes):
+            response = response.encode('utf-8')
+        xml.sax.parseString(response, h)
+        return tags
+
+    def get_xml_tags(self, headers=None):
+        response = self.connection.make_request('GET', self.name,
+                                                query_args='tagging',
+                                                headers=headers)
+        body = response.read()
+        if response.status == 200:
+            return body
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+
+    def set_xml_tags(self, tag_str, headers=None, query_args='tagging'):
+        if headers is None:
+            headers = {}
+        md5 = boto.utils.compute_md5(StringIO(tag_str))
+        headers['Content-MD5'] = md5[1]
+        headers['Content-Type'] = 'text/xml'
+        if not isinstance(tag_str, bytes):
+            tag_str = tag_str.encode('utf-8')
+        response = self.connection.make_request('PUT', self.name,
+                                                data=tag_str,
+                                                query_args=query_args,
+                                                headers=headers)
+        body = response.read()
+        if response.status != 204:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)
+        return True
+
+    def set_tags(self, tags, headers=None):
+        return self.set_xml_tags(tags.to_xml(), headers=headers)
+
+    def delete_tags(self, headers=None):
+        response = self.connection.make_request('DELETE', self.name,
+                                                query_args='tagging',
+                                                headers=headers)
+        body = response.read()
+        boto.log.debug(body)
+        if response.status == 204:
+            return True
+        else:
+            raise self.connection.provider.storage_response_error(
+                response.status, response.reason, body)

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -24,9 +24,9 @@
 
 import xml.sax
 import base64
-from boto.compat import six, urllib
 import time
 
+from boto.compat import six, urllib
 from boto.auth import detect_potential_s3sigv4
 import boto.utils
 from boto.connection import AWSAuthConnection
@@ -89,6 +89,8 @@ class _CallingFormat(object):
 
     def build_auth_path(self, bucket, key=''):
         key = boto.utils.get_utf8_value(key)
+        if isinstance(bucket, bytes):
+            bucket = bucket.decode('utf-8')
         path = ''
         if bucket != '':
             path = '/' + bucket

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -20,6 +20,8 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+from __future__ import print_function
+
 import email.utils
 import errno
 import hashlib
@@ -40,6 +42,7 @@ from boto.provider import Provider
 from boto.s3.keyfile import KeyFile
 from boto.s3.user import User
 from boto import UserAgent
+import boto.utils
 from boto.utils import compute_md5, compute_hash
 from boto.utils import find_matching_headers
 from boto.utils import merge_headers_by_name
@@ -849,9 +852,10 @@ class Key(object):
                 chunk_len = len(chunk)
                 data_len += chunk_len
                 if chunked_transfer:
-                    http_conn.send('%x;\r\n' % chunk_len)
+                    chunk_len_bytes = ('%x' % chunk_len).encode('utf-8')
+                    http_conn.send(chunk_len_bytes + b';\r\n')
                     http_conn.send(chunk)
-                    http_conn.send('\r\n')
+                    http_conn.send(b'\r\n')
                 else:
                     http_conn.send(chunk)
                 for alg in digesters:
@@ -879,9 +883,9 @@ class Key(object):
                 self.local_hashes[alg] = digesters[alg].digest()
 
             if chunked_transfer:
-                http_conn.send('0\r\n')
+                http_conn.send(b'0\r\n')
                     # http_conn.send("Content-MD5: %s\r\n" % self.base64md5)
-                http_conn.send('\r\n')
+                http_conn.send(b'\r\n')
 
             if cb and (cb_count <= 1 or i > 0) and data_len > 0:
                 cb(data_len, cb_size)
@@ -1549,7 +1553,7 @@ class Key(object):
             cb(data_len, cb_size)
         try:
             for bytes in self:
-                fp.write(bytes)
+                six.ensure_binary(bytes, file=fp, end='')
                 data_len += len(bytes)
                 for alg in digesters:
                     digesters[alg].update(bytes)


### PR DESCRIPTION
@walkerjoe, Ed Hodapp, and I made several fixes to help boto be cross-compatible with Python 2 and 3. These issues were identified while working on making gsutil's py-six-current branch compatible with Python 2.7 and 3.5+. This was done under the guidance of @houglum

Notably, we're using the six library to help ensure byte strings vs unicode strings work together nicely. Many of the changes we made revolve around making Python 2 and Python 3's byte vs unicode strings play together nicely, along with changes in division.

Let us know if you have any questions about these changes! :slightly_smiling_face: 