### PR TITLE
Documentation fix for kms create grant

### DIFF
--- a/boto/kms/layer1.py
+++ b/boto/kms/layer1.py
@@ -175,7 +175,7 @@ class KMSConnection(AWSQueryConnection):
 
         :type key_id: string
         :param key_id: A unique key identifier for a customer master key. This
-            value can be a globally unique identifier, an ARN, or an alias.
+            value can be a globally unique identifier or an ARN.
 
         :type grantee_principal: string
         :param grantee_principal: Principal given permission by the grant to


### PR DESCRIPTION
(Originally proposed in #3202)

The `create_grant` call doesn't actually allow the use of key aliases. If you use a key alias, AWS returns an exception

Here's code to reproduce this error. To test it you'll need to set the `kms_key` value to your KMS key's alias and set the `grantee_principle` to the ARN of an IAM role that exists

```
import boto.kms
kms = boto.kms.connect_to_region('us-east-1')
kms_key="alias/mykeyalias"
grantee_principal = 'arn:aws:iam::123456789012:role/ExampleRole'
operations = ['Decrypt']
context = {'EncryptionContextSubset': {'foo': 'bar'}}
result = kms.create_grant(key_id = kms_key,
                          grantee_principal = grantee_principal,
                          operations=operations,
                          constraints=context)
```

Expected results would be to have the grant created.

Actual results are the exception

```
boto.kms.exceptions.InvalidArnException: InvalidArnException: 400 Bad Request
{u'message': u'Key Aliases are not supported for this operation.', u'__type': u'InvalidArnException'}
```