### PR TITLE
fix(auth): Region parser uses unassigned variable when S3 is colocated

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -665,6 +665,7 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         # - bukkit.s3.cn-north-1.amazonaws.com.cn - (Vhosted Beijing region)
         parts = self.split_host_parts(host)
 
+        region_name = ''
         if self.region_name is not None:
             region_name = self.region_name
         else:


### PR DESCRIPTION
Region parser is strongly opinionated about what is the `host` value. A situation when the host simply doesn't contain dots is not anticipated.

In cases when querying colocated S3 host (MinIO, Ceph on localhost/kubernetes pod in the same namespace) the host name simply doesn't contain any dots: e.g. `localhost`, `ceph-nano`, `minio`. Any call via `boto` using v4 protocol results in:

```
local variable 'region_name' referenced before assignment
```

Initialization to empty string at the func start fixes it.