### PR TITLE
Ensure strings can be utf-8 encoded

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -925,7 +925,7 @@ class QuerySignatureV1AuthHandler(QuerySignatureHelper, AuthHandler):
         pairs = []
         for key in keys:
             hmac.update(key.encode('utf-8'))
-            val = get_utf8able_str(params[key])
+            val = get_utf8able_str(params[key]).encode('utf-8')
             hmac.update(val)
             pairs.append(key + '=' + urllib.parse.quote(val))
         qs = '&'.join(pairs)
@@ -949,7 +949,7 @@ class QuerySignatureV2AuthHandler(QuerySignatureHelper, AuthHandler):
         keys = sorted(params.keys())
         pairs = []
         for key in keys:
-            val = get_utf8able_str(params[key])
+            val = get_utf8able_str(params[key]).encode('utf-8')
             pairs.append(urllib.parse.quote(key, safe='') + '=' +
                          urllib.parse.quote(val, safe='-_~'))
         qs = '&'.join(pairs)

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -838,7 +838,7 @@ class STSAnonHandler(AuthHandler):
         pairs = []
         for key in keys:
             val = get_utf8able_str(params[key])
-            pairs.append(key + '=' + self._escape_value(six.ensure_str(val)))
+            pairs.append(key + '=' + self._escape_value(get_utf8able_str(val)))
         return '&'.join(pairs)
 
     def add_auth(self, http_request, **kwargs):
@@ -925,7 +925,7 @@ class QuerySignatureV1AuthHandler(QuerySignatureHelper, AuthHandler):
         pairs = []
         for key in keys:
             hmac.update(key.encode('utf-8'))
-            val = six.ensure_str(params[key])
+            val = get_utf8able_str(params[key])
             hmac.update(val)
             pairs.append(key + '=' + urllib.parse.quote(val))
         qs = '&'.join(pairs)

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -383,7 +383,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         parameter_names = sorted(http_request.params.keys())
         pairs = []
         for pname in parameter_names:
-            pval = boto.utils.get_utf8_value(http_request.params[pname])
+            pval = six.ensure_str(http_request.params[pname])
             pairs.append(urllib.parse.quote(pname, safe=''.encode('ascii')) +
                          '=' +
                          urllib.parse.quote(pval, safe='-_~'.encode('ascii')))
@@ -396,7 +396,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
             return ""
         l = []
         for param in sorted(http_request.params):
-            value = boto.utils.get_utf8_value(http_request.params[param])
+            value = six.ensure_str(http_request.params[param])
             l.append('%s=%s' % (urllib.parse.quote(param, safe='-_.~'),
                                 urllib.parse.quote(value, safe='-_.~')))
         return '&'.join(l)
@@ -623,7 +623,7 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         # query string.
         l = []
         for param in sorted(http_request.params):
-            value = boto.utils.get_utf8_value(http_request.params[param])
+            value = six.ensure_str(http_request.params[param])
             l.append('%s=%s' % (urllib.parse.quote(param, safe='-_.~'),
                                 urllib.parse.quote(value, safe='-_.~')))
         return '&'.join(l)
@@ -836,7 +836,7 @@ class STSAnonHandler(AuthHandler):
         keys.sort(key=lambda x: x.lower())
         pairs = []
         for key in keys:
-            val = boto.utils.get_utf8_value(params[key])
+            val = six.ensure_str(params[key])
             pairs.append(key + '=' + self._escape_value(six.ensure_str(val)))
         return '&'.join(pairs)
 
@@ -897,7 +897,7 @@ class QuerySignatureV0AuthHandler(QuerySignatureHelper, AuthHandler):
         keys.sort(cmp=lambda x, y: cmp(x.lower(), y.lower()))
         pairs = []
         for key in keys:
-            val = boto.utils.get_utf8_value(params[key])
+            val = six.ensure_str(params[key])
             pairs.append(key + '=' + urllib.parse.quote(val))
         qs = '&'.join(pairs)
         return (qs, base64.b64encode(hmac.digest()))
@@ -924,7 +924,7 @@ class QuerySignatureV1AuthHandler(QuerySignatureHelper, AuthHandler):
         pairs = []
         for key in keys:
             hmac.update(key.encode('utf-8'))
-            val = boto.utils.get_utf8_value(params[key])
+            val = six.ensure_str(params[key])
             hmac.update(val)
             pairs.append(key + '=' + urllib.parse.quote(val))
         qs = '&'.join(pairs)
@@ -948,7 +948,7 @@ class QuerySignatureV2AuthHandler(QuerySignatureHelper, AuthHandler):
         keys = sorted(params.keys())
         pairs = []
         for key in keys:
-            val = boto.utils.get_utf8_value(params[key])
+            val = six.ensure_str(params[key])
             pairs.append(urllib.parse.quote(key, safe='') + '=' +
                          urllib.parse.quote(val, safe='-_~'))
         qs = '&'.join(pairs)

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -42,6 +42,7 @@ import posixpath
 from boto.compat import urllib, encodebytes, parse_qs_safe, urlparse, six
 from boto.auth_handler import AuthHandler
 from boto.exception import BotoClientError
+from boto.utils import get_utf8able_str
 
 try:
     from hashlib import sha1 as sha
@@ -383,7 +384,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         parameter_names = sorted(http_request.params.keys())
         pairs = []
         for pname in parameter_names:
-            pval = six.ensure_str(http_request.params[pname])
+            pval = get_utf8able_str(http_request.params[pname])
             pairs.append(urllib.parse.quote(pname, safe=''.encode('ascii')) +
                          '=' +
                          urllib.parse.quote(pval, safe='-_~'.encode('ascii')))
@@ -396,7 +397,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
             return ""
         l = []
         for param in sorted(http_request.params):
-            value = six.ensure_str(http_request.params[param])
+            value = get_utf8able_str(http_request.params[param])
             l.append('%s=%s' % (urllib.parse.quote(param, safe='-_.~'),
                                 urllib.parse.quote(value, safe='-_.~')))
         return '&'.join(l)
@@ -623,7 +624,7 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         # query string.
         l = []
         for param in sorted(http_request.params):
-            value = six.ensure_str(http_request.params[param])
+            value = get_utf8able_str(http_request.params[param])
             l.append('%s=%s' % (urllib.parse.quote(param, safe='-_.~'),
                                 urllib.parse.quote(value, safe='-_.~')))
         return '&'.join(l)
@@ -836,7 +837,7 @@ class STSAnonHandler(AuthHandler):
         keys.sort(key=lambda x: x.lower())
         pairs = []
         for key in keys:
-            val = six.ensure_str(params[key])
+            val = get_utf8able_str(params[key])
             pairs.append(key + '=' + self._escape_value(six.ensure_str(val)))
         return '&'.join(pairs)
 
@@ -897,7 +898,7 @@ class QuerySignatureV0AuthHandler(QuerySignatureHelper, AuthHandler):
         keys.sort(cmp=lambda x, y: cmp(x.lower(), y.lower()))
         pairs = []
         for key in keys:
-            val = six.ensure_str(params[key])
+            val = get_utf8able_str(params[key])
             pairs.append(key + '=' + urllib.parse.quote(val))
         qs = '&'.join(pairs)
         return (qs, base64.b64encode(hmac.digest()))
@@ -948,7 +949,7 @@ class QuerySignatureV2AuthHandler(QuerySignatureHelper, AuthHandler):
         keys = sorted(params.keys())
         pairs = []
         for key in keys:
-            val = six.ensure_str(params[key])
+            val = get_utf8able_str(params[key])
             pairs.append(urllib.parse.quote(key, safe='') + '=' +
                          urllib.parse.quote(val, safe='-_~'))
         qs = '&'.join(pairs)

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -42,6 +42,7 @@ import posixpath
 from boto.compat import urllib, encodebytes, parse_qs_safe, urlparse, six
 from boto.auth_handler import AuthHandler
 from boto.exception import BotoClientError
+from boto.utils import get_utf8able_str
 
 try:
     from hashlib import sha1 as sha
@@ -383,7 +384,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
         parameter_names = sorted(http_request.params.keys())
         pairs = []
         for pname in parameter_names:
-            pval = boto.utils.get_utf8_value(http_request.params[pname])
+            pval = get_utf8able_str(http_request.params[pname])
             pairs.append(urllib.parse.quote(pname, safe=''.encode('ascii')) +
                          '=' +
                          urllib.parse.quote(pval, safe='-_~'.encode('ascii')))
@@ -396,7 +397,7 @@ class HmacAuthV4Handler(AuthHandler, HmacKeys):
             return ""
         l = []
         for param in sorted(http_request.params):
-            value = boto.utils.get_utf8_value(http_request.params[param])
+            value = get_utf8able_str(http_request.params[param])
             l.append('%s=%s' % (urllib.parse.quote(param, safe='-_.~'),
                                 urllib.parse.quote(value, safe='-_.~')))
         return '&'.join(l)
@@ -623,7 +624,7 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         # query string.
         l = []
         for param in sorted(http_request.params):
-            value = boto.utils.get_utf8_value(http_request.params[param])
+            value = get_utf8able_str(http_request.params[param])
             l.append('%s=%s' % (urllib.parse.quote(param, safe='-_.~'),
                                 urllib.parse.quote(value, safe='-_.~')))
         return '&'.join(l)
@@ -836,7 +837,7 @@ class STSAnonHandler(AuthHandler):
         keys.sort(key=lambda x: x.lower())
         pairs = []
         for key in keys:
-            val = boto.utils.get_utf8_value(params[key])
+            val = get_utf8able_str(params[key])
             pairs.append(key + '=' + self._escape_value(six.ensure_str(val)))
         return '&'.join(pairs)
 
@@ -897,7 +898,7 @@ class QuerySignatureV0AuthHandler(QuerySignatureHelper, AuthHandler):
         keys.sort(cmp=lambda x, y: cmp(x.lower(), y.lower()))
         pairs = []
         for key in keys:
-            val = boto.utils.get_utf8_value(params[key])
+            val = get_utf8able_str(params[key])
             pairs.append(key + '=' + urllib.parse.quote(val))
         qs = '&'.join(pairs)
         return (qs, base64.b64encode(hmac.digest()))
@@ -924,7 +925,7 @@ class QuerySignatureV1AuthHandler(QuerySignatureHelper, AuthHandler):
         pairs = []
         for key in keys:
             hmac.update(key.encode('utf-8'))
-            val = boto.utils.get_utf8_value(params[key])
+            val = six.ensure_str(params[key])
             hmac.update(val)
             pairs.append(key + '=' + urllib.parse.quote(val))
         qs = '&'.join(pairs)
@@ -948,7 +949,7 @@ class QuerySignatureV2AuthHandler(QuerySignatureHelper, AuthHandler):
         keys = sorted(params.keys())
         pairs = []
         for key in keys:
-            val = boto.utils.get_utf8_value(params[key])
+            val = get_utf8able_str(params[key])
             pairs.append(urllib.parse.quote(key, safe='') + '=' +
                          urllib.parse.quote(val, safe='-_~'))
         qs = '&'.join(pairs)

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1105,8 +1105,10 @@ class AWSQueryConnection(AWSAuthConnection):
     def _required_auth_capability(self):
         return []
 
+
     def get_utf8_value(self, value):
         return boto.utils.get_utf8_value(value)
+
 
     def make_request(self, action, params=None, path='/', verb='GET'):
         http_request = self.build_base_http_request(verb, path, None,

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1106,6 +1106,15 @@ class AWSQueryConnection(AWSAuthConnection):
         return []
 
 
+    def get_utf8_value(self, value):
+        """This replaces public interface get_utf8_value with new implementation.
+        
+        The old implementation of get_utf8_value has been deprecated and replaced
+        with get_utf8able_str.
+        """
+        return boto.utils.get_utf8able_str(value)
+
+
     def make_request(self, action, params=None, path='/', verb='GET'):
         http_request = self.build_base_http_request(verb, path, None,
                                                     params, {}, '',

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1107,12 +1107,7 @@ class AWSQueryConnection(AWSAuthConnection):
 
 
     def get_utf8_value(self, value):
-        """This replaces public interface get_utf8_value with new implementation.
-        
-        The old implementation of get_utf8_value has been deprecated and replaced
-        with get_utf8able_str.
-        """
-        return boto.utils.get_utf8able_str(value)
+        return boto.utils.get_utf8_value(value)
 
 
     def make_request(self, action, params=None, path='/', verb='GET'):

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1105,8 +1105,6 @@ class AWSQueryConnection(AWSAuthConnection):
     def _required_auth_capability(self):
         return []
 
-    def get_utf8_value(self, value):
-        return boto.utils.get_utf8_value(value)
 
     def make_request(self, action, params=None, path='/', verb='GET'):
         http_request = self.build_base_http_request(verb, path, None,

--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -40,7 +40,7 @@ from boto.gs.lifecycle import LifecycleConfig
 from boto.gs.key import Key as GSKey
 from boto.s3.acl import Policy
 from boto.s3.bucket import Bucket as S3Bucket
-from boto.utils import get_utf8_value
+from boto.utils import get_utf8able_str
 from boto.compat import quote
 from boto.compat import six
 
@@ -644,7 +644,7 @@ class Bucket(S3Bucket):
         :param str storage_class: A string containing the storage class.
         :param dict headers: Additional headers to send with the request.
         """
-        req_body = self.StorageClassBody % (get_utf8_value(storage_class))
+        req_body = self.StorageClassBody % (get_utf8able_str(storage_class))
         self.set_subresource(STORAGE_CLASS_ARG, req_body, headers=headers)
 
     # Method with same signature as boto.s3.bucket.Bucket.add_email_grant(),
@@ -883,7 +883,7 @@ class Bucket(S3Bucket):
 
         body = self.WebsiteBody % (main_page_frag, error_frag)
         response = self.connection.make_request(
-            'PUT', get_utf8_value(self.name), data=get_utf8_value(body),
+            'PUT', get_utf8able_str(self.name), data=get_utf8able_str(body),
             query_args='websiteConfig', headers=headers)
         body = response.read()
         if response.status == 200:

--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -40,6 +40,7 @@ from boto.gs.lifecycle import LifecycleConfig
 from boto.gs.key import Key as GSKey
 from boto.s3.acl import Policy
 from boto.s3.bucket import Bucket as S3Bucket
+from boto.utils import get_utf8able_str
 from boto.compat import quote
 from boto.compat import six
 
@@ -643,7 +644,7 @@ class Bucket(S3Bucket):
         :param str storage_class: A string containing the storage class.
         :param dict headers: Additional headers to send with the request.
         """
-        req_body = self.StorageClassBody % (six.ensure_str(storage_class))
+        req_body = self.StorageClassBody % (get_utf8able_str(storage_class))
         self.set_subresource(STORAGE_CLASS_ARG, req_body, headers=headers)
 
     # Method with same signature as boto.s3.bucket.Bucket.add_email_grant(),
@@ -882,7 +883,7 @@ class Bucket(S3Bucket):
 
         body = self.WebsiteBody % (main_page_frag, error_frag)
         response = self.connection.make_request(
-            'PUT', six.ensure_str(self.name), data=six.ensure_str(body),
+            'PUT', get_utf8able_str(self.name), data=six.ensure_str(body),
             query_args='websiteConfig', headers=headers)
         body = response.read()
         if response.status == 200:

--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -644,7 +644,7 @@ class Bucket(S3Bucket):
         :param str storage_class: A string containing the storage class.
         :param dict headers: Additional headers to send with the request.
         """
-        req_body = self.StorageClassBody % (get_utf8_value(storage_class))
+        req_body = self.StorageClassBody % (six.ensure_str(storage_class))
         self.set_subresource(STORAGE_CLASS_ARG, req_body, headers=headers)
 
     # Method with same signature as boto.s3.bucket.Bucket.add_email_grant(),
@@ -883,7 +883,7 @@ class Bucket(S3Bucket):
 
         body = self.WebsiteBody % (main_page_frag, error_frag)
         response = self.connection.make_request(
-            'PUT', get_utf8_value(self.name), data=get_utf8_value(body),
+            'PUT', six.ensure_str(self.name), data=six.ensure_str(body),
             query_args='websiteConfig', headers=headers)
         body = response.read()
         if response.status == 200:

--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -40,7 +40,6 @@ from boto.gs.lifecycle import LifecycleConfig
 from boto.gs.key import Key as GSKey
 from boto.s3.acl import Policy
 from boto.s3.bucket import Bucket as S3Bucket
-from boto.utils import get_utf8_value
 from boto.compat import quote
 from boto.compat import six
 

--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -883,7 +883,7 @@ class Bucket(S3Bucket):
 
         body = self.WebsiteBody % (main_page_frag, error_frag)
         response = self.connection.make_request(
-            'PUT', get_utf8able_str(self.name), data=six.ensure_str(body),
+            'PUT', get_utf8able_str(self.name), data=get_utf8able_str(body),
             query_args='websiteConfig', headers=headers)
         body = response.read()
         if response.status == 200:

--- a/boto/gs/connection.py
+++ b/boto/gs/connection.py
@@ -23,7 +23,8 @@ from boto.gs.bucket import Bucket
 from boto.s3.connection import S3Connection
 from boto.s3.connection import SubdomainCallingFormat
 from boto.s3.connection import check_lowercase_bucketname
-from boto.utils import get_utf8_value
+from boto.compat import six
+from boto.utils import get_utf8able_str
 
 class Location(object):
     DEFAULT = 'US'
@@ -91,8 +92,8 @@ class GSConnection(S3Connection):
         data = ('<CreateBucketConfiguration>%s%s</CreateBucketConfiguration>'
                  % (location_elem, storage_class_elem))
         response = self.make_request(
-            'PUT', get_utf8_value(bucket_name), headers=headers,
-            data=get_utf8_value(data))
+            'PUT', get_utf8able_str(bucket_name), headers=headers,
+            data=get_utf8able_str(data))
         body = response.read()
         if response.status == 409:
             raise self.provider.storage_create_error(

--- a/boto/gs/connection.py
+++ b/boto/gs/connection.py
@@ -23,7 +23,6 @@ from boto.gs.bucket import Bucket
 from boto.s3.connection import S3Connection
 from boto.s3.connection import SubdomainCallingFormat
 from boto.s3.connection import check_lowercase_bucketname
-from boto.utils import get_utf8_value
 
 class Location(object):
     DEFAULT = 'US'

--- a/boto/gs/connection.py
+++ b/boto/gs/connection.py
@@ -23,6 +23,7 @@ from boto.gs.bucket import Bucket
 from boto.s3.connection import S3Connection
 from boto.s3.connection import SubdomainCallingFormat
 from boto.s3.connection import check_lowercase_bucketname
+from boto.compat import six
 
 class Location(object):
     DEFAULT = 'US'

--- a/boto/gs/connection.py
+++ b/boto/gs/connection.py
@@ -24,6 +24,7 @@ from boto.s3.connection import S3Connection
 from boto.s3.connection import SubdomainCallingFormat
 from boto.s3.connection import check_lowercase_bucketname
 from boto.compat import six
+from boto.utils import get_utf8able_str
 
 class Location(object):
     DEFAULT = 'US'
@@ -91,8 +92,8 @@ class GSConnection(S3Connection):
         data = ('<CreateBucketConfiguration>%s%s</CreateBucketConfiguration>'
                  % (location_elem, storage_class_elem))
         response = self.make_request(
-            'PUT', six.ensure_str(bucket_name), headers=headers,
-            data=six.ensure_str(data))
+            'PUT', get_utf8able_str(bucket_name), headers=headers,
+            data=get_utf8able_str(data))
         body = response.read()
         if response.status == 409:
             raise self.provider.storage_create_error(

--- a/boto/gs/connection.py
+++ b/boto/gs/connection.py
@@ -91,8 +91,8 @@ class GSConnection(S3Connection):
         data = ('<CreateBucketConfiguration>%s%s</CreateBucketConfiguration>'
                  % (location_elem, storage_class_elem))
         response = self.make_request(
-            'PUT', get_utf8_value(bucket_name), headers=headers,
-            data=get_utf8_value(data))
+            'PUT', six.ensure_str(bucket_name), headers=headers,
+            data=six.ensure_str(data))
         body = response.read()
         if response.status == 409:
             raise self.provider.storage_create_error(

--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -24,12 +24,11 @@ import binascii
 import os
 import re
 
-from boto.compat import StringIO
+from boto.compat import StringIO, six
 from boto.exception import BotoClientError
 from boto.s3.key import Key as S3Key
 from boto.s3.keyfile import KeyFile
-from boto.utils import compute_hash
-from boto.utils import get_utf8_value
+from boto.utils import compute_hash, get_utf8able_str
 
 class Key(S3Key):
     """
@@ -707,7 +706,7 @@ class Key(S3Key):
         self.md5 = None
         self.base64md5 = None
 
-        fp = StringIO(get_utf8_value(s))
+        fp = StringIO(get_utf8able_str(s))
         r = self.set_contents_from_file(fp, headers, replace, cb, num_cb,
                                         policy, md5,
                                         if_generation=if_generation)

--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -29,7 +29,6 @@ from boto.exception import BotoClientError
 from boto.s3.key import Key as S3Key
 from boto.s3.keyfile import KeyFile
 from boto.utils import compute_hash
-from boto.utils import get_utf8_value
 
 class Key(S3Key):
     """

--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -28,7 +28,7 @@ from boto.compat import StringIO, six
 from boto.exception import BotoClientError
 from boto.s3.key import Key as S3Key
 from boto.s3.keyfile import KeyFile
-from boto.utils import compute_hash
+from boto.utils import compute_hash, get_utf8able_str
 
 class Key(S3Key):
     """
@@ -706,7 +706,7 @@ class Key(S3Key):
         self.md5 = None
         self.base64md5 = None
 
-        fp = StringIO(six.ensure_str(s))
+        fp = StringIO(get_utf8able_str(s))
         r = self.set_contents_from_file(fp, headers, replace, cb, num_cb,
                                         policy, md5,
                                         if_generation=if_generation)

--- a/boto/gs/key.py
+++ b/boto/gs/key.py
@@ -24,7 +24,7 @@ import binascii
 import os
 import re
 
-from boto.compat import StringIO
+from boto.compat import StringIO, six
 from boto.exception import BotoClientError
 from boto.s3.key import Key as S3Key
 from boto.s3.keyfile import KeyFile
@@ -707,7 +707,7 @@ class Key(S3Key):
         self.md5 = None
         self.base64md5 = None
 
-        fp = StringIO(get_utf8_value(s))
+        fp = StringIO(six.ensure_str(s))
         r = self.set_contents_from_file(fp, headers, replace, cb, num_cb,
                                         policy, md5,
                                         if_generation=if_generation)

--- a/boto/mturk/connection.py
+++ b/boto/mturk/connection.py
@@ -988,7 +988,7 @@ class QualificationRequest(BaseAutoResultElement):
         if name == 'Answer':
             answer_rs = ResultSet([('Answer', QuestionFormAnswer)])
             h = handler.XmlHandler(answer_rs, connection)
-            value = connection.get_utf8_value(value)
+            value = connection.get_utf8able_str(value)
             xml.sax.parseString(value, h)
             self.answers.append(answer_rs)
         else:
@@ -1013,7 +1013,7 @@ class Assignment(BaseAutoResultElement):
         if name == 'Answer':
             answer_rs = ResultSet([('Answer', QuestionFormAnswer)])
             h = handler.XmlHandler(answer_rs, connection)
-            value = connection.get_utf8_value(value)
+            value = connection.get_utf8able_str(value)
             xml.sax.parseString(value, h)
             self.answers.append(answer_rs)
         else:

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -51,6 +51,7 @@ import re
 import base64
 from collections import defaultdict
 from boto.compat import BytesIO, six, StringIO, urllib
+from boto.utils import get_utf8able_str
 
 # as per http://goo.gl/BDuud (02/19/2011)
 
@@ -848,11 +849,8 @@ class Bucket(object):
         """
         headers = headers or {}
         provider = self.connection.provider
-        if six.PY3:
-            if isinstance(src_key_name, bytes):
-                src_key_name = src_key_name.decode('utf-8')
-        else:
-            src_key_name = boto.utils.get_utf8_value(src_key_name)
+        src_key_name = get_utf8able_str(src_key_name)
+        
         if preserve_acl:
             if self.name == src_bucket_name:
                 src_bucket = self

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -51,6 +51,7 @@ import re
 import base64
 from collections import defaultdict
 from boto.compat import BytesIO, six, StringIO, urllib
+from boto.utils import get_utf8able_str
 
 # as per http://goo.gl/BDuud (02/19/2011)
 
@@ -852,7 +853,7 @@ class Bucket(object):
             if isinstance(src_key_name, bytes):
                 src_key_name = src_key_name.decode('utf-8')
         else:
-            src_key_name = six.ensure_str(src_key_name)
+            src_key_name = get_utf8able_str(src_key_name)
         if preserve_acl:
             if self.name == src_bucket_name:
                 src_bucket = self

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -852,7 +852,7 @@ class Bucket(object):
             if isinstance(src_key_name, bytes):
                 src_key_name = src_key_name.decode('utf-8')
         else:
-            src_key_name = boto.utils.get_utf8_value(src_key_name)
+            src_key_name = six.ensure_str(src_key_name)
         if preserve_acl:
             if self.name == src_bucket_name:
                 src_bucket = self

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -849,11 +849,8 @@ class Bucket(object):
         """
         headers = headers or {}
         provider = self.connection.provider
-        if six.PY3:
-            if isinstance(src_key_name, bytes):
-                src_key_name = src_key_name.decode('utf-8')
-        else:
-            src_key_name = get_utf8able_str(src_key_name)
+        src_key_name = get_utf8able_str(src_key_name)
+        
         if preserve_acl:
             if self.name == src_bucket_name:
                 src_bucket = self

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -35,6 +35,7 @@ from boto.s3.bucket import Bucket
 from boto.s3.key import Key
 from boto.resultset import ResultSet
 from boto.exception import BotoClientError, S3ResponseError
+from boto.utils import get_utf8able_str
 
 
 def check_lowercase_bucketname(n):

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -88,7 +88,7 @@ class _CallingFormat(object):
             return self.get_bucket_server(server, bucket)
 
     def build_auth_path(self, bucket, key=''):
-        key = six.ensure_str(key)
+        key = get_utf8able_str(key)
         if isinstance(bucket, bytes):
             bucket = bucket.decode('utf-8')
         path = ''
@@ -97,7 +97,7 @@ class _CallingFormat(object):
         return path + '/%s' % urllib.parse.quote(key)
 
     def build_path_base(self, bucket, key=''):
-        key = six.ensure_str(key)
+        key = get_utf8able_str(key)
         return '/%s' % urllib.parse.quote(key)
 
 
@@ -121,7 +121,7 @@ class OrdinaryCallingFormat(_CallingFormat):
         return server
 
     def build_path_base(self, bucket, key=''):
-        key = six.ensure_str(key)
+        key = get_utf8able_str(key)
         path_base = '/'
         if bucket:
             path_base += "%s/" % bucket

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -88,7 +88,7 @@ class _CallingFormat(object):
             return self.get_bucket_server(server, bucket)
 
     def build_auth_path(self, bucket, key=''):
-        key = boto.utils.get_utf8_value(key)
+        key = six.ensure_str(key)
         if isinstance(bucket, bytes):
             bucket = bucket.decode('utf-8')
         path = ''
@@ -97,7 +97,7 @@ class _CallingFormat(object):
         return path + '/%s' % urllib.parse.quote(key)
 
     def build_path_base(self, bucket, key=''):
-        key = boto.utils.get_utf8_value(key)
+        key = six.ensure_str(key)
         return '/%s' % urllib.parse.quote(key)
 
 
@@ -121,7 +121,7 @@ class OrdinaryCallingFormat(_CallingFormat):
         return server
 
     def build_path_base(self, bucket, key=''):
-        key = boto.utils.get_utf8_value(key)
+        key = six.ensure_str(key)
         path_base = '/'
         if bucket:
             path_base += "%s/" % bucket

--- a/boto/s3/connection.py
+++ b/boto/s3/connection.py
@@ -88,7 +88,7 @@ class _CallingFormat(object):
             return self.get_bucket_server(server, bucket)
 
     def build_auth_path(self, bucket, key=''):
-        key = boto.utils.get_utf8_value(key)
+        key = get_utf8able_str(key)
         if isinstance(bucket, bytes):
             bucket = bucket.decode('utf-8')
         path = ''
@@ -97,7 +97,7 @@ class _CallingFormat(object):
         return path + '/%s' % urllib.parse.quote(key)
 
     def build_path_base(self, bucket, key=''):
-        key = boto.utils.get_utf8_value(key)
+        key = get_utf8able_str(key)
         return '/%s' % urllib.parse.quote(key)
 
 
@@ -121,7 +121,7 @@ class OrdinaryCallingFormat(_CallingFormat):
         return server
 
     def build_path_base(self, bucket, key=''):
-        key = boto.utils.get_utf8_value(key)
+        key = get_utf8able_str(key)
         path_base = '/'
         if bucket:
             path_base += "%s/" % bucket

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -859,20 +859,6 @@ def notify(subject, body=None, html_body=None, to_string=None,
             boto.log.exception('notify failed')
 
 
-def get_utf8_value(value):
-    if isinstance(value, bytes):
-        value.decode('utf-8')
-        return value
-
-    if not isinstance(value, six.string_types):
-        value = six.text_type(value)
-
-    if isinstance(value, six.text_type):
-        value = value.encode('utf-8')
-
-    return value
-
-
 def mklist(value):
     if not isinstance(value, list):
         if isinstance(value, tuple):

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -1084,3 +1084,28 @@ def parse_host(hostname):
     else:
         return hostname.split(':', 1)[0]
 
+
+def get_utf8able_str(s, errors='strict'):
+    """Returns a UTF8-encodable string in PY3, UTF8 bytes in PY2.
+
+    This method is similar to six's `ensure_str()`, except it also
+    makes sure that any bytes passed in can be decoded using the
+    utf-8 codec (and raises a UnicodeDecodeError if not).
+    """
+    if six.PY2:
+        # We want to return utf-8 encoded bytes.
+        if isinstance(s, six.text_type):
+            return s.encode('utf-8', errors)
+        if isinstance(s, six.binary_type):
+            # Verify the bytes can be represented in utf-8
+            s.decode('utf-8')
+            return s
+    else:
+        # We want to return a unicode/str object.
+        if isinstance(s, six.text_type):
+            return s
+        if isinstance(s, six.binary_type):
+            s = s.decode('utf-8')
+            return s
+    raise TypeError('not expecting type "%s"' % type(s))
+

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -1109,7 +1109,7 @@ def get_utf8able_str(s, errors='strict'):
     makes sure that any bytes passed in can be decoded using the
     utf-8 codec (and raises a UnicodeDecodeError if not).
     """
-    if not isinstance(s, (text_type, binary_type)):
+    if not isinstance(s, (six.text_type, six.binary_type)):
         s = str(s)
     if six.PY2:
         # We want to return utf-8 encoded bytes.

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -1127,6 +1127,15 @@ def get_utf8able_str(s, errors='strict'):
     raise TypeError('not expecting type "%s"' % type(s))
 
 
+def get_utf8_value(self, value):
+    """This replaces public interface get_utf8_value with new implementation.
+
+    The old implementation of get_utf8_value has been deprecated and replaced
+    with get_utf8able_str.
+    """
+    return get_utf8able_str(value)
+    
+
 def print_to_fd(*objects, **kwargs):
     """A Python 2/3 compatible analogue to the print function.
 

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -1109,6 +1109,8 @@ def get_utf8able_str(s, errors='strict'):
     makes sure that any bytes passed in can be decoded using the
     utf-8 codec (and raises a UnicodeDecodeError if not).
     """
+    if not isinstance(s, (text_type, binary_type)):
+        s = str(s)
     if six.PY2:
         # We want to return utf-8 encoded bytes.
         if isinstance(s, six.text_type):

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -1101,6 +1101,46 @@ def parse_host(hostname):
     else:
         return hostname.split(':', 1)[0]
 
+
+def get_utf8able_str(s, errors='strict'):
+    """Returns a UTF8-encodable string in PY3, UTF8 bytes in PY2.
+
+    This method is similar to six's `ensure_str()`, except it also
+    makes sure that any bytes passed in can be decoded using the
+    utf-8 codec (and raises a UnicodeDecodeError if not).
+    """
+    if six.PY2:
+        # We want to return utf-8 encoded bytes.
+        if isinstance(s, six.text_type):
+            return s.encode('utf-8', errors)
+        if isinstance(s, six.binary_type):
+            # Verify the bytes can be represented in utf-8
+            s.decode('utf-8')
+            return s
+    else:
+        # We want to return a unicode/str object.
+        if isinstance(s, six.text_type):
+            return s
+        if isinstance(s, six.binary_type):
+            s = s.decode('utf-8')
+            return s
+    raise TypeError('not expecting type "%s"' % type(s))
+
+
+def get_utf8_value(value):
+    if isinstance(value, bytes):
+        value.decode('utf-8')
+        return value
+
+    if not isinstance(value, six.string_types):
+        value = six.text_type(value)
+
+    if isinstance(value, six.text_type):
+        value = value.encode('utf-8')
+
+    return value
+
+
 def print_to_fd(*objects, **kwargs):
     """A Python 2/3 compatible analogue to the print function.
 
@@ -1179,4 +1219,3 @@ def write_to_fd(fd, data):
         fd.write(six.ensure_binary(data))
     else:
         fd.write(data)
-

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -862,6 +862,20 @@ def notify(subject, body=None, html_body=None, to_string=None,
             boto.log.exception('notify failed')
 
 
+def get_utf8_value(value):
+    if isinstance(value, bytes):
+        value.decode('utf-8')
+        return value
+
+    if not isinstance(value, six.string_types):
+        value = six.text_type(value)
+
+    if isinstance(value, six.text_type):
+        value = value.encode('utf-8')
+
+    return value
+
+
 def mklist(value):
     if not isinstance(value, list):
         if isinstance(value, tuple):

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -1107,7 +1107,10 @@ def get_utf8able_str(s, errors='strict'):
 
     This method is similar to six's `ensure_str()`, except it also
     makes sure that any bytes passed in can be decoded using the
-    utf-8 codec (and raises a UnicodeDecodeError if not).
+    utf-8 codec (and raises a UnicodeDecodeError if not). If the
+    object isn't a string, this method will attempt to coerce it
+    to a string with `str()`. Objects without `__str__` property
+    or `__repr__` property will raise an exception.
     """
     if not isinstance(s, (six.text_type, six.binary_type)):
         s = str(s)


### PR DESCRIPTION
## Summary
We replaced the old method get_utf8_value with get_utf8able_str.
It attempts to make objects a unicode string that can by utf8 encoded.

## Testing
`https://github.com/boto/boto/pull/3861.diff` was applied to a local
copy of `gsutil/gslib/vendored/boto`. Integration tests ran successfully
on Linux using Python 2.7.15 with JSON and XML APIs.