### PR TITLE
Add deprecation infrastructure

### DIFF
--- a/.github/ISSUE_TEMPLATES/config.yml
+++ b/.github/ISSUE_TEMPLATES/config.yml
@@ -1,0 +1,2 @@
+---
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATES/new_issue.yaml
+++ b/.github/ISSUE_TEMPLATES/new_issue.yaml
@@ -1,10 +1,12 @@
 ---
 name: New issue
-about: Create an issue
+about: Open a new issue
 title: ''
+labels: ''
 assignees: ''
 
 ---
 
-This package is no longer maintained and has been replaced by [`boto3`](https://github.com/boto/boto3). Issues and pull requests are not reviewed. 
-If you are having an issue with the [`boto3`](https://github.com/boto/boto3) package or the [AWS CLI](https://github.com/aws/aws-cli), please open an issue on their respective repositories.
+### ⚠️DEPRECATION NOTICE⚠️ 
+
+This package is no longer maintained and has been replaced by [`boto3`](https://github.com/boto/boto3/). Issues are not triaged or reviewed by AWS. The issues in this repository can be used by the community for support purposes. If you are having an issue with the [`boto3`](https://github.com/boto/boto3/) package or the [AWS CLI](https://github.com/aws/aws-cli/), please open an issue on their respective repositories.

--- a/.github/workflows/open_issue_message.yml
+++ b/.github/workflows/open_issue_message.yml
@@ -10,4 +10,6 @@ jobs:
             with:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"
-            message: "This package is no longer maintained and has been replaced by [`boto3`](https://github.com/boto/boto3/). Issues are not triaged or reviewed by AWS. The issues in this repository can be used by the community for support purposes. If you are having an issue with the [`boto3`](https://github.com/boto/boto3/) package or the [AWS CLI](https://github.com/aws/aws-cli/), please open an issue on their respective repositories."
+            message: |
+                     ### ⚠️DEPRECATION NOTICE⚠️ 
+                     This package is no longer maintained and has been replaced by [`boto3`](https://github.com/boto/boto3/). Issues are not triaged or reviewed by AWS. The issues in this repository can be used by the community for support purposes. If you are having an issue with the [`boto3`](https://github.com/boto/boto3/) package or the [AWS CLI](https://github.com/aws/aws-cli/), please open an issue on their respective repositories.

--- a/.github/workflows/open_issue_message.yml
+++ b/.github/workflows/open_issue_message.yml
@@ -1,0 +1,13 @@
+name: Open Issue Message
+on:
+    issues:
+       types: [opened]
+jobs:
+    auto_comment:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: aws-actions/closed-issue-message@v1
+            with:
+            # These inputs are both required
+            repo-token: "${{ secrets.GITHUB_TOKEN }}"
+            message: "This package is no longer maintained and has been replaced by [`boto3`](https://github.com/boto/boto3/). Issues are not triaged or reviewed by AWS. The issues in this repository can be used by the community for support purposes. If you are having an issue with the [`boto3`](https://github.com/boto/boto3/) package or the [AWS CLI](https://github.com/aws/aws-cli/), please open an issue on their respective repositories."

--- a/.github/workflows/open_pr_message.yml
+++ b/.github/workflows/open_pr_message.yml
@@ -10,4 +10,6 @@ jobs:
             with:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"
-            message: "This package is no longer maintained and has been replaced by [`boto3`](https://github.com/boto/boto3/). Pull requests are not reviewed by AWS and will not be merged. If you are having an issue with the [`boto3`](https://github.com/boto/boto3/) package or the [AWS CLI](https://github.com/aws/aws-cli/), please open an issue on their respective repositories."
+            message: |
+                     ### ⚠️DEPRECATION NOTICE⚠️ 
+                     This package is no longer maintained and has been replaced by [`boto3`](https://github.com/boto/boto3/). Pull requests are not reviewed by AWS and will not be merged. If you are having an issue with the [`boto3`](https://github.com/boto/boto3/) package or the [AWS CLI](https://github.com/aws/aws-cli/), please open an issue on their respective repositories.

--- a/.github/workflows/open_pr_message.yml
+++ b/.github/workflows/open_pr_message.yml
@@ -1,0 +1,13 @@
+name: Open Issue Message
+on:
+    pull_request:
+       types: [opened]
+jobs:
+    auto_comment:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: aws-actions/closed-issue-message@v1
+            with:
+            # These inputs are both required
+            repo-token: "${{ secrets.GITHUB_TOKEN }}"
+            message: "This package is no longer maintained and has been replaced by [`boto3`](https://github.com/boto/boto3/). Pull requests are not reviewed by AWS and will not be merged. If you are having an issue with the [`boto3`](https://github.com/boto/boto3/) package or the [AWS CLI](https://github.com/aws/aws-cli/), please open an issue on their respective repositories."

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -1,0 +1,32 @@
+name: "Close stale issues and pull requests"
+
+# Controls when the action will run.
+on:
+  schedule:
+  - cron: "0 * * * *"
+
+jobs:
+  issue-cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@v4
+      with:
+        issue-types: issues,pull_requests
+        ancient-issue-message: Greetings! This issue hasn't been active in longer 
+          than one year. Since this repository is no longer maintained, community comments can continue to be made but they will not be reviewed by AWS. In the absence of further activity, this issue will close soon.
+        ancient-pr-message: Greetings! This pull request hasn't been active in longer 
+          than one year. Since this repository is no longer maintained, community comments can continue to be made but they will not be reviewed by AWS. In the absence of further activity, this pull request will close soon.
+
+        # Don't set closed-for-staleness label to skip closing very old issues
+        # regardless of label
+        closed-for-staleness-label: closed-for-staleness
+
+        # Issue timing
+        days-before-ancient: 365
+        days-before-close: 7
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -23,7 +23,7 @@ jobs:
         closed-for-staleness-label: closed-for-staleness
 
         # Issue timing
-        days-before-ancient: 365
+        days-before-ancient: 2555
         days-before-close: 7
 
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add GitHub actions to respond to new issues and pull requests about the deprecation of the package. Redirect users to use `boto3`, or to continue to use the issues in this repository for community support.

Currently, the stale issue bot is in dry run mode and will not close any issues or PRs. Will test first to see what will close, and do it in waves, starting with issues 7 years or older.