### PR TITLE
Fix collections.abc imports for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ matrix:
       python: "3.7"
     - os: linux
       dist: xenial
+      python: "3.9-dev"
+    - os: linux
+      dist: xenial
       python: "pypy3.5"
   allow_failures:
     - python: "3.7"

--- a/boto/dynamodb/types.py
+++ b/boto/dynamodb/types.py
@@ -27,9 +27,14 @@ Python types and vice-versa.
 import base64
 from decimal import (Decimal, DecimalException, Context,
                      Clamped, Overflow, Inexact, Underflow, Rounded)
-from collections import Mapping
 from boto.dynamodb.exceptions import DynamoDBNumberError
 from boto.compat import filter, map, six, long_type
+
+try:
+    # Python 3.3+
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 
 DYNAMODB_CONTEXT = Context(

--- a/boto/mws/connection.py
+++ b/boto/mws/connection.py
@@ -21,13 +21,19 @@
 import xml.sax
 import hashlib
 import string
-import collections
 from boto.connection import AWSQueryConnection
 from boto.exception import BotoServerError
 import boto.mws.exception
 import boto.mws.response
 from boto.handler import XmlHandler
 from boto.compat import filter, map, six, encodebytes
+
+try:
+    # Python 3.3+
+    from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
+
 
 __all__ = ['MWSConnection']
 
@@ -109,7 +115,7 @@ def http_body(field):
 def destructure_object(value, into, prefix, members=False):
     if isinstance(value, boto.mws.response.ResponseElement):
         destructure_object(value.__dict__, into, prefix, members=members)
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, Mapping):
         for name in value:
             if name.startswith('_'):
                 continue
@@ -117,7 +123,7 @@ def destructure_object(value, into, prefix, members=False):
                                members=members)
     elif isinstance(value, six.string_types):
         into[prefix] = value
-    elif isinstance(value, collections.Iterable):
+    elif isinstance(value, Iterable):
         for index, element in enumerate(value):
             suffix = (members and '.member.' or '.') + str(index + 1)
             destructure_object(element, into, prefix + suffix,


### PR DESCRIPTION
Since Python 3.3, `Mapping` etc. has been available in `collections.abc`.

Since Python 3.9, `Mapping` etc. is only available in `collections.abc`.

https://docs.python.org/3.9/whatsnew/3.9.html#removed

```pycon
Python 3.9.0a2+ (heads/master:ec007cb, Jan  5 2020, 12:34:22)
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import collections
>>> collections.Mapping
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'collections' has no attribute 'Mapping'
>>> collections.abc.Mapping
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'collections' has no attribute 'abc'
>>> import collections.abc
>>> collections.abc.Mapping
<class 'collections.abc.Mapping'>
>>>
```

Python 3.9 is already in alpha with full release due in October.

