### PR TITLE
Fixing SyntaxWarning: "is" with a literal in python3.8 and above

### DIFF
--- a/boto/iam/connection.py
+++ b/boto/iam/connection.py
@@ -1111,7 +1111,7 @@ class IAMConnection(AWSQueryConnection):
         else:
 
             for tld, policy in DEFAULT_POLICY_DOCUMENTS.items():
-                if tld is 'default':
+                if tld == 'default':
                     # Skip the default. We'll fall back to it if we don't find
                     # anything.
                     continue


### PR DESCRIPTION
The python 3.8 compiler now produces a SyntaxWarning when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers).

These can often work by accident in CPython, but are not guaranteed by the language spec.

Changing from 'is' to '==' should be backward compatible as well