### PR TITLE
Fix for Python 4: replace unsafe six.PY3 with PY2

### DIFF
--- a/boto/compat.py
+++ b/boto/compat.py
@@ -57,14 +57,7 @@ from boto.vendored.six.moves.urllib.parse import parse_qs, quote, unquote, \
 from boto.vendored.six.moves.urllib.parse import unquote_plus
 from boto.vendored.six.moves.urllib.request import urlopen
 
-if six.PY3:
-    # StandardError was removed, so use the base exception type instead
-    StandardError = Exception
-    long_type = int
-    from configparser import ConfigParser, NoOptionError, NoSectionError
-    unquote_str = unquote_plus
-    parse_qs_safe = parse_qs
-else:
+if six.PY2:
     StandardError = StandardError
     long_type = long
     from ConfigParser import SafeConfigParser as ConfigParser
@@ -100,3 +93,11 @@ else:
                 result[decoded_name] = decoded_value
             return result
         return qs_dict
+
+else:
+    # StandardError was removed, so use the base exception type instead
+    StandardError = Exception
+    long_type = int
+    from configparser import ConfigParser, NoOptionError, NoSectionError
+    unquote_str = unquote_plus
+    parse_qs_safe = parse_qs

--- a/boto/dynamodb/types.py
+++ b/boto/dynamodb/types.py
@@ -69,7 +69,7 @@ if six.PY2:
     def is_binary(n):
         return isinstance(n, Binary)
 
-else:  # PY3
+else:  # PY3+
     def is_str(n):
         return (isinstance(n, str) or
                 isinstance(n, type) and issubclass(n, str))

--- a/boto/glacier/utils.py
+++ b/boto/glacier/utils.py
@@ -125,7 +125,7 @@ def compute_hashes_from_fileobj(fileobj, chunk_size=1024 * 1024):
 
     """
     # Python 3+, not binary
-    if six.PY3 and hasattr(fileobj, 'mode') and 'b' not in fileobj.mode:
+    if not six.PY2 and hasattr(fileobj, 'mode') and 'b' not in fileobj.mode:
         raise ValueError('File-like object must be opened in binary mode!')
 
     linear_hash = hashlib.sha256()

--- a/boto/gs/bucket.py
+++ b/boto/gs/bucket.py
@@ -52,7 +52,7 @@ ENCRYPTION_CONFIG_ARG = 'encryptionConfig'
 LIFECYCLE_ARG = 'lifecycle'
 STORAGE_CLASS_ARG='storageClass'
 _ERROR_DETAILS_REGEX_STR = r'<Details>(?P<details>.*)</Details>'
-if six.PY3:
+if not six.PY2:
     _ERROR_DETAILS_REGEX_STR = _ERROR_DETAILS_REGEX_STR.encode('ascii')
 ERROR_DETAILS_REGEX = re.compile(_ERROR_DETAILS_REGEX_STR)
 
@@ -361,7 +361,7 @@ class Bucket(S3Bucket):
                     details = (('<Details>%s. Note that Full Control access'
                                 ' is required to access ACLs.</Details>') %
                                details)
-                    if six.PY3:
+                    if not six.PY2:
                         # All args to re.sub() must be of same type
                         details = details.encode('utf-8')
                     body = re.sub(ERROR_DETAILS_REGEX, details, body)

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -1197,7 +1197,7 @@ def write_to_fd(fd, data):
     if six.PY2:
         fd.write(data)
         return
-    # PY3 logic:
+    # PY3+ logic:
     if isinstance(data, bytes):
         if ((hasattr(fd, 'mode') and 'b' in fd.mode) or
                 isinstance(fd, io.BytesIO)):

--- a/tests/integration/dynamodb/test_layer2.py
+++ b/tests/integration/dynamodb/test_layer2.py
@@ -460,7 +460,7 @@ class DynamoDBLayer2Test(unittest.TestCase):
         retrieved = table.get_item('foo', 'bar')
         self.assertEqual(retrieved['decimalvalue'], Decimal('1.12345678912345'))
 
-    @unittest.skipIf(six.PY3, "skipping lossy_float_conversion test for Python 3.x")
+    @unittest.skipIf(not six.PY2, "skipping lossy_float_conversion test for Python 3+")
     def test_lossy_float_conversion(self):
         table = self.create_sample_table()
         item = table.new_item('foo', 'bar')

--- a/tests/unit/dynamodb/test_types.py
+++ b/tests/unit/dynamodb/test_types.py
@@ -120,7 +120,7 @@ class TestBinary(unittest.TestCase):
         with self.assertRaises(TypeError):
             types.Binary(1)
 
-    @unittest.skipUnless(six.PY3, "Python 3 only")
+    @unittest.skipUnless(not six.PY2, "Python 3+ only")
     def test_bytes_input(self):
         data = types.Binary(1)
         self.assertEqual(data, b'\x00')
@@ -140,7 +140,7 @@ class TestBinary(unittest.TestCase):
         # Check that the value field is of type bytes
         self.assertEqual(type(data.value), bytes)
 
-    @unittest.skipUnless(six.PY3, "Python 3 only")
+    @unittest.skipUnless(not six.PY2, "Python 3+ only")
     def test_unicode_py3(self):
         with self.assertRaises(TypeError):
             types.Binary(u'\x01')

--- a/tests/unit/glacier/test_utils.py
+++ b/tests/unit/glacier/test_utils.py
@@ -140,7 +140,7 @@ class TestFileHash(unittest.TestCase):
 
             compute_hashes_from_fileobj(f, chunk_size=512)
 
-    @unittest.skipUnless(six.PY3, 'Python 3 requires reading binary!')
+    @unittest.skipUnless(not six.PY2, 'Python 3 requires reading binary!')
     def test_compute_hash_tempfile_py3(self):
         # Note the missing 'b' in the mode!
         with tempfile.TemporaryFile(mode='w+') as f:


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and work begins on Python 3.9+1.

There's some code which uses `six.PY3`:

```python
if six.PY3:
    print("Python 3+ code")
else:
    print "Python 2 code"
```

Where:

```python
PY3 = sys.version_info[0] == 3
```

When run on Python 4, this will run the Python 2 code! Instead, use `six.PY2`.

Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
...
$ flake8 --select YTT
./boto/compat.py:60:4: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./boto/connection.py:657:36: YTT101 `sys.version[:3]` referenced (python3.10), use `sys.version_info`
./boto/connection.py:658:21: YTT101 `sys.version[:3]` referenced (python3.10), use `sys.version_info`
./boto/glacier/utils.py:128:8: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./boto/vendored/six.py:37:7: YTT201 `sys.version_info[0] == 3` referenced (python4), use `>=`
./boto/vendored/six.py:635:8: YTT203 `sys.version_info[1]` compared to integer (python4), compare `sys.version_info` to tuple
./tests/unit/glacier/test_utils.py:143:26: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/unit/dynamodb/test_types.py:123:26: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/unit/dynamodb/test_types.py:143:26: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/dynamodb/test_layer2.py:463:22: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
```

---

See also:

* https://github.com/boto/boto3/pull/2256
* https://github.com/boto/botocore/pull/1933
* https://github.com/boto/s3transfer/pull/152
