### PR TITLE
Fix use of 'is' operator for comparison

### DIFF
--- a/boto/iam/connection.py
+++ b/boto/iam/connection.py
@@ -1111,7 +1111,7 @@ class IAMConnection(AWSQueryConnection):
         else:
 
             for tld, policy in DEFAULT_POLICY_DOCUMENTS.items():
-                if tld is 'default':
+                if tld == 'default':
                     # Skip the default. We'll fall back to it if we don't find
                     # anything.
                     continue


### PR DESCRIPTION
The 'is' operator is not meant to be used for comparisons. It currently working is an implementation detail of CPython.
CPython 3.8 has added a SyntaxWarning for this.