### PR TITLE
[MOVED] See PR #3861

### DIFF
--- a/boto/utils.py
+++ b/boto/utils.py
@@ -861,7 +861,7 @@ def notify(subject, body=None, html_body=None, to_string=None,
 
 def get_utf8_value(value):
     if isinstance(value, bytes):
-        value = value.decode('utf-8')
+        value.decode('utf-8')
         return value
     if not isinstance(value, six.string_types):
         value = six.text_type(value)

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -860,10 +860,10 @@ def notify(subject, body=None, html_body=None, to_string=None,
 
 
 def get_utf8_value(value):
-    if isinstance(value, bytes):
-        value.decode('utf-8')
+    if six.PY3:
+        if isinstance(value, bytes):
+            value = value.decode('utf-8')
         return value
-
     if not isinstance(value, six.string_types):
         value = six.text_type(value)
 

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -860,9 +860,8 @@ def notify(subject, body=None, html_body=None, to_string=None,
 
 
 def get_utf8_value(value):
-    if six.PY3:
-        if isinstance(value, bytes):
-            value = value.decode('utf-8')
+    if isinstance(value, bytes):
+        value = value.decode('utf-8')
         return value
     if not isinstance(value, six.string_types):
         value = six.text_type(value)


### PR DESCRIPTION
After testing, Joe found that reverting this statement to how it existed in my `boto-six` branch of my fork, that it fixed failing XML cp tests in 3.x where bucket names weren't properly being parsed.