### PR TITLE
docs: fix simple typo, garunteed -> guaranteed

### DIFF
--- a/tests/db/test_sequence.py
+++ b/tests/db/test_sequence.py
@@ -95,7 +95,7 @@ class TestDBHandler(object):
         for v in [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144]:
             assert(s.next() == v)
             assert(s.val == v)
-            assert(s2.val == v) # it shouldn't matter which reference we use since it's garunteed to be consistent
+            assert(s2.val == v) # it shouldn't matter which reference we use since it's guaranteed to be consistent
 
     def test_sequence_string(self):
         """Test the String incrementation sequence"""


### PR DESCRIPTION
There is a small typo in tests/db/test_sequence.py.

Should read `guaranteed` rather than `garunteed`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md