### PR TITLE
Fix test failures introduced in #3855 and #3866.

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -392,7 +392,7 @@ class Key(object):
         By providing a next method, the key object supports use as an iterator.
         For example, you can now say:
 
-        for bytes in key:
+        for key_bytes in key:
             write bytes to a file or whatever
 
         All of the HTTP connection stuff is handled for you.
@@ -1552,11 +1552,11 @@ class Key(object):
             i = 0
             cb(data_len, cb_size)
         try:
-            for bytes in self:
-                six.ensure_binary(bytes, file=fp, end='')
-                data_len += len(bytes)
+            for key_bytes in self:
+                print(key_bytes, file=fp, end='')
+                data_len += len(key_bytes)
                 for alg in digesters:
-                    digesters[alg].update(bytes)
+                    digesters[alg].update(key_bytes)
                 if cb:
                     if cb_size > 0 and data_len >= cb_size:
                         break

--- a/tests/integration/s3/mock_storage_service.py
+++ b/tests/integration/s3/mock_storage_service.py
@@ -30,7 +30,6 @@ import copy
 import boto
 import base64
 import re
-import locale
 from hashlib import md5
 
 from boto.utils import compute_md5
@@ -89,23 +88,7 @@ class MockKey(object):
                              torrent=NOT_IMPL,
                              version_id=NOT_IMPL,
                              res_download_handler=NOT_IMPL):
-        if isinstance(self.data, six.binary_type):
-            if 'b' in fp.mode:
-                # data is bytes, and fp is binary
-                fp.write(self.data)
-            elif hasattr(fp, 'buffer'):
-                # data is bytes, but fp is text - try the underlying buffer
-                fp.buffer.write(self.data)
-            else:
-                # data is bytes, but fp is text - try to decode bytes
-                fp.write(
-                    self.data.decode(locale.getpreferredencoding(False)))
-        elif 'b' in fp.mode:
-            # data is not bytes, but fp is binary
-            fp.write(self.data.encode(locale.getpreferredencoding(False)))
-        else:
-            # data is not bytes, and fp is text
-            fp.write(self.data)
+        fp.write(self.data)
 
     def get_file(self, fp, headers=NOT_IMPL, cb=NOT_IMPL, num_cb=NOT_IMPL,
                  torrent=NOT_IMPL, version_id=NOT_IMPL,
@@ -164,7 +147,7 @@ class MockKey(object):
                                cb=NOT_IMPL, num_cb=NOT_IMPL, policy=NOT_IMPL,
                                reduced_redundancy=NOT_IMPL, query_args=NOT_IMPL,
                                size=NOT_IMPL):
-        self.data = b''
+        self.data = ''
         chunk = fp.read(self.BufferSize)
         while chunk:
           self.data += chunk


### PR DESCRIPTION
This is a superset of the proposed changes in https://github.com/boto/boto/pull/3857.

Also changes variable name so that it's not using the name of a built-in
type, i.e. `for key_bytes in self` instead of `for bytes in self`.

While the rollback here might affect Python 3 compatibility in gsutil, we can address
that later - our main focus is not breaking anything that was already working. These
fixes restore the previous functionality; I verified that all boto integration tests and
gsutil integration tests (using a local copy of boto that includes these changes) pass.

+ @catleeball for FYI